### PR TITLE
v0.2.1: ship the Docker image (amd64-only until native arm64 runners)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -4,8 +4,12 @@
 #   docker run -d --name halcyon --network host --restart unless-stopped \
 #     ghcr.io/halcyon-video/halcyon-video
 #
-# Runs on release tags (vX.Y.Z) and by hand (workflow_dispatch). Multi-arch:
-# amd64 + arm64 (NAS / Pi / Apple-silicon hosts).
+# Runs on release tags (vX.Y.Z) and by hand (workflow_dispatch). amd64 only
+# for now: the arm64 half of the v0.2.0 publish died in `npm ci` with a V8
+# "Illegal instruction" under QEMU user emulation (the classic node-on-alpine
+# qemu failure), and emulating around it is a losing game — arm64 comes back
+# as a separate job on GitHub's native ubuntu-24.04-arm runners with a
+# manifest merge, tracked as a follow-up.
 #
 # NOTE: the very first published package is PRIVATE by default — flip it to
 # public once under the org's Packages → halcyon-video → settings, or pulls
@@ -27,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-qemu-action@v3
+      # No setup-qemu: it existed only to emulate the arm64 build (see header).
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -49,7 +53,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "halcyon-video",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "halcyon-video",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "halcyon-video",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch release — identical app to v0.2.0.

- v0.2.0's tag was `publish-image.yml`'s first real firing; the arm64 half died in `npm ci` with a V8 "Illegal instruction" under QEMU emulation, sinking the whole manifest push — no image was published while the README quick start already advertises `docker run ghcr.io/halcyon-video/halcyon-video`
- Fix: publish `linux/amd64` only (drop `setup-qemu`); arm64 returns as a separate job on native `ubuntu-24.04-arm` runners with a manifest merge (tracked follow-up)

## Not verified
- The publish itself — it fires on the v0.2.1 tag after this merge; will confirm the run and that the package appears