### PR TITLE
v0.2.0: playback resume, catalog era pinning, store polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "halcyon-video",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "halcyon-video",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:picks": "node --experimental-strip-types --test tests/staff-picks.test.ts",
     "test:promo": "node --experimental-strip-types --test tests/promo-campaigns.test.ts",
     "test:comingsoon": "node --experimental-strip-types --test tests/coming-soon-feed.test.ts",
+    "test:releasedate": "node --experimental-strip-types --test tests/media-release-date.test.ts tests/media-date-screen.test.ts",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "halcyon-video",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:promo": "node --experimental-strip-types --test tests/promo-campaigns.test.ts",
     "test:comingsoon": "node --experimental-strip-types --test tests/coming-soon-feed.test.ts",
     "test:releasedate": "node --experimental-strip-types --test tests/media-release-date.test.ts tests/media-date-screen.test.ts",
+    "test:playbackflow": "node --experimental-strip-types --test tests/playback-flow.test.ts",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/src/counter-terminal-flow.ts
+++ b/src/counter-terminal-flow.ts
@@ -1,0 +1,203 @@
+// The manager terminal's CONTROLLER — the state machine behind the clerk-desk
+// CRT menu main.ts docks to on a Left press at the checkout counter.
+//
+// Extracted from main.ts (which sits at its enforced line budget) when the
+// menu grew its first SUB-SCREEN: MEDIA RELEASE DATE (#42), the BIOS-style
+// date picker that pins the catalog to a rolling point in time. Row labels
+// stay in counter-terminal.ts (pure data the harness shares); the screen's
+// state machine lives in media-date-screen.ts (pure, unit-tested); this file
+// is only the glue — render onto the scene's CRT, route remote presses,
+// persist the pin, trigger the rebuild.
+//
+// main.ts wires it once via initCounterTerminalFlow(deps) and forwards its
+// input callbacks; nothing here touches DOM state beyond a keyboard listener
+// for typed digits while the date screen is up.
+import { counterTerminalLines } from './counter-terminal';
+import {
+  MediaDateScreenState,
+  initMediaDateScreen,
+  mediaDateScreenDigit,
+  mediaDateScreenKey,
+  mediaDateScreenLines,
+  MediaDateKey,
+} from './media-date-screen';
+import {
+  clearMediaReleasePin,
+  loadMediaReleasePin,
+  saveMediaReleasePin,
+} from './media-release-date';
+
+/** The one row that opens a CRT sub-screen instead of a power action. */
+export const MEDIA_DATE_BUTTON_ID = 'btn-media-date';
+
+interface TerminalScene {
+  setTerminalText(lines: string[] | null, cursorLine?: number): void;
+  enterSearchMode(): void;
+  exitSearchMode(): void;
+}
+
+export interface CounterTerminalDeps {
+  scene: () => TerminalScene | null;
+  /** main.ts's ui-state object — the flow owns its isCounterTerminalOpen flag. */
+  ui: { isCounterTerminalOpen: boolean; readonly isAnyOverlayOpen: boolean };
+  /** Row ids in menu order (main.ts's counterTerminalButtons). */
+  buttons: string[];
+  /** Dispatch a menu row — main.ts's executePowerMenuAction. */
+  execute: (btnId: string) => Promise<void>;
+  keyClick: () => void;
+  log: (msg: string) => void;
+  /** Rebuild the store scene (pin changes take effect at the build funnel). */
+  rebuild: () => Promise<void>;
+}
+
+let deps: CounterTerminalDeps | null = null;
+let mode: 'menu' | 'date' = 'menu';
+let menuIndex = 0;
+let dateState: MediaDateScreenState | null = null;
+
+export function initCounterTerminalFlow(d: CounterTerminalDeps): void {
+  deps = d;
+}
+
+function render(): void {
+  if (!deps) return;
+  const scene = deps.scene();
+  if (!scene) return;
+  if (mode === 'date' && dateState) {
+    const { lines, cursorLine } = mediaDateScreenLines(dateState, loadMediaReleasePin(), new Date());
+    scene.setTerminalText(lines, cursorLine);
+  } else {
+    const { lines, cursorLine } = counterTerminalLines(deps.buttons, menuIndex);
+    scene.setTerminalText(lines, cursorLine);
+  }
+}
+
+// Typed digits are keyboard-only sugar for the date fields; the remote path
+// is entirely arrows + OK. Capture-phase so the store's own key handling
+// never sees them while the screen is up.
+function onDigitKey(e: KeyboardEvent): void {
+  if (mode !== 'date' || !dateState || !/^[0-9]$/.test(e.key)) return;
+  dateState = mediaDateScreenDigit(dateState, e.key);
+  deps?.keyClick();
+  render();
+  e.preventDefault();
+  e.stopPropagation();
+}
+
+function enterDateScreen(): void {
+  mode = 'date';
+  dateState = initMediaDateScreen(loadMediaReleasePin(), new Date());
+  window.addEventListener('keydown', onDigitKey, true);
+  render();
+}
+
+function leaveDateScreen(): void {
+  mode = 'menu';
+  dateState = null;
+  window.removeEventListener('keydown', onDigitKey, true);
+}
+
+export function counterTerminalOpen(): void {
+  if (!deps) return;
+  const scene = deps.scene();
+  if (!scene || deps.ui.isAnyOverlayOpen) return;
+  deps.ui.isCounterTerminalOpen = true;
+  mode = 'menu';
+  menuIndex = 0;
+  scene.enterSearchMode(); // camera dock only — the text is ours
+  render();
+  deps.log('[Terminal] Manager terminal open at the counter.');
+}
+
+export function counterTerminalClose(): void {
+  if (!deps || !deps.ui.isCounterTerminalOpen) return;
+  leaveDateScreen();
+  deps.ui.isCounterTerminalOpen = false;
+  // Hands the camera back and resets the CRT to its idle rental screen.
+  deps.scene()?.exitSearchMode();
+  deps.log('[Terminal] Manager terminal closed.');
+}
+
+async function savePin(s: MediaDateScreenState): Promise<void> {
+  if (!deps) return;
+  const p = (n: number) => n.toString().padStart(2, '0');
+  const date = `${s.year}-${p(s.month)}-${p(s.day)}`;
+  saveMediaReleasePin({
+    mediaReleaseDate: date,
+    pinnedAt: new Date().toISOString(),
+    ...(s.matchEra ? { matchEra: true } : {}),
+  });
+  deps.log(`[Terminal] Media Release Date pinned to ${date}${s.matchEra ? ' — store era follows the pin' : ''}. Restocking...`);
+  counterTerminalClose();
+  await deps.rebuild();
+}
+
+async function clearPin(): Promise<void> {
+  if (!deps) return;
+  if (!loadMediaReleasePin()) {
+    // Nothing pinned — CLEAR is just a walk back to the menu.
+    leaveDateScreen();
+    render();
+    return;
+  }
+  clearMediaReleasePin();
+  deps.log('[Terminal] Media Release Date pin cleared — catalog is live. Restocking...');
+  counterTerminalClose();
+  await deps.rebuild();
+}
+
+/**
+ * One remote/keyboard press while the terminal is docked. The menu keeps its
+ * original moves (Up/Down step, OK runs the row, Right/Back step out); the
+ * date screen maps the full BIOS set through media-date-screen's reducer.
+ */
+export async function counterTerminalInput(kind: MediaDateKey): Promise<void> {
+  if (!deps || !deps.ui.isCounterTerminalOpen) return;
+
+  if (mode === 'date' && dateState) {
+    deps.keyClick();
+    const { state, action } = mediaDateScreenKey(dateState, kind);
+    dateState = state;
+    if (action === 'save') return savePin(state);
+    if (action === 'clear') return clearPin();
+    if (action === 'back') {
+      leaveDateScreen();
+      render();
+      return;
+    }
+    render();
+    return;
+  }
+
+  switch (kind) {
+    case 'up':
+    case 'down': {
+      const n = deps.buttons.length;
+      menuIndex = (menuIndex + (kind === 'up' ? -1 : 1) + n) % n;
+      deps.keyClick();
+      render();
+      return;
+    }
+    case 'ok': {
+      const btnId = deps.buttons[menuIndex];
+      if (btnId === MEDIA_DATE_BUTTON_ID) {
+        deps.keyClick();
+        enterDateScreen();
+        return;
+      }
+      // Close first: several actions (settings drawer, logout) take over the
+      // screen, and the docked camera must be handed back before they do.
+      counterTerminalClose();
+      await deps.execute(btnId);
+      return;
+    }
+    case 'right':
+    case 'back':
+      // Right mirrors the Left press that reached for the terminal; Back is
+      // the same step out.
+      counterTerminalClose();
+      return;
+    case 'left':
+      return; // already docked; Left is what opened it
+  }
+}

--- a/src/counter-terminal.ts
+++ b/src/counter-terminal.ts
@@ -24,6 +24,9 @@ export const COUNTER_TERMINAL_LABELS: Record<string, string> = {
   // CRT-only row (not in the glass power menu): the diegetic door into the
   // SERVICE MODE settings page — the staff knobs hidden from the couch tree.
   'btn-service': 'MANAGER OVERRIDE (STAFF ONLY)',
+  // CRT-only row (#42): opens the BIOS-style date sub-screen that pins the
+  // catalog to a rolling point in time (counter-terminal-flow.ts).
+  'btn-media-date': 'MEDIA RELEASE DATE (PIN CATALOG)',
   'btn-cancel': 'RETURN TO STORE',
 };
 

--- a/src/fixtures/coming-soon-letterboard.ts
+++ b/src/fixtures/coming-soon-letterboard.ts
@@ -48,6 +48,7 @@ import { getActiveTheme, themeTrimDarkHex, themeKneeGoldHex, scaleHex } from '..
 import { markSignMesh } from '../sign-builders';
 import { tryLoadUserAssetTexture } from '../user-assets';
 import { getRequestedDiscoveryIds, onJellyseerrRequestChange } from '../jellyseerr';
+import { activeMediaCutoff } from '../media-release-date';
 import {
   ComingSoonRow,
   collectComingSoon,
@@ -489,6 +490,10 @@ export class ComingSoonLetterboard implements StoreFixture {
       const feed = collectComingSoon(this.ctx.libraries, {
         extra: this.ctx.staffPickMovies,
         requestedIds: getRequestedDiscoveryIds(),
+        // Media Release Date pin (#42): "not out yet" means after the store's
+        // rolling today, not the wall clock's — a store pinned ahead of real
+        // time must not board already-premiered-there titles as coming soon.
+        now: activeMediaCutoff() ?? undefined,
       });
       return comingSoonRows(feed, COMING_SOON_LETTERBOARD_SLOTS);
     } catch (e) {

--- a/src/fixtures/storefront-dressing-93.ts
+++ b/src/fixtures/storefront-dressing-93.ts
@@ -122,32 +122,9 @@ export function buildStorefrontDressing93(scene: StoreScene): void {
     group.add(panel);
   }
 
-  // 3b. Red rental-term cards hung inside the entry glass FACING IN (T25
-  // item 30, measured ~32x9in): '3 EVENING RENTAL' and '2 EVENING RENTAL',
-  // white straight caps on flat red, one each side of the door head.
-  {
-    const cardTex = (line: string) => cachedTex(`term-${line}`, 768, 216, (ctx, w, h) => {
-      ctx.fillStyle = '#c8102e';
-      ctx.fillRect(0, 0, w, h);
-      ctx.fillStyle = '#ffffff';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.font = '700 108px Arial, sans-serif';
-      ctx.fillText(line, w / 2, h / 2 + 4);
-    });
-    for (const [i, line] of ['3 EVENING RENTAL', '2 EVENING RENTAL'].entries()) {
-      const card = new THREE.Mesh(
-        new THREE.PlaneGeometry(2.7, 0.76),
-        new THREE.MeshStandardMaterial({ map: cardTex(line), roughness: 0.7, metalness: 0 })
-      );
-      // Inside face of the vestibule glass, flanking the door head, print
-      // toward the store (rotation.y = PI turns +Z away from the lot).
-      card.position.set(11.0 + (i === 0 ? -1.75 : 1.75), 8.6, glassZ - 0.12);
-      card.rotation.y = Math.PI;
-      markSignMesh(card);
-      group.add(card);
-    }
-  }
+  // (3b. The red '3 EVENING RENTAL' / '2 EVENING RENTAL' cards that used to
+  // hang inside the entry glass, flanking the door head, were removed
+  // entirely by owner request — GH #3.)
 
   // 4. EAS anti-theft pedestals — the cream rounded-top gates, EXIT DOOR ONLY
   // (feedback/035, owner: "we don't need these theft venters in the

--- a/src/fixtures/tip-jar.ts
+++ b/src/fixtures/tip-jar.ts
@@ -1,4 +1,4 @@
-// The tip jar — a cup and a 5-inch card on the checkout counter's band top.
+// The tip jar — a cup and a 9-inch card on the checkout counter's band top.
 //
 // This is a NEW sign for a fictional chain, so there is no reference photo to
 // rectify against: nothing about it is a recreation of a real object, and the
@@ -32,15 +32,21 @@ type Disposable = { geo?: THREE.BufferGeometry; mat?: THREE.Material; tex?: THRE
 const CUP_R_TOP = 0.165;
 const CUP_R_BOT = 0.135;
 const CUP_H = 0.36;
-const CARD_W = 0.5;           // 6 in
+// GH #10: the QR card read too small to bother scanning from where a
+// customer actually stands — scaled ~1.5x (9 in wide, was 6 in).
+const CARD_W = 0.75;
 const CARD_H = CARD_W / TIP_CARD_ASPECT;
 const CARD_T = 0.012;
 const CARD_LEAN = 0.20;       // rad — an easel card leans back about 11 deg
 // They stand SIDE BY SIDE, not card-behind-cup: a 4 in card behind a 4.3 in
 // cup is a card nobody can read (first build, caught in the counter shot).
-const CUP_X = -0.34;
-const CARD_X = 0.26;
-const CARD_TEX_W = 1024;
+// Pushed further apart than a naive centre-scale to keep clearance as the
+// card grew (GH #10): the cup nudges left, the card nudges right, so the
+// gap between the cup's band and the card's near edge is actually WIDER
+// than it was at the old size instead of shrinking into the mug.
+const CUP_X = -0.40;
+const CARD_X = 0.36;
+const CARD_TEX_W = 1536;
 
 export class TipJar implements StoreFixture {
   public placement: FixturePlacement;

--- a/src/jellyfin.ts
+++ b/src/jellyfin.ts
@@ -1,4 +1,8 @@
 import { invoke } from '@tauri-apps/api/core';
+// Explicit .ts specifier: tests/version-collapse.test.ts loads this module
+// under `node --test`'s type-stripping loader, which can't resolve the bare
+// sibling specifier (same note as media-date-screen.ts).
+import { activeMediaCutoff, titleReleasedBy } from './media-release-date.ts';
 
 export interface Movie {
   id: string;
@@ -1150,12 +1154,21 @@ export async function fetchSeriesEpisodes(
       // the season panel's "first episode of season N" lookup, the episode
       // selector's index, and playback's up-next step all walk this array, so
       // they were all reading a mis-ordered series.
-      `${url}/emby/Users/${userId}/Items?ParentId=${seriesId}&IncludeItemTypes=Episode&Recursive=true&Fields=Path,Overview,RunTimeTicks&SortBy=ParentIndexNumber,IndexNumber&SortOrder=Ascending&Limit=500`,
+      `${url}/emby/Users/${userId}/Items?ParentId=${seriesId}&IncludeItemTypes=Episode&Recursive=true&Fields=Path,Overview,RunTimeTicks,PremiereDate&SortBy=ParentIndexNumber,IndexNumber&SortOrder=Ascending&Limit=500`,
       undefined,
       token
     );
     const data = JSON.parse(responseStr);
-    const items: any[] = data.Items || [];
+    let items: any[] = data.Items || [];
+    // Media Release Date pin (#42): a series that premiered before the rolling
+    // cutoff still shelves, but episodes that aired after it haven't happened
+    // yet in the store's timeline — a 1996-pinned store must not list (or
+    // play) a 1998 season. Undated episodes stay, same rule as the catalog.
+    const mediaCutoff = activeMediaCutoff();
+    if (mediaCutoff) {
+      items = items.filter((item) =>
+        titleReleasedBy({ premiereDate: item.PremiereDate || undefined }, mediaCutoff));
+    }
     return items.map((item) => ({
       id: item.Id,
       seriesId,

--- a/src/jellyfin.ts
+++ b/src/jellyfin.ts
@@ -114,6 +114,16 @@ export interface Movie {
   played?: boolean;
   playCount?: number;
   lastPlayedDate?: string; // ISO — orders anchors by recency
+  // Ticks into the item Jellyfin says THIS user left off at. The server only
+  // ever returns a non-zero PlaybackPositionTicks while the item is still
+  // inside its own resume window (fully watched or never started both come
+  // back unset) — so "present -> resume there" is the same rule every other
+  // Jellyfin client follows, with no separate "start over" affordance needed.
+  resumePositionTicks?: number;
+  // Exact runtime in ticks (Jellyfin's RunTimeTicks), alongside the rounded
+  // `duration` display string above. Lets a natural end-of-file be told apart
+  // from a user quit without a per-path duration probe (see playback-flow.ts).
+  runTimeTicks?: number;
   // Set by the staff-picks engine on an OWNED title that the aggregated
   // watch-history recommendations surfaced: its case wears the STAFF PICK
   // sticker (video-case.ts) and it's eligible for the genre endcaps.
@@ -235,6 +245,9 @@ export interface Episode {
   overview: string;
   path: string;
   runTimeTicks?: number;
+  /** This user's UserData.PlaybackPositionTicks — see Movie.resumePositionTicks
+   *  for the same "present -> resume there" rule. */
+  resumePositionTicks?: number;
   thumbUrl?: string;
   seasonId?: string;
   /** Primary (poster, 2:3) image of the Season item this episode belongs to. */
@@ -753,6 +766,7 @@ export async function fetchMediaCatalog(
         primaryImageAspectRatio: (typeof item.PrimaryImageAspectRatio === 'number' && item.PrimaryImageAspectRatio > 0) ? item.PrimaryImageAspectRatio : undefined,
         versions: buildItemVersions(item),
         tmdbId: extractTmdbId(item),
+        runTimeTicks: item.RunTimeTicks || undefined,
         ...extractWatchState(item),
       };
     });
@@ -891,13 +905,19 @@ function extractTmdbId(item: any): number | undefined {
 }
 
 /** This user's watch state off UserData (requested via Fields=UserData). */
-function extractWatchState(item: any): Pick<Movie, 'played' | 'playCount' | 'lastPlayedDate'> {
+function extractWatchState(
+  item: any
+): Pick<Movie, 'played' | 'playCount' | 'lastPlayedDate' | 'resumePositionTicks'> {
   const ud = item?.UserData;
   if (!ud) return {};
   return {
     played: ud.Played === true || undefined,
     playCount: typeof ud.PlayCount === 'number' && ud.PlayCount > 0 ? ud.PlayCount : undefined,
     lastPlayedDate: typeof ud.LastPlayedDate === 'string' && ud.LastPlayedDate ? ud.LastPlayedDate : undefined,
+    resumePositionTicks:
+      typeof ud.PlaybackPositionTicks === 'number' && ud.PlaybackPositionTicks > 0
+        ? ud.PlaybackPositionTicks
+        : undefined,
   };
 }
 
@@ -1040,6 +1060,7 @@ export async function fetchJellyfinLibrariesAndMovies(
             primaryImageAspectRatio: (typeof item.PrimaryImageAspectRatio === 'number' && item.PrimaryImageAspectRatio > 0) ? item.PrimaryImageAspectRatio : undefined,
             versions: item.Type === "Series" ? undefined : buildItemVersions(item),
             tmdbId: extractTmdbId(item),
+            runTimeTicks: item.Type === "Series" ? undefined : (item.RunTimeTicks || undefined),
             ...extractWatchState(item),
           };
         });
@@ -1154,7 +1175,7 @@ export async function fetchSeriesEpisodes(
       // the season panel's "first episode of season N" lookup, the episode
       // selector's index, and playback's up-next step all walk this array, so
       // they were all reading a mis-ordered series.
-      `${url}/emby/Users/${userId}/Items?ParentId=${seriesId}&IncludeItemTypes=Episode&Recursive=true&Fields=Path,Overview,RunTimeTicks,PremiereDate&SortBy=ParentIndexNumber,IndexNumber&SortOrder=Ascending&Limit=500`,
+      `${url}/emby/Users/${userId}/Items?ParentId=${seriesId}&IncludeItemTypes=Episode&Recursive=true&Fields=Path,Overview,RunTimeTicks,PremiereDate,UserData&SortBy=ParentIndexNumber,IndexNumber&SortOrder=Ascending&Limit=500`,
       undefined,
       token
     );
@@ -1179,6 +1200,10 @@ export async function fetchSeriesEpisodes(
       overview: item.Overview || "",
       path: item.Path || "",
       runTimeTicks: item.RunTimeTicks || 0,
+      resumePositionTicks:
+        typeof item.UserData?.PlaybackPositionTicks === 'number' && item.UserData.PlaybackPositionTicks > 0
+          ? item.UserData.PlaybackPositionTicks
+          : undefined,
       // Episode "still" — the Primary image on an Episode item. Sized down for
       // the on-box thumbnail; falls back to a placeholder if the load 404s.
       thumbUrl: `${url}/emby/Items/${item.Id}/Images/Primary?api_key=${token}&maxWidth=400`,

--- a/src/jellyseerr.ts
+++ b/src/jellyseerr.ts
@@ -10,6 +10,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { Movie } from './jellyfin';
 import { isDemoMode } from './demo-mode';
+import { activeSuggestionWindow, titleInWindow, windowGteParam, windowLteParam } from './media-release-date';
 
 export interface JellyseerrConfig {
   url: string;
@@ -282,6 +283,11 @@ export async function fetchDiscoverMovies(): Promise<Movie[]> {
   const seenTmdbIds = new Set<number>();
   const movies: Movie[] = [];
   const dismissed = getDismissedTitleIds();
+  // Release window (#42): the permanent suggestion bounds with the rolling
+  // Media Release Date pin folded into the ceiling (tighter wins). Applied
+  // client-side on every ingested item — the server-side params below are an
+  // efficiency, not the gate, and /discover/trending takes no date params.
+  const win = activeSuggestionWindow();
 
   const ingest = (items: any[]) => {
     for (const item of items) {
@@ -294,6 +300,7 @@ export async function fetchDiscoverMovies(): Promise<Movie[]> {
       // Jellyseerr attaches `mediaInfo` once it knows the title exists in (or
       // has been requested into) the library -- never duplicate those here.
       if (item.mediaInfo) continue;
+      if (!titleInWindow({ premiereDate: item.releaseDate || undefined }, win)) continue;
       const title: string | undefined = item.title || item.name;
       if (!title) continue;
 
@@ -326,12 +333,21 @@ export async function fetchDiscoverMovies(): Promise<Movie[]> {
   };
 
   try {
+    // /discover/movies forwards TMDB's primary-release-date bounds, so ask the
+    // server to pre-trim its page — otherwise a tight window could see a whole
+    // page of out-of-window titles and shelve nothing despite eligible films
+    // one page deeper. Trending has no such params; ingest() gates it.
+    const lte = windowLteParam(win);
+    const gte = windowGteParam(win);
+    const datedMovies = '/api/v1/discover/movies?page=1'
+      + (gte ? `&primaryReleaseDateGte=${gte}` : '')
+      + (lte ? `&primaryReleaseDateLte=${lte}` : '');
     const [trending, popular] = await Promise.all([
       jellyseerrRequest(config, '/api/v1/discover/trending?page=1').catch((e) => {
         console.warn('[Jellyseerr] Trending discovery fetch failed:', e);
         return null;
       }),
-      jellyseerrRequest(config, '/api/v1/discover/movies?page=1').catch((e) => {
+      jellyseerrRequest(config, datedMovies).catch((e) => {
         console.warn('[Jellyseerr] Popular discovery fetch failed:', e);
         return null;
       }),
@@ -446,6 +462,11 @@ export async function fetchCollectionGaps(targets: CollectionGapTarget[]): Promi
   const movies: Movie[] = [];
   const seenTmdbIds = new Set<number>();
   const dismissed = getDismissedTitleIds();
+  // Release window (#42): a gap case is a suggestion ("order it?"), so the
+  // suggestion bounds gate it — EXCEPT one the player already ordered, whose
+  // case must keep standing (the rolling pin still absents post-cutoff ones
+  // at the scene-build funnel regardless).
+  const win = activeSuggestionWindow();
   let dismissedCount = 0;
 
   const fetchOne = async (target: CollectionGapTarget): Promise<void> => {
@@ -475,6 +496,7 @@ export async function fetchCollectionGaps(targets: CollectionGapTarget[]): Promi
       if (dismissed.has(tmdbId)) { dismissedCount++; continue; }
       const title: string | undefined = part.title || part.name;
       if (!title) continue;
+      if (!alreadyRequested && !titleInWindow({ premiereDate: part.releaseDate || undefined }, win)) continue;
 
       seenTmdbIds.add(tmdbId);
 
@@ -557,8 +579,13 @@ const seedCache = new Map<number, RecommendationSeed[]>();
 export async function fetchRecommendationSeeds(anchorTmdbId: number): Promise<RecommendationSeed[]> {
   const config = getJellyseerrConfig();
   if (!config) return [];
+  // Release window (#42): staff-pick seeds obey the same suggestion bounds as
+  // the discovery shelves. The cache keeps the RAW list and the filter runs on
+  // the way out, so a pin set after the cache warmed still bites.
+  const win = activeSuggestionWindow();
+  const inWindow = (list: RecommendationSeed[]) => list.filter((s) => titleInWindow(s, win));
   const cached = seedCache.get(anchorTmdbId);
-  if (cached) return cached;
+  if (cached) return inWindow(cached);
   const seeds: RecommendationSeed[] = [];
   try {
     const res = await jellyseerrRequest(config, `/api/v1/movie/${anchorTmdbId}/recommendations?page=1`);
@@ -585,7 +612,7 @@ export async function fetchRecommendationSeeds(anchorTmdbId: number): Promise<Re
     return [];
   }
   seedCache.set(anchorTmdbId, seeds);
-  return seeds;
+  return inWindow(seeds);
 }
 
 export interface MovieDetailResult {

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,6 +111,13 @@ import { startScreensaverAnimation, stopScreensaverAnimation } from './screensav
 import { buildDemoLibraries, buildDemoDiscovery, buildDemoGames, makeSyntheticEpisodes, demoPoster } from './demo-library';
 import { EMPTY_STAFF_PICKS, loadStaffPicks, StaffPicks } from './staff-picks-loader';
 import { titleMatchKeys } from './staff-picks';
+import {
+  episodeLabel,
+  markWatchedAndFindNext,
+  resolveActiveItemTiming,
+  resolveMpvPrefArgs,
+  playLocalWithMpv,
+} from './playback-flow';
 
 // ─── Application State ────────────────────────────────────────────────────────
 
@@ -3422,20 +3429,9 @@ async function wakeRefresh() {
 // season-then-episode order (see fetchSeriesEpisodes), so an episode running to
 // its end rolls into the next one — across season boundaries too. Rebuilt on
 // every launch; a movie clears it.
+// nextEpisodeInQueue/episodeLabel/markWatchedAndFindNext live in
+// playback-flow.ts — shared with the mpv exit handler below.
 let seriesQueue: { seriesId: string; episodes: Episode[] } | null = null;
-
-/** The episode after `currentItemId` in the active series queue, if any. */
-function nextEpisodeInQueue(movie: Movie, currentItemId: string): Episode | null {
-  if (!movie.isSeries || seriesQueue?.seriesId !== movie.id) return null;
-  const i = seriesQueue.episodes.findIndex((e) => e.id === currentItemId);
-  return i >= 0 ? (seriesQueue.episodes[i + 1] ?? null) : null;
-}
-
-/** "S02E05 · Title" for console/log lines. */
-function episodeLabel(ep: Episode): string {
-  const num = `S${String(ep.seasonNumber).padStart(2, '0')}E${String(ep.episodeNumber).padStart(2, '0')}`;
-  return ep.name ? `${num} · ${ep.name}` : num;
-}
 
 export async function launchVideoPlayback(movie: Movie, overrideItemId?: string, overridePath?: string, startHidden = false, diegetic = false, version?: MovieVersion) {
   revealPendingHidden = false; // fresh launch — clear any stale reveal handshake
@@ -3517,6 +3513,10 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
     seriesQueue = null;
   }
 
+  // Resume position (0 = start over) and, for the mpv path's natural-end vs.
+  // quit check below, the item's known runtime — see resolveActiveItemTiming.
+  const { resumeTicks, durationTicks } = resolveActiveItemTiming(movie, overrideItemId, seriesQueue);
+
   // Local playback first. When the file is on this machine, mpv plays it
   // directly — the only path that gives real HDR and the original soundtrack,
   // and the only one that doesn't have Jellyfin spooling the film to disk as
@@ -3535,16 +3535,30 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
   if (localPath && !diegetic && clientIsServerMachine && !isRemotelyDriven()
       && getSetting<boolean>('bb_local_mpv') !== false) {
     const spawnMpv = async (): Promise<boolean> => {
-      const started = await playLocalWithMpv(localPath, playbackId, 0, () => {
-        ui.isPlaybackActive = false;
-        storeScene?.resumeRendering();
-        storeScene?.resumeAmbientTvs();
-        storeScene?.returnToEntrance();
-        updateMovieHUD(storeScene?.getSelectedMovie() || null);
-        logToConsole(`[Video] Stopped "${movie.title}". Returned through the entrance.`, 'video');
-      });
+      const started = await playLocalWithMpv(
+        localPath, playbackId, resumeTicks, durationTicks, await resolveMpvPrefArgs(),
+        (_positionTicks, endedNaturally) => {
+          ui.isPlaybackActive = false;
+          // Series binge-watching, same as the HTML5 path below: a natural
+          // end rolls straight into the next queued episode; mpv is spawned
+          // again via the ordinary recursive launch, same as a fresh play.
+          const nextEp = markWatchedAndFindNext(movie, endedNaturally, seriesQueue, playbackId, () => storeScene?.restockSlottedFixtures());
+          if (nextEp) {
+            logToConsole(`[Video] "${movie.title}" — up next: ${episodeLabel(nextEp)}.`, 'video');
+            void launchVideoPlayback(movie, nextEp.id, nextEp.path || undefined, false, false);
+            return;
+          }
+          storeScene?.resumeRendering();
+          storeScene?.resumeAmbientTvs();
+          storeScene?.returnToEntrance();
+          updateMovieHUD(storeScene?.getSelectedMovie() || null);
+          logToConsole(`[Video] Stopped "${movie.title}". Returned through the entrance.`, 'video');
+        },
+        (msg) => logToConsole(msg, 'video'),
+      );
       if (started) {
         // The store is behind a fullscreen window now — stop drawing it.
+        ui.isPlaybackActive = true;
         storeScene?.pauseAmbientTvs();
         storeScene?.pauseRendering();
       }
@@ -3626,10 +3640,11 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
   const initialSubtitleIndex = wantSubtitles
     ? (subtitleStreams.find(matchesPrefLang) ?? subtitleStreams.find((s) => s.isDefault) ?? subtitleStreams[0])?.index
     : undefined;
-  if (initialAudioIndex !== undefined || initialSubtitleIndex !== undefined) {
+  if (initialAudioIndex !== undefined || initialSubtitleIndex !== undefined || resumeTicks > 0) {
     logToConsole(
       `[Video] Playback prefs: audio=${initialAudioIndex !== undefined ? trackLabel(preferredAudio!) : 'default'}, ` +
-        `subtitles=${initialSubtitleIndex !== undefined ? 'on' : 'off'}.`,
+        `subtitles=${initialSubtitleIndex !== undefined ? 'on' : 'off'}, ` +
+        `resume=${resumeTicks > 0 ? `${Math.round(resumeTicks / 10_000_000)}s` : 'no'}.`,
       'video',
     );
   }
@@ -3643,6 +3658,7 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
     mediaSourceId,
     audioStreamIndex: initialAudioIndex,
     subtitleStreamIndex: initialSubtitleIndex,
+    startPositionTicks: resumeTicks || undefined,
   });
   const hevcCopy = isHevcPassThroughEnabled() && (sourceVideoCodec === 'hevc' || sourceVideoCodec === 'h265');
   const mediaInfoSummary =
@@ -3677,6 +3693,7 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
     defaultAudioIndex: initialAudioIndex,
     defaultSubtitleIndex: initialSubtitleIndex,
     subtitlesDefaultOn: wantSubtitles,
+    startPositionTicks: resumeTicks || undefined,
     hideVideoSurface: diegetic,
     // Non-diegetic playback exits through returnToEntrance() (onClose below)
     // — gate user-initiated exits behind an "are you sure?" so a Back meant
@@ -3699,30 +3716,14 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
         setTimeout(() => location.reload(), 250);
         return;
       }
-      // Optimistic local watch-state update (feedback/055): reportPlaybackStopped
-      // below is fire-and-forget and nothing re-fetches the library afterwards,
-      // so without this the Movie object StoreScene already holds a reference
-      // to never learns it was watched this session — the PREVIOUSLY VIEWED
-      // drape table (pv-drape-table.ts) would stay frozen at whatever watch
-      // history existed at boot. Only a natural end counts as "watched":
-      // backing out early shouldn't bump play count or reorder the table.
-      // restockSlottedFixtures() patches the already-built table in place
-      // (see its header in store-stock.ts) — cheap enough to call here, before
-      // the store is shown again below, so any texture swap is invisible.
-      if (endedNaturally) {
-        movie.played = true;
-        movie.playCount = (movie.playCount ?? 0) + 1;
-        movie.lastPlayedDate = new Date().toISOString();
-        storeScene?.restockSlottedFixtures();
-      }
-      // A series behaves like a series: an episode that plays to the end rolls
-      // straight into the next one (including into the next season — the queue
-      // is season-then-episode ordered). Backing out early means "I'm done",
-      // so only a natural end advances. The player reuses one <video> element,
-      // so a diegetic (back-room CRT) advance keeps its existing VideoTexture
-      // mapping — no re-attach needed. startHidden stays false: the tape
-      // animation is the gesture for STARTING a title, not for continuing one.
-      const nextEp = endedNaturally ? nextEpisodeInQueue(movie, playbackId) : null;
+      // Optimistic local watch-state update + up-next lookup (see
+      // markWatchedAndFindNext in playback-flow.ts, shared with the mpv exit
+      // handler above) — only a natural end counts as "watched"/advances.
+      // The player reuses one <video> element, so a diegetic (back-room CRT)
+      // advance keeps its existing VideoTexture mapping — no re-attach
+      // needed. startHidden stays false: the tape animation is the gesture
+      // for STARTING a title, not for continuing one.
+      const nextEp = markWatchedAndFindNext(movie, endedNaturally, seriesQueue, playbackId, () => storeScene?.restockSlottedFixtures());
       if (nextEp) {
         reportPlaybackStopped(jellyfinUrl, token, playbackId, positionTicks);
         logToConsole(`[Video] "${movie.title}" — up next: ${episodeLabel(nextEp)}.`, 'video');
@@ -3870,79 +3871,6 @@ function revealVideoPlayback() {
 }
 
 /** Launch the original file in the system media player (mpv/VLC) as a fallback. */
-/**
- * Play a title by handing mpv the file on disk, bypassing Jellyfin's streaming
- * path entirely. Only correct when the media, the server and this app are on
- * one machine — but that's this deployment, and it buys three things the
- * webview cannot do at all: genuine HDR output (Chromium has no HDR video
- * path, so it flattens an HDR10 master to SDR no matter how cleanly the file
- * reaches it), the original lossless multichannel audio instead of a stereo
- * AAC downmix, and seeking that doesn't wait on a server.
- *
- * It also stops Jellyfin writing the film to disk as HLS segments while you
- * watch — ~70 GB for a 4K remux — which it only ever did because the webview
- * can't demux Matroska.
- *
- * Returns false when the local endpoint isn't reachable (production bundle,
- * no dev/preview server) so the caller can fall back to in-app streaming.
- */
-async function playLocalWithMpv(
-  filePath: string,
-  itemId: string,
-  startPositionTicks: number,
-  onExit: (positionTicks: number) => void,
-): Promise<boolean> {
-  const jellyfinUrl = localStorage.getItem('jellyfin_url');
-  const token = localStorage.getItem('jellyfin_token');
-  const startSeconds = Math.max(0, Math.floor(startPositionTicks / 10_000_000));
-
-  let id: string;
-  try {
-    const res = await fetch('/__play', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ path: filePath, startSeconds }),
-    });
-    if (!res.ok) {
-      logToConsole(`[Video] Local player refused the file (${res.status}); streaming instead.`, 'video');
-      return false;
-    }
-    id = (await res.json()).id;
-  } catch {
-    // No endpoint (production bundle) — caller falls back to the in-app player.
-    return false;
-  }
-
-  logToConsole(`[Video] Playing off disk in mpv (from ${startSeconds}s).`, 'video');
-  ui.isPlaybackActive = true;
-  if (jellyfinUrl && token) reportPlaybackStart(jellyfinUrl, token, itemId);
-
-  // Poll for position so Continue Watching still tracks, and so closing mpv
-  // returns to the store the same way the in-app player's Back does.
-  let lastTicks = startPositionTicks;
-  const poll = window.setInterval(async () => {
-    try {
-      const res = await fetch(`/__play?id=${encodeURIComponent(id)}`);
-      if (!res.ok) throw new Error(String(res.status));
-      const s = await res.json();
-      lastTicks = Math.round((s.position ?? 0) * 10_000_000);
-      if (!s.exited) {
-        if (jellyfinUrl && token) reportPlaybackProgress(jellyfinUrl, token, itemId, lastTicks, false);
-        return;
-      }
-      window.clearInterval(poll);
-      if (s.error) logToConsole(`[Video] mpv error: ${s.error}`, 'video');
-      if (jellyfinUrl && token) reportPlaybackStopped(jellyfinUrl, token, itemId, lastTicks);
-      onExit(lastTicks);
-    } catch {
-      // Endpoint vanished (server restarted) — stop polling rather than spin.
-      window.clearInterval(poll);
-      onExit(lastTicks);
-    }
-  }, 5000);
-  return true;
-}
-
 async function playExternally(path: string) {
   if (!isTauri) {
     logToConsole('[Video] External player not available outside Tauri.', 'video');

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,15 @@ import {
   isMembershipPickerOpen,
   type MembershipLoginSession,
 } from './membership-cards';
-import { getActiveTheme, applyThemeCssVars } from './themes';
+import { getActiveTheme, applyThemeCssVars, THEMES, resolveThemeId } from './themes';
+import {
+  activeMediaCutoff,
+  filterLibrariesByCutoff,
+  filterMoviesByCutoff,
+  loadMediaReleasePin,
+  eraThemeIdForDate,
+  toDateOnly,
+} from './media-release-date';
 import { retailAudio } from './audio';
 import { BB_ARCHIVO_BLACK, bundledFontsReady } from './bundled-fonts';
 import { brandString, loadBrandPack } from './brand-pack';
@@ -87,7 +95,13 @@ import {
   refreshSettingThumb,
 } from './settings';
 import type { SettingDef, SettingGroup } from './settings';
-import { counterTerminalLines } from './counter-terminal';
+import {
+  MEDIA_DATE_BUTTON_ID,
+  counterTerminalClose,
+  counterTerminalInput,
+  counterTerminalOpen,
+  initCounterTerminalFlow,
+} from './counter-terminal-flow';
 import { buildControlsHelpPanel, HELP_ROW_PREFIX } from './controls-help';
 import type { CandyRow } from './fixtures/period-fixtures';
 import { getCandyDeliveryAdapter } from './candy-delivery';
@@ -122,10 +136,28 @@ let gameMovies: Movie[] = [];
 // a rebuild rather than a full re-sync.
 let storeLibraries: JellyfinLibrary[] = [];
 let storeGameMovies: Movie[] = [];
+// Store-facing views of the Jellyseerr lists, gated like the libraries above.
+let storeComingSoon: Movie[] = [];
+let storeDiscovery: Movie[] = [];
 function refreshStoreCatalog() {
   const catalog = storeCatalog(librariesList, gameMovies);
-  storeLibraries = catalog.libraries;
-  storeGameMovies = catalog.games;
+  // Media Release Date pin (#42): everything premiering after the rolling
+  // cutoff is absent from the store entirely. Filtered COPIES of the fetched
+  // lists — clearing the pin is a rebuild, never a re-sync.
+  const cutoff = activeMediaCutoff();
+  storeLibraries = cutoff ? filterLibrariesByCutoff(catalog.libraries, cutoff) : catalog.libraries;
+  storeGameMovies = cutoff ? filterMoviesByCutoff(catalog.games, cutoff) : catalog.games;
+  storeComingSoon = cutoff ? filterMoviesByCutoff(comingSoonMovies, cutoff) : comingSoonMovies;
+  storeDiscovery = cutoff ? filterMoviesByCutoff(discoveryMovies, cutoff) : discoveryMovies;
+  if (!cutoff) return;
+  // MATCH STORE ERA: the decor tracks the pin's effective date (and crosses
+  // era boundaries as the rolling date does). Persist-only — we're already
+  // inside the build funnel, so the scene about to build reads the new era.
+  if (loadMediaReleasePin()?.matchEra) {
+    const era = eraThemeIdForDate(cutoff, Object.keys(THEMES));
+    if (era && resolveThemeId(getSetting<string>('bb_theme')) !== era) setSetting('bb_theme', era);
+  }
+  logToConsole(`[System] Media Release Date: store pinned to ${toDateOnly(cutoff)} — later releases are absent.`, 'system');
 }
 // Watch-history staff picks (stickers + genre endcaps) -- see staff-picks.ts.
 // Computed right before the 3D scene is built; stays empty without watch
@@ -469,7 +501,7 @@ const ui = {
   isCandyCheckoutOpen: false,
   isFeedbackOpen: false,
   // The clerk's terminal at the checkout counter, showing the same options as
-  // the power menu but drawn on the desk CRT (see openCounterTerminal). Not an
+  // the power menu but drawn on the desk CRT (counter-terminal-flow.ts). Not an
   // overlay — it's in-scene — but it owns the arrow keys while docked, so it
   // joins isAnyOverlayOpen to keep shelf navigation from running underneath.
   isCounterTerminalOpen: false,
@@ -494,13 +526,14 @@ const powerButtons = ['btn-settings', 'btn-controls', 'btn-flat-mode', 'btn-susp
 // commands are idempotent no-ops when the display is already in that state.
 let cecDisplayAssumedOn = true;
 
-// The counter CRT carries one extra row the glass power menu doesn't:
+// The counter CRT carries extra rows the glass power menu doesn't:
 // MANAGER OVERRIDE, the diegetic (and only couch-reachable) entry into the
-// SERVICE MODE settings page (review §4.3). Inserted just above RETURN TO
-// STORE so the safe exit stays last.
+// SERVICE MODE settings page (review §4.3), and MEDIA RELEASE DATE (#42),
+// the catalog-pin sub-screen. Inserted just above RETURN TO STORE so the
+// safe exit stays last.
 const counterTerminalButtons = (() => {
   const ids = [...powerButtons];
-  ids.splice(ids.indexOf('btn-cancel'), 0, 'btn-service');
+  ids.splice(ids.indexOf('btn-cancel'), 0, MEDIA_DATE_BUTTON_ID, 'btn-service');
   return ids;
 })();
 
@@ -827,50 +860,19 @@ function closePowerMenu() {
 // StoreScene.enterSearchMode) with the options rendered in amber phosphor.
 //
 // Rows are the SAME `powerButtons` ids the overlay uses (plus the CRT-only
-// MANAGER OVERRIDE row — see counterTerminalButtons) and dispatch through
-// the same executePowerMenuAction(), so the two views can never drift out of
-// sync — including the demo-mode filter that drops logout/exit. Only the labels
-// differ: the CRT is 40 columns wide, so they're shortened here.
-// Row text lives in src/counter-terminal.ts so the 3D harness (which boots
-// StoreScene without this DOM shell) renders the identical menu.
-let counterTerminalIndex = 0;
-
-function renderCounterTerminal() {
-  const { lines, cursorLine } = counterTerminalLines(counterTerminalButtons, counterTerminalIndex);
-  storeScene?.setTerminalText(lines, cursorLine);
-}
-
-function openCounterTerminal() {
-  if (!storeScene || ui.isAnyOverlayOpen) return;
-  ui.isCounterTerminalOpen = true;
-  counterTerminalIndex = 0;
-  storeScene.enterSearchMode(); // camera dock only — the text is ours
-  renderCounterTerminal();
-  logToConsole('[Terminal] Manager terminal open at the counter.', 'system');
-}
-
-function closeCounterTerminal() {
-  if (!ui.isCounterTerminalOpen) return;
-  ui.isCounterTerminalOpen = false;
-  // Hands the camera back and resets the CRT to its idle rental screen.
-  storeScene?.exitSearchMode();
-  logToConsole('[Terminal] Manager terminal closed.', 'system');
-}
-
-function stepCounterTerminal(delta: number) {
-  const n = counterTerminalButtons.length;
-  counterTerminalIndex = (counterTerminalIndex + delta + n) % n;
-  retailAudio.playKeyClick();
-  renderCounterTerminal();
-}
-
-async function activateCounterTerminal() {
-  const btnId = counterTerminalButtons[counterTerminalIndex];
-  // Close first: several actions (settings drawer, logout) take over the
-  // screen, and the docked camera must be handed back before they do.
-  closeCounterTerminal();
-  await executePowerMenuAction(btnId);
-}
+// MANAGER OVERRIDE and MEDIA RELEASE DATE rows — see counterTerminalButtons)
+// and dispatch through the same executePowerMenuAction(), so the two views can
+// never drift out of sync. The controller itself (menu state + the #42 date
+// sub-screen) lives in counter-terminal-flow.ts; this is its one wiring point.
+initCounterTerminalFlow({
+  scene: () => storeScene,
+  ui,
+  buttons: counterTerminalButtons,
+  execute: (btnId) => executePowerMenuAction(btnId),
+  keyClick: () => retailAudio.playKeyClick(),
+  log: (msg) => logToConsole(msg, 'system'),
+  rebuild: () => rebuildStoreScene(),
+});
 
 // ─── Settings Drawer ───────────────────────────────────────────────────────
 //
@@ -2425,7 +2427,7 @@ async function initializeStoreScene(preservePosterCache = false) {
         if (lib.movies[i].discovery) lib.movies.splice(i, 1);
       }
     }
-    bootFlatStore(storeLibraries, canvasContainer, storeGameMovies, discoveryMovies);
+    bootFlatStore(storeLibraries, canvasContainer, storeGameMovies, storeDiscovery);
     hideBootOverlay();
     return;
   }
@@ -2497,7 +2499,7 @@ async function initializeStoreScene(preservePosterCache = false) {
     await calibrateQualityIfNeeded();
 
     const { StoreScene } = await import('./three-scene');
-    const scene = new StoreScene(canvasContainer, storeLibraries, logToConsole, jfUrl, jfToken, comingSoonMovies, discoveryMovies, storeGameMovies, staffPicks);
+    const scene = new StoreScene(canvasContainer, storeLibraries, logToConsole, jfUrl, jfToken, storeComingSoon, storeDiscovery, storeGameMovies, staffPicks);
     armQualityBackstop();
 
     let lastLoggedPct = -1;
@@ -2614,7 +2616,7 @@ async function initializeStoreScene(preservePosterCache = false) {
     };
 
     // Left at the checkout counter reaches for the clerk's terminal.
-    scene.onCounterTerminal = () => openCounterTerminal();
+    scene.onCounterTerminal = () => counterTerminalOpen();
     scene.onEnterFlatMode = () => executePowerMenuAction('btn-flat-mode');
 
     // Library-select (end-cap) left/right nav arrows on the floating locator.
@@ -4025,7 +4027,7 @@ async function main() {
       if (ui.isLoginOpen) return;
       if (ui.isSearchOpen) return;
       if (ui.isPowerMenuOpen) return;
-      if (ui.isCounterTerminalOpen) return; // already docked; Left is what opened it
+      if (ui.isCounterTerminalOpen) { counterTerminalInput('left'); return; }
       if (ui.isSettingsDrawerOpen) {
         if (settingsRowKeys[settingsIndex] !== SETTINGS_CLOSE_KEY) activateSelectedSetting(-1);
         return;
@@ -4049,8 +4051,9 @@ async function main() {
       if (ui.isSearchOpen) return;
       if (ui.isPowerMenuOpen) return;
       // Right steps back out of the terminal to the counter — the mirror of
-      // the Left press that reached for it.
-      if (ui.isCounterTerminalOpen) { closeCounterTerminal(); return; }
+      // the Left press that reached for it (or moves field focus while the
+      // date sub-screen is up; the flow decides).
+      if (ui.isCounterTerminalOpen) { counterTerminalInput('right'); return; }
       if (ui.isSettingsDrawerOpen) {
         if (settingsRowKeys[settingsIndex] !== SETTINGS_CLOSE_KEY) activateSelectedSetting(1);
         return;
@@ -4082,7 +4085,7 @@ async function main() {
         setPowerMenuSelection(nextIdx);
         logToConsole(`[Input] Power menu selection: ${powerButtons[nextIdx]}`, 'system');
       } else if (ui.isCounterTerminalOpen) {
-        stepCounterTerminal(-1);
+        counterTerminalInput('up');
       } else if (ui.isVersionPickerOpen) {
         moveVersionPickerSelection(-1);
       } else if (ui.isCandyCheckoutOpen) {
@@ -4108,7 +4111,7 @@ async function main() {
         setPowerMenuSelection(nextIdx);
         logToConsole(`[Input] Power menu selection: ${powerButtons[nextIdx]}`, 'system');
       } else if (ui.isCounterTerminalOpen) {
-        stepCounterTerminal(1);
+        counterTerminalInput('down');
       } else if (ui.isVersionPickerOpen) {
         moveVersionPickerSelection(1);
       } else if (ui.isCandyCheckoutOpen) {
@@ -4140,7 +4143,7 @@ async function main() {
       // than falling through to selectAction(), which in checkout mode would
       // confirm the rental.
       if (ui.isCounterTerminalOpen) {
-        await activateCounterTerminal();
+        await counterTerminalInput('ok');
         return;
       }
 
@@ -4229,7 +4232,7 @@ async function main() {
       }
 
       if (ui.isCounterTerminalOpen) {
-        closeCounterTerminal();
+        counterTerminalInput('back'); // steps the date sub-screen out first
         return;
       }
 
@@ -4269,7 +4272,7 @@ async function main() {
       if (ui.isSearchOpen) { closeSearch(); return; }
       // P while the diegetic version is already up closes it rather than
       // stacking the glass overlay on top of the same options.
-      if (ui.isCounterTerminalOpen) { closeCounterTerminal(); return; }
+      if (ui.isCounterTerminalOpen) { counterTerminalClose(); return; }
 
       if (ui.isExitConfirmOpen) {
         closeExitConfirm();

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,6 +88,7 @@ import {
   getSettingDef,
   nextCycleValue,
   currentValueLabel,
+  resolveHint,
   buildStoreBrandPanel,
   activateBrandRow,
   BRAND_ROW_PREFIX,
@@ -153,9 +154,15 @@ function refreshStoreCatalog() {
   // MATCH STORE ERA: the decor tracks the pin's effective date (and crosses
   // era boundaries as the rolling date does). Persist-only — we're already
   // inside the build funnel, so the scene about to build reads the new era.
+  // This is the one override that SHOULD win without asking (that's what the
+  // follow is for), so when it actually changes the era, say so — the store
+  // looking different today needs a line explaining why.
   if (loadMediaReleasePin()?.matchEra) {
     const era = eraThemeIdForDate(cutoff, Object.keys(THEMES));
-    if (era && resolveThemeId(getSetting<string>('bb_theme')) !== era) setSetting('bb_theme', era);
+    if (era && resolveThemeId(getSetting<string>('bb_theme')) !== era) {
+      setSetting('bb_theme', era);
+      logToConsole(`[System] Media Release Date: the store has crossed into its ${THEMES[era].name} era.`, 'system');
+    }
   }
   logToConsole(`[System] Media Release Date: store pinned to ${toDateOnly(cutoff)} — later releases are absent.`, 'system');
 }
@@ -974,7 +981,8 @@ function generateSettingsDrawer() {
     row.className = 'settings-row settings-text-row';
     row.id = `setting-row-${def.key}`;
     row.tabIndex = -1; // focusable by setSettingsSelection, not in tab order
-    if (def.hint) row.dataset.hint = def.hint; // footer-bar hint, see makeRow
+    const textHint = resolveHint(def);
+    if (textHint) row.dataset.hint = textHint; // footer-bar hint, see makeRow
     const main = document.createElement('span');
     main.className = 'settings-row-main';
     main.innerHTML = `
@@ -1076,7 +1084,7 @@ function generateSettingsDrawer() {
       if (def.kind === 'text' || def.kind === 'secret') {
         groupEl.appendChild(makeTextRow(def));
       } else {
-        groupEl.appendChild(makeRow(def.key, def.label, def.hint, '', `setting-value-${def.key}`));
+        groupEl.appendChild(makeRow(def.key, def.label, resolveHint(def), '', `setting-value-${def.key}`));
       }
     };
     if (settingsPage === 'Store Brand') {
@@ -1450,6 +1458,18 @@ function activateSetting(key: string, dir: number) {
     generateSettingsDrawer();
     refreshSettingsValues();
     setSettingsSelection(Math.max(0, settingsRowKeys.indexOf(key)));
+  }
+
+  // Post-commit hook (e.g. changing Store Theme detaches era-follow so the
+  // pick can stick). Runs BEFORE the value/hint refresh below so both render
+  // the post-hook truth — the theme row must lose its "(AUTO)" the moment the
+  // follow detaches, not on the next drawer open.
+  const note = def.onChange?.(getSetting(key));
+  if (typeof note === 'string') logToConsole(`[System] ${note}`, 'system');
+  if (typeof def.hint === 'function') {
+    const row = document.getElementById(`setting-row-${key}`);
+    if (row) row.dataset.hint = def.hint();
+    updateSettingsCrtChrome(); // the footer bar shows the selected row's hint
   }
 
   const el = document.getElementById(`setting-value-${key}`);

--- a/src/media-date-screen.ts
+++ b/src/media-date-screen.ts
@@ -1,0 +1,181 @@
+// Issue #42 — the MEDIA RELEASE DATE screen on the counter CRT, as pure state.
+//
+// BIOS-clock interaction, because the couch remote is momentary buttons only:
+// Left/Right move focus across YEAR / MONTH / DAY / MATCH ERA / SET / CLEAR /
+// BACK, Up/Down change the focused value (or toggle MATCH ERA), OK advances a
+// field (and fires the focused action row), Back returns to the manager menu.
+// Typed digits are keyboard-only sugar handled by the flow module on top.
+//
+// Pure data + reducer + formatter, no DOM and no three.js: main.ts's flow
+// module and the shot harness both render the SAME lines, and the reducer
+// unit-tests under bare `node --test` alongside media-release-date.test.ts.
+// Explicit .ts specifier (allowImportingTsExtensions): unlike the other
+// node-tested modules this one has a RUNTIME dependency on a sibling, and the
+// bare specifier resolves under Vite/tsc but not under `node --test`'s
+// type-stripping loader.
+import type { MediaReleasePin } from './media-release-date.ts';
+import {
+  PIN_YEAR_MAX,
+  PIN_YEAR_MIN,
+  effectiveCutoff,
+  formatCutoffLabel,
+} from './media-release-date.ts';
+
+export const FOCUS_YEAR = 0;
+export const FOCUS_MONTH = 1;
+export const FOCUS_DAY = 2;
+export const FOCUS_ERA = 3;
+export const FOCUS_SET = 4;
+export const FOCUS_CLEAR = 5;
+export const FOCUS_BACK = 6;
+const FOCUS_COUNT = 7;
+
+export interface MediaDateScreenState {
+  year: number;
+  month: number; // 1-12
+  day: number;   // 1-31, clamped to the month
+  matchEra: boolean;
+  focus: number; // FOCUS_* above
+  /** Digits typed into the focused field since it gained focus (keyboard). */
+  typed: string;
+}
+
+export type MediaDateKey = 'up' | 'down' | 'left' | 'right' | 'ok' | 'back';
+
+export interface MediaDateKeyResult {
+  state: MediaDateScreenState;
+  /** What the host flow should do beyond re-rendering. */
+  action: 'none' | 'save' | 'clear' | 'back';
+}
+
+const daysInMonth = (y: number, m: number): number => new Date(y, m, 0).getDate();
+
+const clampDay = (s: MediaDateScreenState): MediaDateScreenState => ({
+  ...s,
+  day: Math.min(s.day, daysInMonth(s.year, s.month)),
+});
+
+/** Start from the current pin's effective date (or today, unpinned). */
+export function initMediaDateScreen(pin: MediaReleasePin | null, now: Date): MediaDateScreenState {
+  const base = pin ? effectiveCutoff(pin, now) : now;
+  return {
+    year: Math.min(PIN_YEAR_MAX, Math.max(PIN_YEAR_MIN, base.getFullYear())),
+    month: base.getMonth() + 1,
+    day: base.getDate(),
+    matchEra: !!pin?.matchEra,
+    focus: FOCUS_YEAR,
+    typed: '',
+  };
+}
+
+/** One remote/keyboard press. Pure — the host applies `action` itself. */
+export function mediaDateScreenKey(s: MediaDateScreenState, key: MediaDateKey): MediaDateKeyResult {
+  const move = (delta: number): MediaDateKeyResult => ({
+    state: { ...s, focus: (s.focus + delta + FOCUS_COUNT) % FOCUS_COUNT, typed: '' },
+    action: 'none',
+  });
+  switch (key) {
+    case 'left': return move(-1);
+    case 'right': return move(1);
+    case 'up':
+    case 'down': {
+      const d = key === 'up' ? 1 : -1;
+      if (s.focus === FOCUS_YEAR) {
+        const year = Math.min(PIN_YEAR_MAX, Math.max(PIN_YEAR_MIN, s.year + d));
+        return { state: clampDay({ ...s, year, typed: '' }), action: 'none' };
+      }
+      if (s.focus === FOCUS_MONTH) {
+        const month = ((s.month - 1 + d + 12) % 12) + 1;
+        return { state: clampDay({ ...s, month, typed: '' }), action: 'none' };
+      }
+      if (s.focus === FOCUS_DAY) {
+        const n = daysInMonth(s.year, s.month);
+        const day = ((s.day - 1 + d + n) % n) + 1;
+        return { state: { ...s, day, typed: '' }, action: 'none' };
+      }
+      if (s.focus === FOCUS_ERA) {
+        return { state: { ...s, matchEra: !s.matchEra, typed: '' }, action: 'none' };
+      }
+      return { state: s, action: 'none' }; // action rows: ^/v is inert
+    }
+    case 'ok':
+      if (s.focus === FOCUS_SET) return { state: s, action: 'save' };
+      if (s.focus === FOCUS_CLEAR) return { state: s, action: 'clear' };
+      if (s.focus === FOCUS_BACK) return { state: s, action: 'back' };
+      if (s.focus === FOCUS_ERA) {
+        return { state: { ...s, matchEra: !s.matchEra }, action: 'none' };
+      }
+      return move(1); // date fields: OK steps toward SET
+    case 'back':
+      return { state: s, action: 'back' };
+  }
+}
+
+/**
+ * A typed digit into the focused date field (keyboard users). Fields fill
+ * left-to-right and auto-advance when full; out-of-range values clamp on
+ * commit, so "00" can never wedge a month.
+ */
+export function mediaDateScreenDigit(s: MediaDateScreenState, digit: string): MediaDateScreenState {
+  if (!/^[0-9]$/.test(digit)) return s;
+  if (s.focus !== FOCUS_YEAR && s.focus !== FOCUS_MONTH && s.focus !== FOCUS_DAY) return s;
+  const width = s.focus === FOCUS_YEAR ? 4 : 2;
+  const typed = (s.typed + digit).slice(0, width);
+  const value = parseInt(typed, 10);
+  let next: MediaDateScreenState = { ...s, typed };
+  if (typed.length < width) {
+    // Partial entry shows live where it can (a half-typed year of "19" reads
+    // as 19 — harmless, it clamps on commit or further digits).
+    if (s.focus === FOCUS_MONTH && value >= 1 && value <= 12) next.month = value;
+    if (s.focus === FOCUS_DAY && value >= 1) next.day = Math.min(value, daysInMonth(s.year, s.month));
+    if (s.focus === FOCUS_YEAR && typed.length === 4) next.year = value;
+    return next;
+  }
+  // Field full: commit with clamps, then advance focus.
+  if (s.focus === FOCUS_YEAR) next.year = Math.min(PIN_YEAR_MAX, Math.max(PIN_YEAR_MIN, value));
+  if (s.focus === FOCUS_MONTH) next.month = Math.min(12, Math.max(1, value));
+  if (s.focus === FOCUS_DAY) next.day = Math.max(1, Math.min(value, daysInMonth(next.year, next.month)));
+  next = clampDay(next);
+  next.focus = next.focus + 1;
+  next.typed = '';
+  return next;
+}
+
+const p2 = (n: number) => n.toString().padStart(2, '0');
+
+/**
+ * The CRT lines (each <= 40 chars — drawTerminal hard-clips there) plus the
+ * row the blinking cursor parks on. The focused element wears brackets.
+ */
+export function mediaDateScreenLines(
+  s: MediaDateScreenState,
+  pin: MediaReleasePin | null,
+  now: Date,
+): { lines: string[]; cursorLine: number } {
+  const wrap = (txt: string, focused: boolean) => (focused ? `[${txt}]` : ` ${txt} `);
+  const status = pin
+    ? `STATUS: PINNED — STORE DATE ${formatCutoffLabel(pin, now)}`
+    : 'STATUS: LIVE — CATALOG UNPINNED';
+  const dateRow =
+    `  DATE: ${wrap(String(s.year), s.focus === FOCUS_YEAR)}/${wrap(p2(s.month), s.focus === FOCUS_MONTH)}/${wrap(p2(s.day), s.focus === FOCUS_DAY)}`;
+  const eraRow = `  MATCH STORE ERA: ${wrap(s.matchEra ? 'YES' : 'NO', s.focus === FOCUS_ERA)}`;
+  const actionsRow =
+    ` ${wrap('SET PIN', s.focus === FOCUS_SET)}  ${wrap('CLEAR', s.focus === FOCUS_CLEAR)}  ${wrap('BACK', s.focus === FOCUS_BACK)}`;
+  // Exactly 10 rows: the counterterm CRT clips at ~10 body lines before the
+  // footer bar (verified on the mediadate shot), so no blank between the
+  // action row and the two advice lines.
+  const lines = [
+    'MEDIA RELEASE DATE — CATALOG PIN',
+    '',
+    status,
+    '',
+    dateRow,
+    eraRow,
+    '',
+    actionsRow,
+    'TITLES PAST THE STORE DATE VANISH.',
+    '</> FIELD  ^/v CHANGE  OK NEXT/USE',
+  ];
+  const cursorLine = s.focus <= FOCUS_DAY ? 4 : s.focus === FOCUS_ERA ? 5 : 7;
+  return { lines, cursorLine };
+}

--- a/src/media-release-date.ts
+++ b/src/media-release-date.ts
@@ -1,0 +1,314 @@
+// Issue #42 — Media Release Date: pin the store's catalog to a rolling point
+// in time, independent of store era.
+//
+// The pin is a content-time axis: everything that premiered after the rolling
+// cutoff is absent from the store entirely — not shelved, not searchable, not
+// suggested, doesn't play — same as if it hadn't been made yet. Store ERA
+// (bb_theme: decor/signage/fixtures) stays a separate axis; the optional
+// matchEra flag couples them one way (pin drives era) for people who want the
+// whole store to live in the pinned year.
+//
+// Same persistence shape as rental-clock.ts: the decision is computed ONCE at
+// the moment it's made ({ mediaReleaseDate, pinnedAt }) and every boot only
+// compares against it — the effective cutoff is mediaReleaseDate plus however
+// many whole local days have passed since pinnedAt, so the store's "today"
+// marches forward one real day per real day, permanently offset from actual
+// today. Never re-derived from a different base on reboot.
+//
+// This module is deliberately dependency-free (no three.js, no DOM beyond a
+// guarded localStorage) so the rules unit-test straight under `node --test`
+// (npm run test:releasedate).
+
+export const MEDIA_RELEASE_DATE_KEY = 'bb_media_release_date';
+
+export interface MediaReleasePin {
+  /** The pinned catalog date, as a local calendar date 'YYYY-MM-DD'. */
+  mediaReleaseDate: string;
+  /**
+   * ISO instant the pin was set (computed once, at the terminal). Absent on a
+   * hand-written bare-date pin (harness/tooling): the cutoff then simply IS
+   * mediaReleaseDate every boot — a static pin that never advances.
+   */
+  pinnedAt?: string;
+  /**
+   * When true, the store's ERA follows the pin: each boot re-derives the
+   * period theme from the effective cutoff (see eraThemeIdForDate), so the
+   * decor crosses 1993/2000/2010 the day the rolling date does. Off = the
+   * two axes stay fully decoupled (a bb-2010 store can carry 1996 stock).
+   */
+  matchEra?: boolean;
+}
+
+const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/** Sanity range for typed/persisted pin years — outside it, treat as corrupt. */
+export const PIN_YEAR_MIN = 1900;
+export const PIN_YEAR_MAX = 2100;
+
+/**
+ * Parse 'YYYY-MM-DD' into a LOCAL-midnight Date, or null if it isn't a real
+ * calendar date (1996-02-31 round-trips wrong through the Date constructor,
+ * which is the validation).
+ */
+export function parseDateOnly(s: string | undefined | null): Date | null {
+  if (!s) return null;
+  const m = DATE_ONLY.exec(s.trim());
+  if (!m) return null;
+  const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  if (y < PIN_YEAR_MIN || y > PIN_YEAR_MAX) return null;
+  const date = new Date(y, mo - 1, d);
+  if (date.getFullYear() !== y || date.getMonth() !== mo - 1 || date.getDate() !== d) return null;
+  return date;
+}
+
+/** Format a Date as the local calendar date 'YYYY-MM-DD'. */
+export function toDateOnly(d: Date): string {
+  const p = (n: number) => n.toString().padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+/**
+ * Parse + validate a raw `bb_media_release_date` string. Accepts the full
+ * record JSON the terminal writes, or a bare 'YYYY-MM-DD' (a static pin —
+ * handy for tooling and hand edits). Anything malformed returns null so a bad
+ * write can never wedge boot into an empty store.
+ */
+export function parseMediaReleasePin(raw: string | null | undefined): MediaReleasePin | null {
+  if (!raw) return null;
+  const s = raw.trim();
+  if (parseDateOnly(s)) return { mediaReleaseDate: s };
+  try {
+    const obj = JSON.parse(s) as Partial<MediaReleasePin> | string;
+    if (typeof obj === 'string') return parseDateOnly(obj) ? { mediaReleaseDate: obj } : null;
+    if (!obj || typeof obj !== 'object') return null;
+    if (!parseDateOnly(obj.mediaReleaseDate)) return null;
+    const pin: MediaReleasePin = { mediaReleaseDate: obj.mediaReleaseDate! };
+    if (typeof obj.pinnedAt === 'string' && Number.isFinite(Date.parse(obj.pinnedAt))) {
+      pin.pinnedAt = obj.pinnedAt;
+    }
+    if (obj.matchEra === true) pin.matchEra = true;
+    return pin;
+  } catch {
+    return null;
+  }
+}
+
+/** Whole local calendar days from `from`'s date to `to`'s date (clamped >= 0). */
+function calendarDaysBetween(from: Date, to: Date): number {
+  const a = new Date(from.getFullYear(), from.getMonth(), from.getDate());
+  const b = new Date(to.getFullYear(), to.getMonth(), to.getDate());
+  // Local-midnight difference; rounding absorbs the odd DST hour.
+  return Math.max(0, Math.round((b.getTime() - a.getTime()) / 86_400_000));
+}
+
+/**
+ * The effective cutoff for a boot happening at `now`: the pinned date advanced
+ * by the whole local days elapsed since pinnedAt, as an INCLUSIVE end-of-day
+ * instant (a title premiering ON the cutoff date exists). Calendar-component
+ * math, so DST transitions never shear the offset.
+ */
+export function effectiveCutoff(pin: MediaReleasePin, now: Date): Date {
+  const base = parseDateOnly(pin.mediaReleaseDate) ?? now;
+  const pinnedAt = pin.pinnedAt ? new Date(pin.pinnedAt) : null;
+  const days = pinnedAt && Number.isFinite(pinnedAt.getTime()) ? calendarDaysBetween(pinnedAt, now) : 0;
+  return new Date(base.getFullYear(), base.getMonth(), base.getDate() + days, 23, 59, 59, 999);
+}
+
+/**
+ * Whether a title had premiered by `cutoff`. Exact premiereDate wins; a title
+ * carrying only a year is treated as released on Jan 1 of that year (year <=
+ * cutoff year keeps it). A title with NO date data at all always stays — the
+ * pin must never vanish undated stock.
+ */
+export function titleReleasedBy(
+  title: { premiereDate?: string; year?: number },
+  cutoff: Date,
+): boolean {
+  if (title.premiereDate) {
+    const t = Date.parse(title.premiereDate);
+    if (Number.isFinite(t)) return t <= cutoff.getTime();
+  }
+  if (typeof title.year === 'number' && Number.isFinite(title.year) && title.year > 0) {
+    return title.year <= cutoff.getFullYear();
+  }
+  return true;
+}
+
+/** Filter a movie list to titles released by `cutoff` (fresh array, input untouched). */
+export function filterMoviesByCutoff<T extends { premiereDate?: string; year?: number }>(
+  movies: T[],
+  cutoff: Date,
+): T[] {
+  return movies.filter((m) => titleReleasedBy(m, cutoff));
+}
+
+/**
+ * Filter every library's movie list against `cutoff`. Returns COPIES ({...lib}
+ * with a fresh movies array) and drops libraries the cutoff empties entirely —
+ * a 1996 store must not build an aisle for its all-2020s library. The fetched
+ * input is never mutated, which is what makes clearing the pin a rebuild
+ * rather than a re-sync (same contract as games-only's storeCatalog).
+ */
+export function filterLibrariesByCutoff<L extends { movies: { premiereDate?: string; year?: number }[] }>(
+  libraries: L[],
+  cutoff: Date,
+): L[] {
+  return libraries
+    .map((lib) => ({ ...lib, movies: filterMoviesByCutoff(lib.movies, cutoff) }))
+    .filter((lib) => lib.movies.length > 0);
+}
+
+/**
+ * The era theme the pin implies: among year-suffixed theme ids ('bb-1993',
+ * 'bb-2010', ...), the latest whose year <= the cutoff's year — a store pinned
+ * to 1996 dresses as bb-1993 until its rolling date reaches 2000. A cutoff
+ * before the earliest era wears that earliest era. Ids without a -YYYY suffix
+ * (custom packs) are ignored; null when none qualify.
+ */
+export function eraThemeIdForDate(cutoff: Date, themeIds: string[]): string | null {
+  const year = cutoff.getFullYear();
+  let best: { id: string; year: number } | null = null;
+  let earliest: { id: string; year: number } | null = null;
+  for (const id of themeIds) {
+    const m = /-(\d{4})$/.exec(id);
+    if (!m) continue;
+    const y = Number(m[1]);
+    if (!earliest || y < earliest.year) earliest = { id, year: y };
+    if (y <= year && (!best || y > best.year)) best = { id, year: y };
+  }
+  return (best ?? earliest)?.id ?? null;
+}
+
+// ── Permanent Jellyseerr suggestion bounds (static, admin-set) ──────────────
+//
+// Independent of the rolling pin: a fixed release-date window on everything
+// Jellyseerr-suggested (discovery shelves, staff-pick seeds, collection-gap
+// cases). 'YYYY' or 'YYYY-MM-DD'; the bare year reads inclusively (from 1980 =
+// from 1980-01-01, until 1999 = until 1999-12-31). Composes with the rolling
+// pin — whichever upper bound is tighter wins — so a store can be pinned to
+// 1999 AND permanently refuse pre-1980 suggestions at the same time.
+
+export const SUGGEST_FROM_KEY = 'jellyseerr_suggest_from';
+export const SUGGEST_UNTIL_KEY = 'jellyseerr_suggest_until';
+
+/** Parse a bound value: 'YYYY' or 'YYYY-MM-DD'. `edge` resolves a bare year. */
+export function parseBound(raw: string | null | undefined, edge: 'start' | 'end'): Date | null {
+  if (!raw) return null;
+  const s = raw.trim();
+  if (/^\d{4}$/.test(s)) {
+    const y = Number(s);
+    if (y < PIN_YEAR_MIN || y > PIN_YEAR_MAX) return null;
+    return edge === 'start' ? new Date(y, 0, 1) : new Date(y, 11, 31, 23, 59, 59, 999);
+  }
+  const d = parseDateOnly(s);
+  if (!d) return null;
+  return edge === 'end' ? new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999) : d;
+}
+
+export interface SuggestionWindow {
+  /** Suggestions must have premiered ON/AFTER this instant (null = no floor). */
+  min: Date | null;
+  /** Suggestions must have premiered ON/BEFORE this instant (null = no ceiling). */
+  max: Date | null;
+}
+
+/**
+ * The window Jellyseerr-sourced suggestions must premiere inside: the static
+ * bounds, with the rolling pin's effective cutoff folded into the ceiling
+ * (tighter wins). Pass the values read from storage/settings so the pure math
+ * stays node-testable.
+ */
+export function suggestionWindow(
+  pin: MediaReleasePin | null,
+  from: string | null | undefined,
+  until: string | null | undefined,
+  now: Date,
+): SuggestionWindow {
+  const min = parseBound(from, 'start');
+  let max = parseBound(until, 'end');
+  if (pin) {
+    const cutoff = effectiveCutoff(pin, now);
+    if (!max || cutoff.getTime() < max.getTime()) max = cutoff;
+  }
+  return { min, max };
+}
+
+/** Whether a suggestion premieres inside the window (undated: only a floor rejects it). */
+export function titleInWindow(
+  title: { premiereDate?: string; year?: number },
+  win: SuggestionWindow,
+): boolean {
+  if (win.max && !titleReleasedBy(title, win.max)) return false;
+  if (win.min) {
+    if (title.premiereDate) {
+      const t = Date.parse(title.premiereDate);
+      if (Number.isFinite(t)) return t >= win.min.getTime();
+    }
+    if (typeof title.year === 'number' && Number.isFinite(title.year) && title.year > 0) {
+      // Year-only: the whole year must not sit entirely before the floor.
+      return title.year >= win.min.getFullYear();
+    }
+    // Undated suggestions can't prove they clear the floor — drop them
+    // (unlike owned stock, a suggestion is safe to lose).
+    return false;
+  }
+  return true;
+}
+
+/** The window's ceiling as 'YYYY-MM-DD' for a server-side lte param, or null. */
+export function windowLteParam(win: SuggestionWindow): string | null {
+  return win.max ? toDateOnly(win.max) : null;
+}
+
+/** The window's floor as 'YYYY-MM-DD' for a server-side gte param, or null. */
+export function windowGteParam(win: SuggestionWindow): string | null {
+  return win.min ? toDateOnly(win.min) : null;
+}
+
+/** Terminal/status label for a pin, e.g. "12-JUN-1996" (effective, not base). */
+export function formatCutoffLabel(pin: MediaReleasePin, now: Date): string {
+  const d = effectiveCutoff(pin, now);
+  const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+  return `${d.getDate().toString().padStart(2, '0')}-${months[d.getMonth()]}-${d.getFullYear()}`;
+}
+
+// ── localStorage plumbing (guarded so the pure math above stays node-testable) ──
+
+export function loadMediaReleasePin(): MediaReleasePin | null {
+  if (typeof localStorage === 'undefined') return null;
+  return parseMediaReleasePin(localStorage.getItem(MEDIA_RELEASE_DATE_KEY));
+}
+
+export function saveMediaReleasePin(pin: MediaReleasePin): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(MEDIA_RELEASE_DATE_KEY, JSON.stringify(pin));
+  } catch {
+    // Storage full/unavailable — the pin still applies this session.
+  }
+}
+
+export function clearMediaReleasePin(): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.removeItem(MEDIA_RELEASE_DATE_KEY);
+}
+
+/**
+ * The effective cutoff for THIS boot, or null when unpinned — the one-call
+ * form the funnel and scene code use.
+ */
+export function activeMediaCutoff(now: Date = new Date()): Date | null {
+  const pin = loadMediaReleasePin();
+  return pin ? effectiveCutoff(pin, now) : null;
+}
+
+/** The active suggestion window off storage (pin + permanent bounds). */
+export function activeSuggestionWindow(now: Date = new Date()): SuggestionWindow {
+  if (typeof localStorage === 'undefined') return { min: null, max: null };
+  return suggestionWindow(
+    loadMediaReleasePin(),
+    localStorage.getItem(SUGGEST_FROM_KEY),
+    localStorage.getItem(SUGGEST_UNTIL_KEY),
+    now,
+  );
+}

--- a/src/playback-flow.ts
+++ b/src/playback-flow.ts
@@ -1,0 +1,205 @@
+// Playback orchestration shared by (or exclusive to) the local-mpv path.
+//
+// Extracted from main.ts, which sits at its enforced line budget: the mpv
+// exit handler needed the same "did this end naturally, and if so what's
+// next" logic the in-app HTML5 player's onClose already had, and mpv itself
+// needed the local file handed off to it (playLocalWithMpv) to actually gain
+// resume, next-episode autoplay, and the Settings ▸ Playback language/caption
+// preferences the HTML5 path already honored. Moving playLocalWithMpv here
+// wholesale — rather than just adding params to it in place — is what pays
+// for those three features without growing main.ts at all.
+// Explicit .ts specifiers: tests/playback-flow.test.ts loads this module
+// under `node --test`'s type-stripping loader, which can't resolve a bare
+// sibling specifier (same note as jellyfin.ts's own media-release-date.ts import).
+import type { Movie, Episode } from './jellyfin.ts';
+import { reportPlaybackStart, reportPlaybackProgress, reportPlaybackStopped } from './jellyfin.ts';
+
+const TICKS_PER_SECOND = 10_000_000;
+
+/** The up-next queue launchVideoPlayback keeps for the series currently
+ *  playing (main.ts's module-level `seriesQueue`). */
+export interface SeriesQueue {
+  seriesId: string;
+  episodes: Episode[];
+}
+
+/** The episode after `currentItemId` in the active series queue, if any. */
+export function nextEpisodeInQueue(queue: SeriesQueue | null, movie: Movie, currentItemId: string): Episode | null {
+  if (!movie.isSeries || queue?.seriesId !== movie.id) return null;
+  const i = queue.episodes.findIndex((e) => e.id === currentItemId);
+  return i >= 0 ? (queue.episodes[i + 1] ?? null) : null;
+}
+
+/** "S02E05 · Title" for console/log lines. */
+export function episodeLabel(ep: Episode): string {
+  const num = `S${String(ep.seasonNumber).padStart(2, '0')}E${String(ep.episodeNumber).padStart(2, '0')}`;
+  return ep.name ? `${num} · ${ep.name}` : num;
+}
+
+/** Where to start, and how long the item runs, in Jellyfin ticks. An episode
+ *  played by override id looks itself up in the queue main.ts just built (it
+ *  carries the same per-user UserData fields the movie-level fetch does);
+ *  everything else falls back to the movie's own synced fields. Both are
+ *  simply absent (0) when unknown — the caller treats 0 duration as "can't
+ *  tell a natural end from a quit" and 0 resume as "start from 0:00", which
+ *  is exactly the safe default in each case. */
+export function resolveActiveItemTiming(
+  movie: Movie,
+  overrideItemId: string | undefined,
+  queue: SeriesQueue | null
+): { resumeTicks: number; durationTicks: number } {
+  const ep = overrideItemId ? queue?.episodes.find((e) => e.id === overrideItemId) : undefined;
+  if (ep) return { resumeTicks: ep.resumePositionTicks ?? 0, durationTicks: ep.runTimeTicks ?? 0 };
+  return {
+    resumeTicks: overrideItemId ? 0 : movie.resumePositionTicks ?? 0,
+    durationTicks: overrideItemId ? 0 : movie.runTimeTicks ?? 0,
+  };
+}
+
+/**
+ * Optimistic local watch-state update + up-next lookup, shared by both
+ * playback paths' exit handling (feedback/055's fix, now with a second
+ * caller): reportPlaybackStopped is fire-and-forget and nothing re-fetches
+ * the library afterwards, so without this the Movie object the store already
+ * holds a reference to never learns it was watched this session. Only a
+ * natural end counts as "watched" — backing out (or quitting mpv) early
+ * shouldn't bump play count, reorder PREVIOUSLY VIEWED, or roll into the next
+ * episode.
+ */
+export function markWatchedAndFindNext(
+  movie: Movie,
+  endedNaturally: boolean,
+  queue: SeriesQueue | null,
+  playbackId: string,
+  restock: () => void
+): Episode | null {
+  if (!endedNaturally) return null;
+  movie.played = true;
+  movie.playCount = (movie.playCount ?? 0) + 1;
+  movie.lastPlayedDate = new Date().toISOString();
+  restock();
+  return nextEpisodeInQueue(queue, movie, playbackId);
+}
+
+/**
+ * Settings ▸ Playback's audio-language and default-captions preferences,
+ * translated to mpv launch args. mpv opens the raw local file directly (no
+ * Jellyfin MediaStreams list to pick an index from, unlike the in-app HLS
+ * path's track picker), so a language preference goes straight through as an
+ * ffmpeg-style language code; "captions off" is the more precise --sid=no
+ * rather than an empty --slang, which would just leave mpv's own default
+ * subtitle selection in charge.
+ *
+ * settings.ts is imported lazily (rather than at module scope) so this file
+ * stays loadable by tests/playback-flow.test.ts under `node --test`'s
+ * type-stripping loader — settings.ts pulls in a much larger, DOM/scene-heavy
+ * import graph than the rest of this module needs.
+ */
+export interface MpvPrefArgs {
+  alang?: string;
+  slang?: string;
+  subsOff?: boolean;
+}
+
+export async function resolveMpvPrefArgs(): Promise<MpvPrefArgs> {
+  const { getSetting } = await import('./settings.ts');
+  const prefLang = String(getSetting<string>('bb_audio_lang') ?? '').trim().toLowerCase();
+  const wantSubtitles = getSetting<boolean>('bb_subtitles_default');
+  return {
+    alang: prefLang || undefined,
+    slang: wantSubtitles && prefLang ? prefLang : undefined,
+    subsOff: !wantSubtitles,
+  };
+}
+
+// How close the last known playhead has to land to the item's known runtime
+// to count as "played to the end" rather than "quit". mpv reports position on
+// a sub-second cadence (see vite.config.ts's BBPOS parsing) but the runtime
+// this compares against is Jellyfin's own scanned RunTimeTicks, which can be
+// a couple of seconds off a file's real last frame — wide enough to absorb
+// that, narrow enough that backing out shortly before the credits never
+// misreads as "finished".
+const NATURAL_FINISH_TOLERANCE_TICKS = 3 * TICKS_PER_SECOND;
+
+/** Natural end-of-file vs. a user quit for the mpv path, which — unlike the
+ *  in-app player's native 'ended' event — has no such signal of its own.
+ *  Duration unknown (0) always means "can't tell", never "finished". */
+export function isMpvNaturalFinish(positionTicks: number, durationTicks: number): boolean {
+  return durationTicks > 0 && durationTicks - positionTicks <= NATURAL_FINISH_TOLERANCE_TICKS;
+}
+
+/**
+ * Play a title by handing mpv the file on disk, bypassing Jellyfin's streaming
+ * path entirely. Only correct when the media, the server and this app are on
+ * one machine — but that's this deployment, and it buys three things the
+ * webview cannot do at all: genuine HDR output (Chromium has no HDR video
+ * path, so it flattens an HDR10 master to SDR no matter how cleanly the file
+ * reaches it), the original lossless multichannel audio instead of a stereo
+ * AAC downmix, and seeking that doesn't wait on a server.
+ *
+ * It also stops Jellyfin writing the film to disk as HLS segments while you
+ * watch — ~70 GB for a 4K remux — which it only ever did because the webview
+ * can't demux Matroska.
+ *
+ * Returns false when the local endpoint isn't reachable (production bundle,
+ * no dev/preview server) so the caller can fall back to in-app streaming.
+ */
+export async function playLocalWithMpv(
+  filePath: string,
+  itemId: string,
+  startPositionTicks: number,
+  durationTicks: number,
+  prefs: MpvPrefArgs,
+  onExit: (positionTicks: number, endedNaturally: boolean) => void,
+  log: (msg: string) => void
+): Promise<boolean> {
+  const jellyfinUrl = localStorage.getItem('jellyfin_url');
+  const token = localStorage.getItem('jellyfin_token');
+  const startSeconds = Math.max(0, Math.floor(startPositionTicks / TICKS_PER_SECOND));
+
+  let id: string;
+  try {
+    const res = await fetch('/__play', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: filePath, startSeconds, ...prefs }),
+    });
+    if (!res.ok) {
+      log(`[Video] Local player refused the file (${res.status}); streaming instead.`);
+      return false;
+    }
+    id = (await res.json()).id;
+  } catch {
+    // No endpoint (production bundle) — caller falls back to the in-app player.
+    return false;
+  }
+
+  log(`[Video] Playing off disk in mpv (from ${startSeconds}s).`);
+  if (jellyfinUrl && token) reportPlaybackStart(jellyfinUrl, token, itemId);
+
+  // Poll for position so Continue Watching still tracks, and so closing mpv
+  // returns to the store the same way the in-app player's Back does.
+  let lastTicks = startPositionTicks;
+  const poll = window.setInterval(async () => {
+    try {
+      const res = await fetch(`/__play?id=${encodeURIComponent(id)}`);
+      if (!res.ok) throw new Error(String(res.status));
+      const s = await res.json();
+      lastTicks = Math.round((s.position ?? 0) * TICKS_PER_SECOND);
+      if (!s.exited) {
+        if (jellyfinUrl && token) reportPlaybackProgress(jellyfinUrl, token, itemId, lastTicks, false);
+        return;
+      }
+      window.clearInterval(poll);
+      if (s.error) log(`[Video] mpv error: ${s.error}`);
+      if (jellyfinUrl && token) reportPlaybackStopped(jellyfinUrl, token, itemId, lastTicks);
+      onExit(lastTicks, isMpvNaturalFinish(lastTicks, durationTicks));
+    } catch {
+      // Endpoint vanished (server restarted) — stop polling rather than spin.
+      // Ambiguous exit: never autoplay on a guess.
+      window.clearInterval(poll);
+      onExit(lastTicks, false);
+    }
+  }, 5000);
+  return true;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -31,6 +31,7 @@ import {
 import { brandDropReport } from './brand-drop';
 import type { LogoShape, LogoSpec } from './logo-spec';
 import { drawLogo, getLogoFontString } from './logo-renderer';
+import { loadMediaReleasePin, saveMediaReleasePin } from './media-release-date';
 import type { StoreScene } from './three-scene';
 
 export type SettingKind = 'toggle' | 'cycle' | 'text' | 'secret';
@@ -55,8 +56,26 @@ export interface SettingDef<T = unknown> {
   applyMode: ApplyMode;
   /** For 'live' settings: apply the new value to the running scene in place. */
   apply?: (value: T, scene: StoreScene) => void;
-  /** One-line helper text shown under the row. */
-  hint?: string;
+  /**
+   * One-line helper text shown under the row. A function form is re-resolved
+   * every time the drawer (re)builds a row — for rows whose advice depends on
+   * live state (e.g. Store Theme while era-follow is driving it). Read it
+   * through resolveHint(), never directly.
+   */
+  hint?: string | (() => string);
+  /**
+   * Decorates the row's displayed value at render time (currentValueLabel) —
+   * e.g. Store Theme shows "… (AUTO)" while the Media Release Date pin is
+   * driving the era. Receives the plain label, returns what to show.
+   */
+  valueLabel?: (label: string) => string;
+  /**
+   * Runs after a drawer commit persists a new value (cycle/toggle rows).
+   * A returned string is logged to the boot console — the hook for side
+   * effects a change must announce (e.g. changing the theme detaches
+   * era-follow so the pick can actually stick).
+   */
+  onChange?: (value: unknown) => string | void;
   /**
    * Service/developer knob: registered so the registry documents the key and
    * live-apply still works, but never rendered on the couch-facing drawer
@@ -188,14 +207,20 @@ export function nextCycleValue(key: string): string {
 export function currentValueLabel(key: string): string {
   const def = registry.get(key);
   if (!def) return '';
-  if (def.kind === 'toggle') return getSetting<boolean>(key) ? 'On' : 'Off';
+  const decorate = (label: string) => (def.valueLabel ? def.valueLabel(label) : label);
+  if (def.kind === 'toggle') return decorate(getSetting<boolean>(key) ? 'On' : 'Off');
   if (def.kind === 'cycle') {
     const cur = String(getSetting(key));
-    return def.values?.find((v) => v.id === cur)?.label ?? cur;
+    return decorate(def.values?.find((v) => v.id === cur)?.label ?? cur);
   }
   const val = getSetting<string>(key);
-  if (def.kind === 'secret') return val ? '••••••••' : '(not set)';
-  return val || '(not set)';
+  if (def.kind === 'secret') return decorate(val ? '••••••••' : '(not set)');
+  return decorate(val || '(not set)');
+}
+
+/** A def's hint for THIS render — resolves the dynamic (function) form. */
+export function resolveHint(def: SettingDef): string | undefined {
+  return typeof def.hint === 'function' ? def.hint() : def.hint;
 }
 
 // ─── Option thumbnails (W3) ──────────────────────────────────────────────────
@@ -366,6 +391,13 @@ export function registerCoreSettings(): void {
   coreRegistered = true;
 
   // Store Look ---------------------------------------------------------------
+  // While the Media Release Date pin's MATCH STORE ERA is on (#42), this row
+  // is being DRIVEN: the scene-build funnel re-derives bb_theme from the pin
+  // every rebuild. Auto-brightness rules apply — the row wears "(AUTO)" and
+  // says who's driving BEFORE you touch it, and touching it takes control
+  // back (onChange detaches the follow) instead of losing a silent fight
+  // with the funnel one rebuild later.
+  const eraFollowOn = (): boolean => !!loadMediaReleasePin()?.matchEra;
   registerSetting({
     key: 'bb_theme',
     label: 'Store Theme',
@@ -374,7 +406,18 @@ export function registerCoreSettings(): void {
     values: Object.values(THEMES).map((t) => ({ id: t.id, label: t.name })),
     default: 'bb-1990',
     applyMode: 'rebuild-scene',
-    hint: 'Era + brand styling for the whole store.',
+    // Footer bar clips hints at 62 chars — the follow-mode line is written
+    // to fit whole, so the "detaches" half is never truncated away.
+    hint: () => eraFollowOn()
+      ? 'Following the Media Release Date pin. A change detaches it.'
+      : 'Era + brand styling for the whole store.',
+    valueLabel: (label) => (eraFollowOn() ? `${label} (AUTO)` : label),
+    onChange: () => {
+      const pin = loadMediaReleasePin();
+      if (!pin?.matchEra) return;
+      saveMediaReleasePin({ ...pin, matchEra: false });
+      return 'Store era detached from the Media Release Date pin — era follow is off.';
+    },
   });
 
   // Store Brand -------------------------------------------------------------
@@ -1788,7 +1831,8 @@ export function buildSettingsGroupPreview(container: HTMLElement, group: Setting
     row.type = 'button';
     row.className = 'settings-row';
     row.id = `setting-row-${def.key}`;
-    if (def.hint) row.dataset.hint = def.hint; // one-line footer-bar hint (CRT chrome)
+    const rowHint = resolveHint(def);
+    if (rowHint) row.dataset.hint = rowHint; // one-line footer-bar hint (CRT chrome)
     row.innerHTML = `
       <span class="settings-row-main">
         <span class="settings-row-label">${def.label}</span>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -883,6 +883,20 @@ export function registerCoreSettings(): void {
   cred('jellyseerr_url', 'Jellyseerr URL', 'text');
   cred('jellyseerr_apikey', 'Jellyseerr API Key', 'secret');
 
+  // Permanent release-date bounds on everything Jellyseerr SUGGESTS (discovery
+  // shelves, staff-pick seeds, un-ordered collection gaps) — a static window
+  // that does NOT move with the clock, unlike the terminal's rolling Media
+  // Release Date pin. The two compose: tighter bound wins (#42).
+  const seerrOn = (): boolean => !!getSetting<string>('jellyseerr_url');
+  cred('jellyseerr_suggest_from', 'Suggestions From', 'text', {
+    visibleWhen: seerrOn,
+    hint: 'YYYY or YYYY-MM-DD. Never suggest titles released earlier.',
+  });
+  cred('jellyseerr_suggest_until', 'Suggestions Until', 'text', {
+    visibleWhen: seerrOn,
+    hint: 'YYYY or YYYY-MM-DD. Never suggest titles released later. The Media Release Date pin still applies if tighter.',
+  });
+
   // Remote Play: stream this running store, peer-to-peer, to any browser on
   // the network (see src/remote-play.ts). Live toggle — starts/stops hosting
   // without a rebuild.

--- a/src/signage-catalog.ts
+++ b/src/signage-catalog.ts
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import { createSignTextTexture, createCategorySignTexture, createNewReleasesSignTexture } from './canvas-textures';
 import { bb93SignageOn } from './genre-colors';
-import { BB_ANTON } from './bundled-fonts';
 
 export type SignCategory =
   | 'bin-topper'        // above previously-viewed bins
@@ -11,7 +10,7 @@ export type SignCategory =
   | 'shelf'             // on gondola shelves / pricing strips
   | 'divider'           // on shelf dividers
   | 'ceiling-nav'       // hanging navigation (GENRE names, NEW RELEASES →, etc.)
-  | 'ceiling-promo';    // hanging price/promo cards (1993: "$3 RENTAL", "INCREDIBLE VALUES")
+  | 'ceiling-promo';    // hanging price/promo cards (1993: "INCREDIBLE VALUES")
 
 export interface SignDef {
   id: string;
@@ -19,42 +18,6 @@ export interface SignDef {
   fixture: 'acrylic-tent' | 'ceiling-hanging' | 'shelf-topper' | 'wall' | 'wire-frame';
   texture: () => THREE.Texture;   // canvas-texture factory
   size: { w: number; h: number }; // feet
-}
-
-// Footage-style promo card: big condensed ALL-CAPS lines filling the card
-// width (tight leading), optional small header line — the way the real
-// hanging cards read from across the store.
-function stackedCardTexture(bg: string, fg: string, lines: string[], header: string | null): THREE.Texture {
-  const canvas = document.createElement('canvas');
-  canvas.width = 640;
-  canvas.height = Math.round(640 * (header ? 1.35 : 0.68));
-  const ctx = canvas.getContext('2d')!;
-  ctx.fillStyle = bg;
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'middle';
-  ctx.fillStyle = fg;
-  let y = 40;
-  if (header) {
-    ctx.font = '700 44px "Arial Narrow", Arial, sans-serif';
-    ctx.fillText(header, canvas.width / 2, y + 20);
-    y += 78;
-  }
-  const lineH = (canvas.height - y - 30) / lines.length;
-  for (const line of lines) {
-    let size = Math.min(120, lineH * 0.82);
-    ctx.font = `800 ${size}px "Arial Narrow", ${BB_ANTON}, sans-serif`;
-    while (size > 30 && ctx.measureText(line).width > canvas.width - 60) {
-      size -= 4;
-      ctx.font = `800 ${size}px "Arial Narrow", ${BB_ANTON}, sans-serif`;
-    }
-    ctx.fillText(line, canvas.width / 2, y + lineH / 2);
-    y += lineH;
-  }
-  const tex = new THREE.CanvasTexture(canvas);
-  tex.colorSpace = THREE.SRGBColorSpace;
-  tex.anisotropy = 8;
-  return tex;
 }
 
 const STATIC_CATALOG: SignDef[] = [
@@ -100,17 +63,10 @@ const STATIC_CATALOG: SignDef[] = [
     texture: () => createSignTextTexture('Movie Theater Candy', '$1.99 each', 'promo', 0.9 / 0.7),
     size: { w: 0.9, h: 0.7 }
   },
-  // 1993 footage pack: the hanging promo card (stacked condensed lines
-  // filling the card, per the footage close-ups) and the closed-lane tent.
-  // (The yellow INCREDIBLE VALUES card over the bargain bin was retired by
-  // owner pin 031.)
-  {
-    id: 'three-dollar-rental',
-    category: 'ceiling-promo',
-    fixture: 'ceiling-hanging',
-    texture: () => stackedCardTexture('#7e2430', '#e8c46a', ['2-EVENING', 'NEW RELEASE', 'RENTAL  $3'], null),
-    size: { w: 2.0, h: 1.35 }
-  },
+  // 1993 footage pack: the closed-lane tent. (The yellow INCREDIBLE VALUES
+  // card over the bargain bin was retired by owner pin 031; the red
+  // "2-EVENING NEW RELEASE RENTAL $3" ceiling card over the back-wall floor
+  // displays was removed entirely by owner request — GH #2.)
   {
     id: 'next-register-please',
     category: 'register',

--- a/src/signage-config.ts
+++ b/src/signage-config.ts
@@ -21,12 +21,13 @@ export const DEFAULT_SIGNAGE_CONFIG: Record<string, string | null> = {
   // Set any `ceiling-nav-line-<lineId>` to `null` here to remove it, or to
   // a specific sign ID to override the dynamic genre name.
 
-  // 1993 footage pack: red "$3 RENTAL" card in front of the New Releases
-  // wall and the yellow "NEXT REGISTER PLEASE" tent on the closed stretch of
-  // the counter band. The bargain-bin INCREDIBLE VALUES card was removed at
-  // the owner's request (pin 031) — slot deliberately empty.
+  // 1993 footage pack: the yellow "NEXT REGISTER PLEASE" tent on the closed
+  // stretch of the counter band. The bargain-bin INCREDIBLE VALUES card was
+  // removed at the owner's request (pin 031) — slot deliberately empty. The
+  // red "$3 RENTAL" card that used to hang in front of the New Releases wall
+  // was removed entirely (GH #2) — its slot no longer exists at all, so
+  // there's no key for it here (see STATIC_SIGNAGE_SLOT_IDS below).
   'promo-previously-viewed': null,
-  'promo-new-release': 'three-dollar-rental',
   'register-next': 'next-register-please',
 };
 
@@ -52,7 +53,6 @@ export const STATIC_SIGNAGE_SLOT_IDS: readonly string[] = [
   'wall-newrelease-left-wall',
   // 1993 hanging promo cards (store-shell.ts)
   'promo-previously-viewed',
-  'promo-new-release',
 ];
 
 // Ceiling genre/library nav slots are DYNAMIC — one per shelving line, id

--- a/src/store-inspect.ts
+++ b/src/store-inspect.ts
@@ -601,11 +601,15 @@ export function ensureHeroCases(scene: StoreScene, movie: Movie, nrCase = false)
   // aspect, so the rental copy appeared to change size per title.
   const gameDims = movie.game ? gameCaseDims(movie.platform, movie.discCount) : undefined;
   const shellDims = movie.game ? gameRentalDims(movie.platform) : undefined;
+  // Same probe the shelf path resolves off the browsed library (store-stock's
+  // updateLOD) — the hero/inspect case sits closer to the camera than any
+  // shelf copy, so it should carry the same environment reflections, not none.
+  const probeIdx = Math.min(scene.selectedLibraryIdx, 4);
   if (!scene.heroFrontMesh || !scene.heroBackMesh) {
     const geoFront = getCaseGeometry(isAnimated, gameDims);
     const geoBack = getRentalCaseGeometry(false, shellDims);
-    const front = new THREE.Mesh(geoFront, createHeroJellyfinMaterials(movie));
-    const back = new THREE.Mesh(geoBack, createHeroRentalMaterials(movie));
+    const front = new THREE.Mesh(geoFront, createHeroJellyfinMaterials(movie, undefined, false, false, probeIdx));
+    const back = new THREE.Mesh(geoBack, createHeroRentalMaterials(movie, false, probeIdx));
     [front, back].forEach((m) => {
       m.castShadow = true;
       m.receiveShadow = true;
@@ -641,7 +645,7 @@ export function ensureHeroCases(scene: StoreScene, movie: Movie, nrCase = false)
     // RELEASE RENTAL case, matching the wall's instanced back boxes.
     scene.heroBackMesh.material = nrCase
       ? getGoldCaseMaterials()
-      : createHeroRentalMaterials(movie, wantDetail !== null);
+      : createHeroRentalMaterials(movie, wantDetail !== null, probeIdx);
     perfTrace.end(SP_HERO);
     if (movie.isSeries) scene.ensureSeriesEpisodes(movie);
     // Poster may still be streaming in — either never decoded yet, or its
@@ -663,18 +667,21 @@ export function ensureHeroCases(scene: StoreScene, movie: Movie, nrCase = false)
 }
 
 export function heroFrontMaterials(scene: StoreScene, movie: Movie): THREE.Material[] {
+  // Same probe index the shelf path resolves off the browsed library
+  // (store-stock's updateLOD) — see ensureHeroCases above.
+  const probeIdx = Math.min(scene.selectedLibraryIdx, 4);
   // The retail box's back carries the synopsis + cast list — the text the
   // shopper is actually reading — so an inspected case gets the high-resolution
   // face here too, not just via ensureHeroCases (this is the path flip and
   // cast-row navigation come back through).
-  if (movie.isSeries) return createHeroSeriesBoxsetMaterials(movie, scene.highlightedBackRegionName);
-  const mats = createHeroJellyfinMaterials(movie, scene.highlightedBackRegionName, false, scene.mode === 'inspect');
+  if (movie.isSeries) return createHeroSeriesBoxsetMaterials(movie, scene.highlightedBackRegionName, probeIdx);
+  const mats = createHeroJellyfinMaterials(movie, scene.highlightedBackRegionName, false, scene.mode === 'inspect', probeIdx);
   // A game's real back/spine scans arrive over the network. Fire and forget,
   // UNLIKE the asset viewer, which awaits: this runs on every browse keypress
   // and blocking the hero rebuild on a fetch would stall the cursor. The swap
   // mutates `mats` in place, so the mesh already holding the array picks it up
   // — it just needs a frame, and the loop is render-on-demand.
-  applyGameCaseArt(movie, mats).then((changed) => { if (changed) scene.requestRender(); });
+  applyGameCaseArt(movie, mats, probeIdx).then((changed) => { if (changed) scene.requestRender(); });
   return mats;
 }
 

--- a/src/store-shell.ts
+++ b/src/store-shell.ts
@@ -1551,6 +1551,21 @@ export function buildStore(scene: StoreScene) {
     // Poster plane matches the frame constants above (2:3 aspect ratio).
     const posterMesh = new THREE.Mesh(new THREE.PlaneGeometry(posterW, posterH), posterMat);
 
+    // GH #5: the material is DoubleSide (issue #61 wanted it opaque from
+    // both sides, since the poster hangs mid-pane with nothing to hide),
+    // but DoubleSide draws the SAME uv on both faces — it doesn't mirror
+    // one of them. A plane's default front face (the one that reads
+    // correctly) pointed local +Z, which every caller's parent transform
+    // (frontWindow's rotation.y=PI, each side ribbon's inward yaw) turns
+    // into a normal aimed INTO the store. So the correct print always
+    // faced the sales floor and the parking lot got the mirrored back.
+    // A real poster faces the street: flip the plane 180 here so the
+    // front face's normal points the other way (outside, for every
+    // caller of this shared factory) and let the inside keep the
+    // DoubleSide fallback — a mirrored read, same as the reference
+    // footage shoots any poster through glass from the wrong side.
+    posterMesh.rotation.y = Math.PI;
+
     // Center vertically in the GLAZED pane itself — knee wall top (2.0, the
     // window builders' KNEE_H) up to the glazing head. It used to center
     // between the waist rail and the head, which hung every poster high in

--- a/src/store-shell.ts
+++ b/src/store-shell.ts
@@ -2456,18 +2456,12 @@ export function buildStore(scene: StoreScene) {
       length: leftWallShelfWidth,
       localZ: 0.1
     }] : []),
-    // 1993 footage pack: red "$3 RENTAL / 2 EVENING NEW RELEASE" card hanging
-    // in front of the New Releases back wall, the way the real store hung its
-    // price promo right over the new-release bays.
-    {
-      id: 'promo-new-release',
-      category: 'ceiling-promo',
-      // Hang it lower in the 2000 store so it clears the TV-bank housing that
-      // now sits over the New Releases wall centre.
-      pos: new THREE.Vector3(STORE_CENTER_X, getActiveTheme().id === 'bb-2000' ? 7.4 : 8.9, backWallZ + 3.5),
-      yaw: 0
-    },
-    // ...and the yellow "INCREDIBLE VALUES / PREVIOUSLY VIEWED MOVIES" card
+    // (The red "$3 RENTAL / 2 EVENING NEW RELEASE" card that used to hang
+    // here, in front of the New Releases back wall over the floor displays,
+    // was removed entirely by owner request — GH #2. The slot construction
+    // and its catalog entry are gone too, not just nulled in signage-config.)
+    //
+    // The yellow "INCREDIBLE VALUES / PREVIOUSLY VIEWED MOVIES" card
     // over the bargain bin (our previously-viewed tub). The bin RESOLVES its
     // own position at build time (relativeToBackWall + clamp — see
     // bargain-bin.ts), so read the built fixture's footprint, not the raw

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -1216,7 +1216,15 @@ export class StoreScene {
       // Left wall has no stepped corner: its unit back-aligns to the back wall.
       const unitBackZ = this.nrLeftWallUnitBackZ();
       const unitSpace = (this.sideRibbon ? this.sideRibbon.backZ - SIDE_RIBBON_CLEARANCE : 15.0) - unitBackZ;
-      this.nrLeftWallCols = Math.max(0, Math.min(36, Math.floor((unitSpace - 1.0) / BOX_SPACING)));
+      // GH #6: this used to hard-cap at 36 columns regardless of how much wall
+      // was actually available, which left the run stopping visibly short of
+      // the window ribbon on any store wide enough to offer more (the
+      // baseline-width store's ~44 available columns only ever built 36,
+      // an 8-column/~4.6ft gap of bare wall between the last case and the
+      // glass). The whole point of this calc is described right above it as
+      // ADAPTIVE — sized to whatever the ribbon leaves behind it — so let it
+      // actually use the space it computed instead of throwing some away.
+      this.nrLeftWallCols = Math.max(0, Math.floor((unitSpace - 1.0) / BOX_SPACING));
       if (this.nrLeftWallCols < SECTION_COLS) this.nrLeftWallCols = 0; // below one section, drop the run
 
       this.nrTotalCols = this.nrLeftWallCols + this.nrBackWallCols;

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -55,6 +55,7 @@ import {
   StorefrontSpec,
   FixturePlacement,
 } from './store-layout';
+import { activeMediaCutoff } from './media-release-date';
 import { titleMatchKeys } from './staff-picks';
 import { OutdoorLightingRig, type OutsideMode } from './outdoor-lighting';
 import { CandyDisplay, CandyRow } from './fixtures/period-fixtures';
@@ -1233,9 +1234,21 @@ export class StoreScene {
       });
     });
     const allMovies = Array.from(allMoviesMap.values());
+    // Media Release Date pin (#42): under a pin, "new" means newest in the
+    // STORE'S timeline — the nearest premiere at or before the rolling cutoff
+    // (the catalog is already filtered to it) — not most recently added to
+    // the server, which would fill the wall with whatever synced last.
+    const nrCutoff = activeMediaCutoff();
+    const nrReleaseKey = (m: Movie): number => {
+      if (m.premiereDate) {
+        const t = Date.parse(m.premiereDate);
+        if (Number.isFinite(t)) return t;
+      }
+      return m.year > 0 ? new Date(m.year, 0, 1).getTime() : 0;
+    };
     const sortedByDate = [...allMovies].sort((a, b) => {
-      const dateA = a.dateCreated ? new Date(a.dateCreated).getTime() : 0;
-      const dateB = b.dateCreated ? new Date(b.dateCreated).getTime() : 0;
+      const dateA = nrCutoff ? nrReleaseKey(a) : (a.dateCreated ? new Date(a.dateCreated).getTime() : 0);
+      const dateB = nrCutoff ? nrReleaseKey(b) : (b.dateCreated ? new Date(b.dateCreated).getTime() : 0);
       if (dateA !== dateB) return dateB - dateA;
       return b.title.localeCompare(a.title);
     });

--- a/src/tip-jar.ts
+++ b/src/tip-jar.ts
@@ -10,9 +10,11 @@
 // which is the point: no vendored encoder, no dependency, no network.
 //
 // The store shows this to a living room, so the card is deliberately quiet: a
-// 5-inch counter card next to the register, no glow, no animation, nothing on
-// the marquee. It is also switchable off entirely (`bb_tip_jar`), because the
-// same build runs on a family TV where a donation ask is not wanted.
+// counter card next to the register (9 in wide as of GH #10, up from the
+// original 6 — it read too small to bother scanning), no glow, no animation,
+// nothing on the marquee. It is also switchable off entirely (`bb_tip_jar`),
+// because the same build runs on a family TV where a donation ask is not
+// wanted.
 import { getActiveLogoSpec, HALCYON_GOLD, HALCYON_CREAM, HALCYON_BLUE } from './logo-spec';
 import { getActiveTheme } from './themes';
 import { BB_ARCHIVO_BLACK, bundledFontReady, ensureBundledFont } from './bundled-fonts';

--- a/src/video-case.ts
+++ b/src/video-case.ts
@@ -4543,7 +4543,7 @@ export interface InstancedMovieGroup {
   movie: Movie;
 }
 
-export function createMovieInstancedMeshes(movie: Movie, count: number): InstancedMovieGroup {
+export function createMovieInstancedMeshes(movie: Movie, count: number, probeIdx?: number): InstancedMovieGroup {
   const boxGeo = getGeometry();
   initSharedMaterials();
 
@@ -4589,8 +4589,6 @@ export function createMovieInstancedMeshes(movie: Movie, count: number): Instanc
   let shelfDetailsLoaded = false;
   let fullDetailsLoaded = false;
   let lastLoadedPriority = 0;
-
-  const probeIdx = (movie as any).reflectionProbeIdx;
 
   const loadShelfDetails = (priority = 1) => {
     const isFirstLoad = !shelfDetailsLoaded;
@@ -5229,13 +5227,12 @@ function gameFaceMaterial(key: string, map: THREE.Texture, env: THREE.Texture | 
  * folds into side flaps, so a real one reads its title from either edge.
  * Cardboard cartons keep the single -X spine.
  */
-export async function applyGameCaseArt(movie: Movie, mats: THREE.Material[]): Promise<boolean> {
+export async function applyGameCaseArt(movie: Movie, mats: THREE.Material[], probeIdx?: number): Promise<boolean> {
   if (!movie.game || !movie.gameArt) return false;
   const [back, spine] = await Promise.all([
     loadGameFaceTexture(movie, 'back'),
     loadGameFaceTexture(movie, 'spine'),
   ]);
-  const probeIdx = (movie as any).reflectionProbeIdx;
   const env = (probeIdx !== undefined && reflectionProbes[probeIdx]) ? reflectionProbes[probeIdx] : null;
   let changed = false;
   if (back) {
@@ -5287,11 +5284,10 @@ export async function applyGameCaseArt(movie: Movie, mats: THREE.Material[]): Pr
   return changed;
 }
 
-export function createHeroJellyfinMaterials(movie: Movie, highlightedName?: string, pinEndcap: boolean = false, heroDetail: boolean = false): THREE.Material[] {
+export function createHeroJellyfinMaterials(movie: Movie, highlightedName?: string, pinEndcap: boolean = false, heroDetail: boolean = false, probeIdx?: number): THREE.Material[] {
   initSharedMaterials();
   const isAnimated = CASE_MEDIUM === 'vhs' && movie.libraryName === 'Animated Movies';
   const spineColor = leftmostColorCache.get(movie.id) || null;
-  const probeIdx = (movie as any).reflectionProbeIdx;
 
   const edgeMat = isAnimated ? sharedWhiteMaterial! : sharedBlackMaterial!;
   // Series season boxsets keep the loose shrink-wrap film (ROADMAP B3);
@@ -5316,10 +5312,9 @@ export function createHeroJellyfinMaterials(movie: Movie, highlightedName?: stri
 // front's title sticker).
 // `heroDetail`: see createHeroJellyfinMaterials above — true only for the case
 // being inspected, which is the one whose print anyone can actually read.
-export function createHeroRentalMaterials(movie: Movie, heroDetail: boolean = false): THREE.Material[] {
+export function createHeroRentalMaterials(movie: Movie, heroDetail: boolean = false, probeIdx?: number): THREE.Material[] {
   initSharedMaterials();
   const isAnimated = CASE_MEDIUM === 'vhs' && movie.libraryName === 'Animated Movies';
-  const probeIdx = (movie as any).reflectionProbeIdx;
 
   // GH #42: the hero rental copy is a clamshell — black molded edges on VHS
   // (including Animated Movies, which now match every other tape); white on DVD.
@@ -5861,10 +5856,10 @@ export function drawSeriesSeasonPanel(
  * front / metadata back / tinted spine edges, with the wide +X / -X side
  * panels swapped for the neutral brand canvas and the vertical season selector.
  */
-export function createHeroSeriesBoxsetMaterials(movie: Movie, _highlightedName?: string): THREE.Material[] {
+export function createHeroSeriesBoxsetMaterials(movie: Movie, _highlightedName?: string, probeIdx?: number): THREE.Material[] {
   // highlightedName only ever influenced base[5], which is discarded below —
   // don't pass it through, so no highlight canvas redraw happens per keypress.
-  const base = createHeroJellyfinMaterials(movie);
+  const base = createHeroJellyfinMaterials(movie, undefined, false, false, probeIdx);
   return [
     getSeriesPanel('episodes').mat,
     getSeriesPanel('play').mat,
@@ -5874,7 +5869,7 @@ export function createHeroSeriesBoxsetMaterials(movie: Movie, _highlightedName?:
     // Back face: the episode selector replaces the usual STARRING/CREDITS back.
     // Content is painted by drawSeriesEpisodeBackCover (driven from the scene,
     // which owns the fetched episode list); base[5] is discarded.
-    getSeriesBackPanel().mat,
+    getSeriesBackPanel(probeIdx).mat,
   ];
 }
 

--- a/tests/media-date-screen.test.ts
+++ b/tests/media-date-screen.test.ts
@@ -1,0 +1,114 @@
+// Issue #42 — unit tests for the MEDIA RELEASE DATE screen's pure reducer:
+// BIOS-style focus/value moves, digit typing, day clamping, action rows, and
+// the 40-column line contract drawTerminal enforces.
+//
+//   npm run test:releasedate   (runs alongside media-release-date.test.ts)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  FOCUS_BACK,
+  FOCUS_CLEAR,
+  FOCUS_DAY,
+  FOCUS_ERA,
+  FOCUS_MONTH,
+  FOCUS_SET,
+  FOCUS_YEAR,
+  initMediaDateScreen,
+  mediaDateScreenDigit,
+  mediaDateScreenKey,
+  mediaDateScreenLines,
+} from '../src/media-date-screen.ts';
+
+const now = new Date(2026, 7, 8, 12); // Sat 2026-08-08
+
+test('init: unpinned starts at today, focus on year, era-follow off', () => {
+  const s = initMediaDateScreen(null, now);
+  assert.equal(s.year, 2026);
+  assert.equal(s.month, 8);
+  assert.equal(s.day, 8);
+  assert.equal(s.matchEra, false);
+  assert.equal(s.focus, FOCUS_YEAR);
+});
+
+test('init: pinned starts at the EFFECTIVE date and keeps matchEra', () => {
+  const pin = { mediaReleaseDate: '1996-06-12', pinnedAt: new Date(2026, 7, 1).toISOString(), matchEra: true };
+  const s = initMediaDateScreen(pin, now); // 7 days after pinning
+  assert.equal(s.year, 1996);
+  assert.equal(s.month, 6);
+  assert.equal(s.day, 19);
+  assert.equal(s.matchEra, true);
+});
+
+test('left/right move focus and wrap', () => {
+  let s = initMediaDateScreen(null, now);
+  s = mediaDateScreenKey(s, 'left').state;
+  assert.equal(s.focus, FOCUS_BACK);
+  s = mediaDateScreenKey(s, 'right').state;
+  assert.equal(s.focus, FOCUS_YEAR);
+  s = mediaDateScreenKey(s, 'right').state;
+  assert.equal(s.focus, FOCUS_MONTH);
+});
+
+test('up/down change the focused field; month wraps; day clamps to month', () => {
+  let s = { ...initMediaDateScreen(null, now), year: 1996, month: 1, day: 31, focus: FOCUS_MONTH };
+  s = mediaDateScreenKey(s, 'up').state; // Jan -> Feb
+  assert.equal(s.month, 2);
+  assert.equal(s.day, 29); // 1996 is a leap year
+  s = { ...s, month: 12, day: 15 };
+  s = mediaDateScreenKey(s, 'up').state; // Dec wraps to Jan
+  assert.equal(s.month, 1);
+});
+
+test('up/down toggle MATCH STORE ERA', () => {
+  let s = { ...initMediaDateScreen(null, now), focus: FOCUS_ERA };
+  s = mediaDateScreenKey(s, 'down').state;
+  assert.equal(s.matchEra, true);
+  s = mediaDateScreenKey(s, 'up').state;
+  assert.equal(s.matchEra, false);
+});
+
+test('ok advances date fields, fires the focused action row', () => {
+  let s = initMediaDateScreen(null, now);
+  const r1 = mediaDateScreenKey(s, 'ok');
+  assert.equal(r1.action, 'none');
+  assert.equal(r1.state.focus, FOCUS_MONTH);
+  assert.equal(mediaDateScreenKey({ ...s, focus: FOCUS_SET }, 'ok').action, 'save');
+  assert.equal(mediaDateScreenKey({ ...s, focus: FOCUS_CLEAR }, 'ok').action, 'clear');
+  assert.equal(mediaDateScreenKey({ ...s, focus: FOCUS_BACK }, 'ok').action, 'back');
+  assert.equal(mediaDateScreenKey(s, 'back').action, 'back');
+});
+
+test('typed digits fill a field and auto-advance on the last one', () => {
+  let s = initMediaDateScreen(null, now);
+  for (const d of '1996') s = mediaDateScreenDigit(s, d);
+  assert.equal(s.year, 1996);
+  assert.equal(s.focus, FOCUS_MONTH);
+  for (const d of '06') s = mediaDateScreenDigit(s, d);
+  assert.equal(s.month, 6);
+  assert.equal(s.focus, FOCUS_DAY);
+  for (const d of '31') s = mediaDateScreenDigit(s, d);
+  assert.equal(s.day, 30); // June has 30 days — clamped on commit
+  assert.equal(s.focus, FOCUS_ERA);
+});
+
+test('typed out-of-range month clamps instead of wedging', () => {
+  let s = { ...initMediaDateScreen(null, now), focus: FOCUS_MONTH };
+  for (const d of '00') s = mediaDateScreenDigit(s, d);
+  assert.equal(s.month, 1);
+});
+
+test('lines: every row fits the CRT 40-column clip, brackets track focus', () => {
+  const pin = { mediaReleaseDate: '1996-06-12' };
+  for (let focus = FOCUS_YEAR; focus <= FOCUS_BACK; focus++) {
+    const s = { ...initMediaDateScreen(pin, now), focus };
+    const { lines, cursorLine } = mediaDateScreenLines(s, pin, now);
+    for (const line of lines) assert.ok(line.length <= 40, `"${line}" is ${line.length} chars`);
+    assert.ok(cursorLine >= 0 && cursorLine < lines.length);
+  }
+  const focused = mediaDateScreenLines({ ...initMediaDateScreen(pin, now), focus: FOCUS_SET }, pin, now);
+  assert.match(focused.lines[7], /\[SET PIN\]/);
+  assert.match(focused.lines[2], /12-JUN-1996/);
+  const live = mediaDateScreenLines(initMediaDateScreen(null, now), null, now);
+  assert.match(live.lines[2], /LIVE/);
+});

--- a/tests/media-release-date.test.ts
+++ b/tests/media-release-date.test.ts
@@ -1,0 +1,191 @@
+// Issue #42 — unit tests for the pure Media Release Date rules: pin parsing,
+// the rolling effective cutoff, title gating (premiereDate + year fallback),
+// library filtering, era derivation, and the permanent suggestion window.
+//
+//   npm run test:releasedate
+//
+// Runs under plain `node --test` with type stripping — no test framework.
+// Calendar math is LOCAL time throughout, same as the module.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseDateOnly,
+  toDateOnly,
+  parseMediaReleasePin,
+  effectiveCutoff,
+  titleReleasedBy,
+  filterMoviesByCutoff,
+  filterLibrariesByCutoff,
+  eraThemeIdForDate,
+  parseBound,
+  suggestionWindow,
+  titleInWindow,
+  windowLteParam,
+  windowGteParam,
+  formatCutoffLabel,
+} from '../src/media-release-date.ts';
+
+const at = (y: number, m: number, d: number, h = 12) => new Date(y, m - 1, d, h, 0, 0, 0);
+
+// ── parsing ─────────────────────────────────────────────────────────────────
+
+test('parseDateOnly: real dates parse local, impossible dates reject', () => {
+  assert.deepEqual(parseDateOnly('1996-06-12'), new Date(1996, 5, 12));
+  assert.equal(parseDateOnly('1996-02-31'), null); // not a real day
+  assert.equal(parseDateOnly('96-06-12'), null);
+  assert.equal(parseDateOnly('1996/06/12'), null);
+  assert.equal(parseDateOnly('2101-01-01'), null); // outside sanity range
+});
+
+test('parseMediaReleasePin: bare date, full record, corrupt input', () => {
+  assert.deepEqual(parseMediaReleasePin('1996-06-12'), { mediaReleaseDate: '1996-06-12' });
+  const rec = parseMediaReleasePin(JSON.stringify({
+    mediaReleaseDate: '1996-06-12', pinnedAt: '2026-08-08T10:00:00.000Z', matchEra: true,
+  }));
+  assert.deepEqual(rec, {
+    mediaReleaseDate: '1996-06-12', pinnedAt: '2026-08-08T10:00:00.000Z', matchEra: true,
+  });
+  assert.equal(parseMediaReleasePin('{"mediaReleaseDate":"nope"}'), null);
+  assert.equal(parseMediaReleasePin('{broken'), null);
+  assert.equal(parseMediaReleasePin(''), null);
+  assert.equal(parseMediaReleasePin(null), null);
+  // A bad pinnedAt degrades to a static pin rather than rejecting the record.
+  assert.deepEqual(
+    parseMediaReleasePin('{"mediaReleaseDate":"1996-06-12","pinnedAt":"garbage"}'),
+    { mediaReleaseDate: '1996-06-12' },
+  );
+});
+
+// ── rolling cutoff ──────────────────────────────────────────────────────────
+
+test('effectiveCutoff: static pin (no pinnedAt) is end of the pinned day', () => {
+  const c = effectiveCutoff({ mediaReleaseDate: '1996-06-12' }, at(2026, 8, 8));
+  assert.equal(toDateOnly(c), '1996-06-12');
+  assert.equal(c.getHours(), 23);
+});
+
+test('effectiveCutoff: advances one day per elapsed local day', () => {
+  const pin = { mediaReleaseDate: '1996-06-12', pinnedAt: at(2026, 8, 1, 15).toISOString() };
+  assert.equal(toDateOnly(effectiveCutoff(pin, at(2026, 8, 1, 16))), '1996-06-12'); // same day
+  assert.equal(toDateOnly(effectiveCutoff(pin, at(2026, 8, 2, 9))), '1996-06-13');  // next morning
+  assert.equal(toDateOnly(effectiveCutoff(pin, at(2026, 8, 31))), '1996-07-12');    // 30 days on
+});
+
+test('effectiveCutoff: clock set backwards never rolls the pin back', () => {
+  const pin = { mediaReleaseDate: '1996-06-12', pinnedAt: at(2026, 8, 8).toISOString() };
+  assert.equal(toDateOnly(effectiveCutoff(pin, at(2026, 8, 1))), '1996-06-12');
+});
+
+test('effectiveCutoff: rolls across month and year ends', () => {
+  const pin = { mediaReleaseDate: '1999-12-30', pinnedAt: at(2026, 8, 1).toISOString() };
+  assert.equal(toDateOnly(effectiveCutoff(pin, at(2026, 8, 3))), '2000-01-01');
+});
+
+// ── title gating ────────────────────────────────────────────────────────────
+
+const cutoff96 = effectiveCutoff({ mediaReleaseDate: '1996-06-12' }, at(2026, 8, 8));
+
+test('titleReleasedBy: exact premiere dates gate to the day', () => {
+  assert.equal(titleReleasedBy({ premiereDate: '1996-06-12T00:00:00Z' }, cutoff96), true);
+  assert.equal(titleReleasedBy({ premiereDate: '1996-06-20T00:00:00Z' }, cutoff96), false);
+  assert.equal(titleReleasedBy({ premiereDate: '1980-01-01T00:00:00Z' }, cutoff96), true);
+});
+
+test('titleReleasedBy: year-only falls back to year <= cutoff year', () => {
+  assert.equal(titleReleasedBy({ year: 1996 }, cutoff96), true); // same year, month unknown → keep
+  assert.equal(titleReleasedBy({ year: 1997 }, cutoff96), false);
+  assert.equal(titleReleasedBy({ year: 0 }, cutoff96), true); // no real data → keep
+});
+
+test('titleReleasedBy: unparseable premiere falls through to year, then keeps', () => {
+  assert.equal(titleReleasedBy({ premiereDate: 'not-a-date', year: 2005 }, cutoff96), false);
+  assert.equal(titleReleasedBy({ premiereDate: 'not-a-date' }, cutoff96), true);
+  assert.equal(titleReleasedBy({}, cutoff96), true);
+});
+
+test('filterLibrariesByCutoff: copies, filters, drops emptied libraries', () => {
+  const libs = [
+    { name: 'Mixed', movies: [{ year: 1990 }, { year: 2005 }] },
+    { name: 'Modern', movies: [{ premiereDate: '2020-01-01T00:00:00Z', year: 2020 }] },
+  ];
+  const out = filterLibrariesByCutoff(libs, cutoff96);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].name, 'Mixed');
+  assert.equal(out[0].movies.length, 1);
+  // Inputs untouched — clearing the pin must be a rebuild, not a re-sync.
+  assert.equal(libs[0].movies.length, 2);
+  assert.equal(libs[1].movies.length, 1);
+  assert.notEqual(out[0], libs[0]);
+});
+
+test('filterMoviesByCutoff returns a fresh array', () => {
+  const input = [{ year: 1990 }];
+  const out = filterMoviesByCutoff(input, cutoff96);
+  assert.notEqual(out, input);
+  assert.deepEqual(out, input);
+});
+
+// ── era derivation ──────────────────────────────────────────────────────────
+
+const ERAS = ['bb-1990', 'bb-1993', 'bb-2000', 'bb-2010'];
+
+test('eraThemeIdForDate: latest era at or before the cutoff year', () => {
+  assert.equal(eraThemeIdForDate(at(1996, 6, 12), ERAS), 'bb-1993');
+  assert.equal(eraThemeIdForDate(at(1991, 1, 1), ERAS), 'bb-1990');
+  assert.equal(eraThemeIdForDate(at(2000, 1, 1), ERAS), 'bb-2000');
+  assert.equal(eraThemeIdForDate(at(2026, 8, 8), ERAS), 'bb-2010');
+});
+
+test('eraThemeIdForDate: before the earliest era wears the earliest', () => {
+  assert.equal(eraThemeIdForDate(at(1985, 7, 1), ERAS), 'bb-1990');
+});
+
+test('eraThemeIdForDate: unsuffixed ids are ignored; none suffixed → null', () => {
+  assert.equal(eraThemeIdForDate(at(1996, 6, 12), ['custom-pack', ...ERAS]), 'bb-1993');
+  assert.equal(eraThemeIdForDate(at(1996, 6, 12), ['custom-pack']), null);
+});
+
+// ── permanent suggestion window ─────────────────────────────────────────────
+
+test('parseBound: bare years read inclusively at each edge', () => {
+  assert.deepEqual(parseBound('1980', 'start'), new Date(1980, 0, 1));
+  assert.equal(toDateOnly(parseBound('1999', 'end')!), '1999-12-31');
+  assert.deepEqual(parseBound('1980-06-15', 'start'), new Date(1980, 5, 15));
+  assert.equal(parseBound('80', 'start'), null);
+  assert.equal(parseBound('', 'start'), null);
+});
+
+test('suggestionWindow: rolling pin folds into the ceiling, tighter wins', () => {
+  const pin = { mediaReleaseDate: '1996-06-12' };
+  const now = at(2026, 8, 8);
+  // Pin tighter than the static bound.
+  let win = suggestionWindow(pin, '1980', '2010', now);
+  assert.equal(windowLteParam(win), '1996-06-12');
+  assert.equal(windowGteParam(win), '1980-01-01');
+  // Static bound tighter than the pin.
+  win = suggestionWindow(pin, null, '1990', now);
+  assert.equal(windowLteParam(win), '1990-12-31');
+  // No pin, no bounds — wide open.
+  win = suggestionWindow(null, null, null, now);
+  assert.equal(win.min, null);
+  assert.equal(win.max, null);
+  assert.equal(windowLteParam(win), null);
+});
+
+test('titleInWindow: ceiling and floor both gate; undated fails a floor only', () => {
+  const win = suggestionWindow(null, '1980', '1999', at(2026, 8, 8));
+  assert.equal(titleInWindow({ premiereDate: '1985-03-01T00:00:00Z' }, win), true);
+  assert.equal(titleInWindow({ premiereDate: '1979-12-31T00:00:00Z' }, win), false);
+  assert.equal(titleInWindow({ premiereDate: '2005-01-01T00:00:00Z' }, win), false);
+  assert.equal(titleInWindow({ year: 1980 }, win), true); // year floor is inclusive
+  assert.equal(titleInWindow({ year: 1979 }, win), false);
+  assert.equal(titleInWindow({}, win), false); // undated can't prove it clears the floor
+  const noFloor = suggestionWindow(null, null, '1999', at(2026, 8, 8));
+  assert.equal(titleInWindow({}, noFloor), true); // no floor → undated passes
+});
+
+test('formatCutoffLabel renders the EFFECTIVE date', () => {
+  const pin = { mediaReleaseDate: '1996-06-12', pinnedAt: at(2026, 8, 1).toISOString() };
+  assert.equal(formatCutoffLabel(pin, at(2026, 8, 3)), '14-JUN-1996');
+});

--- a/tests/playback-flow.test.ts
+++ b/tests/playback-flow.test.ts
@@ -1,0 +1,132 @@
+// Playback-exit/queue logic shared by both playback paths (in-app HTML5 and
+// local mpv) — the mpv path can't be exercised end to end without a live
+// Jellyfin server + mpv session, so these pure functions are what stand in
+// for that coverage.
+//
+//   npm run test:playbackflow (or: node --experimental-strip-types --test tests/playback-flow.test.ts)
+//
+// Runs under plain `node --test` with type stripping — no test framework.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Movie, Episode } from '../src/jellyfin.ts';
+import {
+  nextEpisodeInQueue,
+  episodeLabel,
+  resolveActiveItemTiming,
+  markWatchedAndFindNext,
+  isMpvNaturalFinish,
+  type SeriesQueue,
+} from '../src/playback-flow.ts';
+
+function mkMovie(extra: Partial<Movie> = {}): Movie {
+  return {
+    id: 'series-1',
+    title: 'Twin Peaks',
+    year: 1990,
+    duration: 'Series',
+    rating: 'TV-14',
+    overview: '',
+    director: '',
+    actors: [],
+    genres: [],
+    localPath: '',
+    isSeries: true,
+    ...extra,
+  };
+}
+
+function mkEpisode(id: string, season: number, ep: number, extra: Partial<Episode> = {}): Episode {
+  return {
+    id,
+    seriesId: 'series-1',
+    seriesName: 'Twin Peaks',
+    seasonNumber: season,
+    episodeNumber: ep,
+    name: `Episode ${ep}`,
+    overview: '',
+    path: `/tv/${id}.mkv`,
+    ...extra,
+  };
+}
+
+test('nextEpisodeInQueue: walks the queue and crosses season boundaries', () => {
+  const queue: SeriesQueue = {
+    seriesId: 'series-1',
+    episodes: [mkEpisode('e1', 1, 1), mkEpisode('e2', 1, 2), mkEpisode('e3', 2, 1)],
+  };
+  const movie = mkMovie();
+  assert.equal(nextEpisodeInQueue(queue, movie, 'e1')?.id, 'e2');
+  assert.equal(nextEpisodeInQueue(queue, movie, 'e2')?.id, 'e3'); // crosses into season 2
+  assert.equal(nextEpisodeInQueue(queue, movie, 'e3'), null); // series finale: nothing next
+});
+
+test('nextEpisodeInQueue: a non-series movie or a stale/mismatched queue never advances', () => {
+  const queue: SeriesQueue = { seriesId: 'series-1', episodes: [mkEpisode('e1', 1, 1), mkEpisode('e2', 1, 2)] };
+  assert.equal(nextEpisodeInQueue(queue, mkMovie({ isSeries: false }), 'e1'), null);
+  assert.equal(nextEpisodeInQueue(queue, mkMovie({ id: 'other-series' }), 'e1'), null);
+  assert.equal(nextEpisodeInQueue(null, mkMovie(), 'e1'), null);
+});
+
+test('episodeLabel: zero-pads and includes the title when present', () => {
+  assert.equal(episodeLabel(mkEpisode('e1', 2, 5, { name: 'The Return' })), 'S02E05 · The Return');
+  assert.equal(episodeLabel(mkEpisode('e1', 1, 1, { name: '' })), 'S01E01');
+});
+
+test('resolveActiveItemTiming: movie-level fields when playing the item itself', () => {
+  const movie = mkMovie({ isSeries: false, resumePositionTicks: 12_000_000, runTimeTicks: 72_000_000_000 });
+  const timing = resolveActiveItemTiming(movie, undefined, null);
+  assert.equal(timing.resumeTicks, 12_000_000);
+  assert.equal(timing.durationTicks, 72_000_000_000);
+});
+
+test('resolveActiveItemTiming: an overridden episode looks itself up in the queue, never the movie', () => {
+  const movie = mkMovie({ resumePositionTicks: 999, runTimeTicks: 999 }); // must NOT leak into the episode case
+  const queue: SeriesQueue = {
+    seriesId: 'series-1',
+    episodes: [mkEpisode('e1', 1, 1, { resumePositionTicks: 30_000_000, runTimeTicks: 260_000_000_000 })],
+  };
+  const timing = resolveActiveItemTiming(movie, 'e1', queue);
+  assert.equal(timing.resumeTicks, 30_000_000);
+  assert.equal(timing.durationTicks, 260_000_000_000);
+});
+
+test('resolveActiveItemTiming: unknown episode/absent fields resolve to 0, never undefined', () => {
+  const movie = mkMovie();
+  assert.deepEqual(resolveActiveItemTiming(movie, 'missing-ep', null), { resumeTicks: 0, durationTicks: 0 });
+  assert.deepEqual(resolveActiveItemTiming(mkMovie({ isSeries: false }), undefined, null), { resumeTicks: 0, durationTicks: 0 });
+});
+
+test('markWatchedAndFindNext: a quit never bumps watch state or advances', () => {
+  const movie = mkMovie({ isSeries: false, played: undefined, playCount: undefined });
+  let restocked = false;
+  const next = markWatchedAndFindNext(movie, false, null, 'series-1', () => { restocked = true; });
+  assert.equal(next, null);
+  assert.equal(movie.played, undefined);
+  assert.equal(movie.playCount, undefined);
+  assert.equal(restocked, false);
+});
+
+test('markWatchedAndFindNext: a natural end marks watched, restocks, and returns the next episode', () => {
+  const movie = mkMovie({ playCount: 2 });
+  const queue: SeriesQueue = { seriesId: 'series-1', episodes: [mkEpisode('e1', 1, 1), mkEpisode('e2', 1, 2)] };
+  let restocked = false;
+  const next = markWatchedAndFindNext(movie, true, queue, 'e1', () => { restocked = true; });
+  assert.equal(next?.id, 'e2');
+  assert.equal(movie.played, true);
+  assert.equal(movie.playCount, 3);
+  assert.equal(restocked, true);
+});
+
+test('isMpvNaturalFinish: unknown duration is always ambiguous, never a finish', () => {
+  assert.equal(isMpvNaturalFinish(0, 0), false);
+  assert.equal(isMpvNaturalFinish(7200, 0), false);
+});
+
+test('isMpvNaturalFinish: within tolerance of the known runtime counts as finished', () => {
+  const TICKS_PER_SECOND = 10_000_000;
+  const duration = 7200 * TICKS_PER_SECOND;
+  assert.equal(isMpvNaturalFinish(duration, duration), true); // exact
+  assert.equal(isMpvNaturalFinish(duration - 2 * TICKS_PER_SECOND, duration), true); // within tolerance
+  assert.equal(isMpvNaturalFinish(duration - 30 * TICKS_PER_SECOND, duration), false); // an early quit
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -179,7 +179,7 @@ function mpvPlayerPlugin() {
     "",
   ].join("\n"));
 
-  function launch(file: string, startSeconds: number): string {
+  function launch(file: string, startSeconds: number, prefs?: { alang?: string; slang?: string; subsOff?: boolean }): string {
     const id = String(nextId++);
     const session = { position: startSeconds, exited: false } as {
       position: number; exited: boolean; error?: string;
@@ -214,9 +214,17 @@ function mpvPlayerPlugin() {
       // leave-the-room behavior as the in-app player's MPRIS pause).
       "--input-ipc-server=/tmp/halcyon-mpv.sock",
       `--start=${Math.max(0, Math.floor(startSeconds))}`,
-      "--",
-      file,
     ];
+    // Settings ▸ Playback preferences (bb_audio_lang / bb_subtitles_default),
+    // translated by playback-flow.ts's resolveMpvPrefArgs — mpv has no
+    // Jellyfin-style track-index picker for a raw local file, so these go
+    // straight through as ffmpeg-style language codes; "captions off" is the
+    // precise --sid=no rather than an empty --slang, which would just leave
+    // mpv's own default subtitle selection in charge.
+    if (prefs?.alang) args.push(`--alang=${prefs.alang}`);
+    if (prefs?.slang) args.push(`--slang=${prefs.slang}`);
+    if (prefs?.subsOff) args.push("--sid=no");
+    args.push("--", file);
 
     const child = spawn("mpv", args, { stdio: ["ignore", "pipe", "pipe"] });
 
@@ -273,7 +281,12 @@ function mpvPlayerPlugin() {
         if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
           return json(404, { error: "no such file" });
         }
-        return json(200, { id: launch(file, Number(body.startSeconds) || 0) });
+        const prefs = {
+          alang: typeof body.alang === "string" ? body.alang.slice(0, 32) : undefined,
+          slang: typeof body.slang === "string" ? body.slang.slice(0, 32) : undefined,
+          subsOff: body.subsOff === true,
+        };
+        return json(200, { id: launch(file, Number(body.startSeconds) || 0, prefs) });
       } catch (err) {
         return json(400, { error: String(err) });
       }


### PR DESCRIPTION
10 commits, 9 issues closed on merge (#42 via merge commit; #40 #10 #2 #3 #5 #6 via commit keywords).

## Playback
- Resume from saved position on both player paths (mpv `--start`, HTML5 `startPositionTicks`)
- mpv path: next-episode autoplay on natural finish (3s runtime tolerance; ambiguous exit never autoplays)
- mpv now honors Settings ▸ Playback audio-language / captions prefs (`--alang` / `--slang` / `--sid=no`)

## Catalog
- Media release date: pin the store's catalog to a rolling point in time, independent of store era (#42)

## Store fixes
- Hero/inspected case gets reflection-probe environment again (dead `reflectionProbeIdx` reads → threaded parameter) (#40)
- Tip QR plaque 1.5x — now actually decodes from a screenshot; old size did not (#10)
- New Releases window-side run fills to the window ribbon (dropped a stale 36-column cap) (#6)
- Window posters read correctly from the street (#5)
- Removed red rental-term cards over the entrance doors and the back-wall ceiling card (#2, #3)

## Verified
- `npm run build` green on every commit (tsc + line budgets); full test suite 162/162 at wave-1; `test:nav` 7/7 + clerkpath audit after the wall extension
- Before/after screenshots on every visual change; QR decode confirmed via OpenCV

## Not verified
- Live-Jellyfin mpv behaviors (real resume pickup, episode chaining, track-pref args) — needs a couch test
- Known pre-existing moderate Dependabot alert (glib) — untouched by this release