### PR TITLE
Release v0.3.0: one navigation layer, opening-day first run, counter fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "halcyon-video",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "halcyon-video",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:comingsoon": "node --experimental-strip-types --test tests/coming-soon-feed.test.ts",
     "test:releasedate": "node --experimental-strip-types --test tests/media-release-date.test.ts tests/media-date-screen.test.ts",
     "test:playbackflow": "node --experimental-strip-types --test tests/playback-flow.test.ts",
+    "test:setup": "node --experimental-strip-types --test tests/store-setup-screens.test.ts",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "halcyon-video",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/ambient-tvs.ts
+++ b/src/ambient-tvs.ts
@@ -18,6 +18,7 @@ import { loadProp } from './props';
 import { getActiveTheme } from './themes';
 import { makeCurvedScreenGeometry, makeTubeOverlayMaterial, makeCrtTestCardTexture } from './crt-tube';
 import { makeCrtGlassMaterial } from './glass-reflection';
+import { tvPoolLibraryIds } from './library-settings';
 import { TV_PATCH_LAYER } from './scene-shared';
 
 // Front bezel: a flat rounded-rect frame with a rectangular aperture, extruded
@@ -129,11 +130,35 @@ export class AmbientTvs implements StoreFixture {
   constructor(private ctx: FixtureContext) {}
 
   build(): void {
-    const FAMILY_GENRES = new Set(['Family']);
+    // What the overhead sets may play (#39): libraries the user explicitly
+    // selected (Settings → Playback → Overhead TVs, bb_tvlib_* toggles via
+    // library-settings.ts) — or, with nothing selected, the original
+    // family-genre heuristic over the whole catalog, so existing stores keep
+    // their behavior. A selection that matches no loaded library (say, the
+    // store stopped carrying it) falls back the same way rather than going
+    // dark. Same gate for live streaming and the test-card stand-in below.
+    const chosen = tvPoolLibraryIds();
     const allMovies: Movie[] = [];
-    this.ctx.libraries.forEach(lib => lib.movies.forEach(m => { if (!m.isSeries) allMovies.push(m); }));
-    let pool = allMovies.filter(m => m.genres.some(g => FAMILY_GENRES.has(g)));
-    if (pool.length === 0) pool = allMovies;
+    const chosenMovies: Movie[] = [];
+    this.ctx.libraries.forEach(lib => lib.movies.forEach(m => {
+      if (m.isSeries) return;
+      allMovies.push(m);
+      if (chosen.has(lib.id)) chosenMovies.push(m);
+    }));
+    let pool: Movie[];
+    if (chosenMovies.length > 0) {
+      pool = chosenMovies;
+      this.ctx.log(`[System] CRT TVs: drawing from ${chosen.size} selected library(ies).`, 'system');
+    } else {
+      const FAMILY_GENRES = new Set(['Family']);
+      pool = allMovies.filter(m => m.genres.some(g => FAMILY_GENRES.has(g)));
+      if (pool.length === 0) pool = allMovies;
+    }
+    (window as any).__tvPool = {
+      selected: chosen.size,
+      size: pool.length,
+      libs: [...new Set(pool.map(m => m.libraryName))].sort(),
+    };
 
     // The TVs are store furniture — they hang from the ceiling regardless of
     // whether a stream is available; without a server they just show dead glass.

--- a/src/boot-flow.ts
+++ b/src/boot-flow.ts
@@ -1,0 +1,552 @@
+// The boot / credentials flow — every path from "the app just loaded" to "the
+// store is stocked and revealed": saved-session auto-connect with its stall
+// watchdog and backoff retry, the membership-card picker hand-off, the classic
+// DOM login form's handlers, demo-mode stocking, and the login/boot overlay
+// show/hide pairs.
+//
+// Extracted from main.ts (which sits at its enforced line budget) as the
+// prerequisite step of the first-run opening-day work (#41): main.ts keeps the
+// store-facing state (libraries, games, scene) and hands this module setters
+// and loaders through initBootFlow(deps); nothing here reaches back into
+// main.ts directly, so the two can't tangle.
+import {
+  fetchJellyfinLibrariesAndMovies,
+  authenticateUser,
+  validateToken,
+  fetchPublicUsers,
+  normalizeUrl,
+  JellyfinLibrary,
+} from './jellyfin';
+import {
+  openMembershipCardPicker,
+  closeMembershipCardPicker,
+  type MembershipLoginSession,
+} from './membership-cards';
+import { buildDemoLibraries, buildDemoGames } from './demo-library';
+import { getSetting } from './settings';
+import { isDemoMode } from './demo-mode';
+
+export interface BootFlowDeps {
+  log: (message: string, type?: 'system' | 'cec' | 'video') => void;
+  /** main.ts's ui-state object — this flow owns its isLoginOpen flag. */
+  ui: { isLoginOpen: boolean };
+  /** Publish a fetched/synthesized library list into main.ts's state. */
+  setLibraries: (libs: JellyfinLibrary[]) => void;
+  /** Publish demo game stock (main.ts's gameMovies). */
+  setGames: (games: import('./jellyfin').Movie[]) => void;
+  /** The optional sidecar loaders (Jellyseerr coming-soon/discovery, Romm). */
+  loadComingSoon: () => Promise<void>;
+  loadDiscovery: () => Promise<void>;
+  loadGames: () => Promise<void>;
+  mergeCollectionGaps: (libs: JellyfinLibrary[]) => Promise<number>;
+  logJellyseerrStatus: (gapCount: number) => Promise<void>;
+  gameCount: () => number;
+  /** waitForFontsAndInit — the font gate + scene build funnel. */
+  launchStore: () => void;
+  /** Destroy the live scene + HUD timers (log-out / switch-member teardown). */
+  teardownScene: () => void;
+}
+
+let deps: BootFlowDeps | null = null;
+
+export function initBootFlow(d: BootFlowDeps): void {
+  deps = d;
+}
+
+// ─── Login / boot overlays ────────────────────────────────────────────────────
+
+export function showLoginOverlay() {
+  if (isDemoMode) return; // the demo never logs in
+  closeMembershipCardPicker(); // defensive: idempotent if it wasn't open
+  if (deps) deps.ui.isLoginOpen = true;
+  const overlay = document.getElementById('login-overlay');
+  if (overlay) {
+    overlay.classList.add('visible');
+
+    const envUrl = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_URL : undefined;
+    const savedUrl = localStorage.getItem('jellyfin_url') || envUrl;
+    if (savedUrl) {
+      const urlInput = document.getElementById('login-url') as HTMLInputElement;
+      if (urlInput) urlInput.value = savedUrl;
+    }
+
+    const envUser = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_USERNAME : undefined;
+    const savedUsername = localStorage.getItem('jellyfin_username') || envUser;
+    const userInput = document.getElementById('login-user') as HTMLInputElement;
+    if (userInput) {
+      if (savedUsername) userInput.value = savedUsername;
+      userInput.focus();
+    }
+
+    const envPass = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_PASSWORD : undefined;
+    const passInput = document.getElementById('login-pass') as HTMLInputElement;
+    if (passInput && envPass) {
+      passInput.value = envPass;
+    }
+
+    // Jellyseerr (optional) -- same persistence mechanism as the Jellyfin
+    // fields above, just two extra fields that stay blank when unused.
+    const envJellyseerrUrl = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYSEERR_URL : undefined;
+    const savedJellyseerrUrl = localStorage.getItem('jellyseerr_url') || envJellyseerrUrl;
+    const jellyseerrUrlInput = document.getElementById('login-jellyseerr-url') as HTMLInputElement;
+    if (jellyseerrUrlInput) jellyseerrUrlInput.value = savedJellyseerrUrl || '';
+
+    const envJellyseerrKey = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYSEERR_APIKEY : undefined;
+    const savedJellyseerrKey = localStorage.getItem('jellyseerr_apikey') || envJellyseerrKey;
+    const jellyseerrKeyInput = document.getElementById('login-jellyseerr-key') as HTMLInputElement;
+    if (jellyseerrKeyInput) jellyseerrKeyInput.value = savedJellyseerrKey || '';
+
+    // T18: Romm (optional) -- same prefill treatment as Jellyseerr. Column
+    // stays hidden (values still prefilled, just not shown) unless the Video
+    // Games section is switched on in Settings, so opting in still requires a
+    // deliberate settings-drawer toggle before Romm creds are even offered.
+    const envRommUrl = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_ROMM_URL : undefined;
+    const envRommKey = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_ROMM_APIKEY : undefined;
+    const rommUrlInput = document.getElementById('login-romm-url') as HTMLInputElement | null;
+    if (rommUrlInput) rommUrlInput.value = localStorage.getItem('romm_url') || envRommUrl || '';
+    const rommKeyInput = document.getElementById('login-romm-key') as HTMLInputElement | null;
+    if (rommKeyInput) rommKeyInput.value = localStorage.getItem('romm_apikey') || envRommKey || '';
+    const rommColumn = document.getElementById('login-romm-column');
+    if (rommColumn) rommColumn.style.display = getSetting<boolean>('bb_games_enabled') ? '' : 'none';
+  }
+}
+
+export function hideLoginOverlay() {
+  if (deps) deps.ui.isLoginOpen = false;
+  const overlay = document.getElementById('login-overlay');
+  if (overlay) {
+    overlay.classList.remove('visible');
+  }
+}
+
+export function hideBootOverlay() {
+  const overlay = document.getElementById('boot-overlay');
+  if (overlay) {
+    overlay.classList.remove('visible');
+  }
+}
+
+// Re-shown after a manual login (the boot overlay is only up by default on the
+// very first paint) so the scene has somewhere opaque to load behind while its
+// textures stream in.
+export function showBootOverlay() {
+  const overlay = document.getElementById('boot-overlay');
+  if (overlay) {
+    overlay.classList.add('visible');
+  }
+}
+
+// ─── Credentials / Boot ───────────────────────────────────────────────────────
+
+/**
+ * Shared "we're authenticated, now go load the store" tail used by both the
+ * classic login form and the membership card picker (T17). Never stores a
+ * password -- only the resulting session token/userid.
+ */
+async function finishLoginAndLaunch(urlInput: string, session: MembershipLoginSession) {
+  if (!deps) return;
+  deps.log(`[System] Authenticated successfully as ${session.userName}.`, 'system');
+  localStorage.setItem('jellyfin_url', urlInput);
+  localStorage.setItem('jellyfin_token', session.accessToken);
+  localStorage.setItem('jellyfin_userid', session.userId);
+  localStorage.setItem('jellyfin_last_userid', session.userId); // remembered for next boot's card highlight
+
+  deps.log('[System] Downloading movie libraries and catalog metadata...', 'system');
+  // Stall watchdog, not a deadline — see the auto-login path for why a fixed
+  // cap on total sync duration is unsurvivable for a large enough library.
+  const LOGIN_STALL_MS = 45_000;
+  let loginStallTimer: ReturnType<typeof setTimeout> | null = null;
+  let onLoginStall: (() => void) | null = null;
+  const armLoginStall = () => {
+    if (loginStallTimer) clearTimeout(loginStallTimer);
+    loginStallTimer = setTimeout(() => onLoginStall?.(), LOGIN_STALL_MS);
+  };
+  const loginTimeout = new Promise<never>((_, reject) => {
+    onLoginStall = () => reject(new Error(`No response from Jellyfin for ${LOGIN_STALL_MS / 1000}s`));
+    armLoginStall();
+  });
+  let libs: JellyfinLibrary[];
+  try {
+    [libs] = await Promise.all([
+      Promise.race([
+        fetchJellyfinLibrariesAndMovies(urlInput, session.accessToken, session.userId, armLoginStall),
+        loginTimeout
+      ]),
+      deps.loadComingSoon(),
+      deps.loadDiscovery(),
+      deps.loadGames()
+    ]);
+  } finally {
+    if (loginStallTimer) clearTimeout(loginStallTimer);
+  }
+  deps.setLibraries(libs);
+  const gapCount = await deps.mergeCollectionGaps(libs);
+  const totalMoviesCount = libs.reduce((acc, lib) => acc + lib.movies.length, 0);
+
+  deps.log(`[System] Loaded ${libs.length} libraries (${totalMoviesCount} titles total). Launching store...`, 'system');
+  await deps.logJellyseerrStatus(gapCount);
+  if (deps.gameCount() > 0) {
+    deps.log(`[System] Romm: ${deps.gameCount()} game(s) loaded for the Video Games section.`, 'system');
+  }
+  hideLoginOverlay();
+  // Bring the boot overlay back up as an opaque loading screen -- it stays
+  // visible (see initializeStoreScene) until every cover texture has loaded.
+  showBootOverlay();
+  deps.launchStore();
+}
+
+/**
+ * Boot/re-login entry point (T17): if we know a server URL, try its public
+ * user list first and show the fanned membership-card picker; only fall back
+ * to the classic single-login form if the server has no saved URL yet, the
+ * public user list is disabled, or it comes back empty (single-user server).
+ */
+export async function showLoginOrCards(reason?: string) {
+  if (isDemoMode || !deps) return; // the demo never logs in
+  const savedUrl = localStorage.getItem('jellyfin_url');
+  if (savedUrl) {
+    try {
+      const users = await fetchPublicUsers(savedUrl);
+      if (users.length > 0) {
+        if (reason) deps.log(`[System] ${reason}`, 'system');
+        deps.log(`[System] Found ${users.length} membership card(s) on ${savedUrl}.`, 'system');
+        openMembershipCardPicker({
+          serverUrl: savedUrl,
+          users,
+          lastUserId: localStorage.getItem('jellyfin_last_userid'),
+          onLogin: (session) => finishLoginAndLaunch(savedUrl, session),
+          onManualLogin: () => abortBootToLogin(reason),
+          onDemoMode: () => {
+            hideLoginOverlay();
+            closeMembershipCardPicker();
+            showBootOverlay();
+            startDemoAndLoad();
+          },
+          log: (msg) => deps?.log(msg, 'system'),
+        });
+        return;
+      }
+    } catch (e: any) {
+      deps.log(`[System] Public user list unavailable (${e?.message ?? e}); falling back to login form.`, 'system');
+    }
+  }
+  abortBootToLogin(reason);
+}
+
+/**
+ * "Switch Member" affordance (T17), reachable from the settings drawer:
+ * tears down the current session/scene (like logging out) but keeps the
+ * server URL, then re-shows the membership card picker so another
+ * household member can pick their own card without re-typing the server.
+ */
+export function switchMember() {
+  if (!deps) return;
+  deps.log('[System] Switching membership card...', 'system');
+  localStorage.removeItem('jellyfin_token');
+  localStorage.removeItem('jellyfin_userid');
+  deps.teardownScene();
+  void showLoginOrCards();
+}
+
+function abortBootToLogin(reason?: string) {
+  hideBootOverlay();
+  showLoginOverlay();
+  if (reason) {
+    const errorMsg = document.getElementById('login-error-msg') as HTMLDivElement;
+    const submitBtn = document.getElementById('btn-login-submit') as HTMLButtonElement;
+    if (submitBtn) { submitBtn.disabled = false; submitBtn.innerText = 'Connect & Sync'; }
+    if (errorMsg) { errorMsg.style.color = 'red'; errorMsg.innerText = reason; }
+  }
+}
+
+/**
+ * Demo-mode boot (see src/demo-mode.ts): no credential gate, no Jellyfin
+ * fetch, no login overlay ever — stock the store from the synthetic demo
+ * library and hand off to the normal texture-gated reveal.
+ */
+export function startDemoAndLoad() {
+  if (!deps) return;
+  // First visit defaults to daytime out the windows (the scene otherwise
+  // rolls day/night 50/50 per boot); user-changeable in Store Look after.
+  if (!localStorage.getItem('bb_outside')) localStorage.setItem('bb_outside', 'day');
+  // The games department is off by default (bb_games_enabled, main.ts fetchGames)
+  // because it costs a RomM round-trip nobody asked for. The demo has no RomM and
+  // no round trip — buildDemoGames() is synchronous and local — so that default
+  // was buying nothing here and cost us the whole department: every visitor to
+  // the Pages demo saw a store with no VIDEO GAMES section, which is why the
+  // feature reads as missing to people who have only ever seen the demo. Opt in
+  // on first boot only, so a visitor who switches it off keeps it off.
+  if (!localStorage.getItem('bb_games_enabled')) localStorage.setItem('bb_games_enabled', '1');
+  deps.log('[System] Demo mode: stocking the store with a placeholder library (no media server).', 'system');
+  deps.setLibraries(buildDemoLibraries(900));
+  deps.setGames(buildDemoGames(60));
+  deps.launchStore();
+}
+
+export async function checkCredentialsAndLoad() {
+  if (!deps) return;
+  const d = deps;
+  // Security hardening: Purge any stored plaintext password
+  localStorage.removeItem('jellyfin_password');
+
+  const envUrl = (typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_URL : undefined) || '';
+  const envUser = (typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_USERNAME : undefined) || '';
+  const envPass = (typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_PASSWORD : undefined) || '';
+
+  let jellyfinUrl = localStorage.getItem('jellyfin_url') || envUrl;
+  let token = localStorage.getItem('jellyfin_token');
+  let userId = localStorage.getItem('jellyfin_userid');
+
+  // If no saved token/userId, attempt auto-authentication using credentials stored in .env.local / env
+  if ((!token || !userId || !jellyfinUrl) && envUrl && envUser && envPass) {
+    d.log('[System] File credentials (.env.local) found. Authenticating automatically...', 'system');
+    try {
+      const session = await authenticateUser(envUrl, envUser, envPass);
+      localStorage.setItem('jellyfin_url', envUrl);
+      localStorage.setItem('jellyfin_username', envUser);
+      localStorage.setItem('jellyfin_token', session.accessToken);
+      localStorage.setItem('jellyfin_userid', session.userId);
+      localStorage.setItem('jellyfin_last_userid', session.userId);
+      jellyfinUrl = envUrl;
+      token = session.accessToken;
+      userId = session.userId;
+      d.log(`[System] Auto-authenticated successfully as ${session.userName}.`, 'system');
+
+      if (typeof import.meta.env !== 'undefined') {
+        if (import.meta.env.VITE_JELLYSEERR_URL && import.meta.env.VITE_JELLYSEERR_APIKEY) {
+          localStorage.setItem('jellyseerr_url', import.meta.env.VITE_JELLYSEERR_URL);
+          localStorage.setItem('jellyseerr_apikey', import.meta.env.VITE_JELLYSEERR_APIKEY);
+        }
+        if (import.meta.env.VITE_ROMM_URL && import.meta.env.VITE_ROMM_APIKEY) {
+          localStorage.setItem('romm_url', import.meta.env.VITE_ROMM_URL);
+          localStorage.setItem('romm_apikey', import.meta.env.VITE_ROMM_APIKEY);
+          if (!localStorage.getItem('bb_games_enabled')) {
+            localStorage.setItem('bb_games_enabled', '1');
+          }
+        }
+      }
+    } catch (err: any) {
+      d.log(`[System] Auto-authentication from file credentials failed: ${err?.message || err}`, 'system');
+    }
+  }
+
+  let escaped = false;
+  let retryTimeoutId: any = null;
+
+  // Any keypress or click on the boot screen skips auto-connect and goes to login.
+  const bootEscape = (e: Event) => {
+    if (e.type === 'keydown' && (e as KeyboardEvent).key === 'Tab') return; // ignore tab
+    escaped = true;
+    if (retryTimeoutId) {
+      clearTimeout(retryTimeoutId);
+      retryTimeoutId = null;
+    }
+    document.removeEventListener('keydown', bootEscape);
+    document.removeEventListener('click', bootEscape);
+    hideBootOverlay();
+    showLoginOrCards();
+  };
+  document.addEventListener('keydown', bootEscape);
+  document.addEventListener('click', bootEscape);
+
+  if (jellyfinUrl && token && userId) {
+    d.log('[System] Saved Jellyfin credentials found. Connecting...', 'system');
+
+    // A STALL timeout, not a deadline. This was a flat 20s cap on the whole
+    // multi-library sync, which a large enough catalog can never beat: the
+    // sync would be killed mid-flight, retried, and killed again forever, so
+    // boot never reached the store and every post-login step (collection
+    // gaps, the Jellyseerr status line, the scene itself) simply never ran.
+    // Sync duration scales with library size and is not a fault; silence is.
+    // The watchdog therefore fires only when the server has sent nothing at
+    // all for this long, and every page resets it.
+    const STALL_MS = 45_000;
+    let currentDelay = 10_000; // starts at 10s
+    const MAX_DELAY = 5 * 60 * 1000; // 5min cap
+
+    const attemptSync = async () => {
+      if (escaped) return;
+
+      const activeToken = localStorage.getItem('jellyfin_token') || token;
+      const activeUserId = localStorage.getItem('jellyfin_userid') || userId;
+
+      let stallTimer: ReturnType<typeof setTimeout> | null = null;
+      let onStall: (() => void) | null = null;
+      const armStall = () => {
+        if (stallTimer) clearTimeout(stallTimer);
+        stallTimer = setTimeout(() => onStall?.(), STALL_MS);
+      };
+      const stallPromise = new Promise<never>((_, reject) => {
+        onStall = () => reject(new Error(`No response from Jellyfin for ${STALL_MS / 1000}s`));
+        armStall();
+      });
+
+      try {
+        let libs: JellyfinLibrary[];
+        [libs] = await Promise.all([
+          Promise.race([
+            fetchJellyfinLibrariesAndMovies(jellyfinUrl, activeToken!, activeUserId!, armStall),
+            stallPromise
+          ]),
+          d.loadComingSoon(),
+          d.loadDiscovery(),
+          d.loadGames()
+        ]);
+        if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
+
+        if (escaped) return;
+
+        document.removeEventListener('keydown', bootEscape);
+        document.removeEventListener('click', bootEscape);
+        if (retryTimeoutId) {
+          clearTimeout(retryTimeoutId);
+          retryTimeoutId = null;
+        }
+
+        d.setLibraries(libs);
+        const gapCount = await d.mergeCollectionGaps(libs);
+        const totalMoviesCount = libs.reduce((acc, lib) => acc + lib.movies.length, 0);
+        d.log(`[System] Connected to Jellyfin. Sync'd ${libs.length} libraries (${totalMoviesCount} movies total).`, 'system');
+        await d.logJellyseerrStatus(gapCount);
+        if (d.gameCount() > 0) {
+          d.log(`[System] Romm: ${d.gameCount()} game(s) loaded for the Video Games section.`, 'system');
+        }
+
+        hideLoginOverlay(); // in case user clicked to dismiss boot screen
+        closeMembershipCardPicker();
+        // Boot overlay stays up (see waitForFontsAndInit/initializeStoreScene) until
+        // every cover texture has loaded, so the store is never revealed mid-load.
+        d.launchStore();
+      } catch (err: any) {
+        if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
+        if (escaped) return;
+
+        const msg = err?.message ?? (typeof err === 'string' ? err : String(err));
+        d.log(`[System] Auto-login failed: ${msg}. Retrying in ${currentDelay / 1000}s...`, 'system');
+
+        retryTimeoutId = setTimeout(async () => {
+          if (escaped) return;
+
+          // Before each retry, check if cached token fails validation. If so, attempt to re-auth from cached credentials.
+          const freshToken = localStorage.getItem('jellyfin_token') || token;
+          try {
+            const isValid = await validateToken(jellyfinUrl, freshToken!);
+            if (!isValid) {
+              const user = localStorage.getItem('jellyfin_username') || envUser;
+              const pass = localStorage.getItem('jellyfin_password') || envPass;
+              if (user && pass && jellyfinUrl) {
+                d.log('[System] Jellyfin token stale — re-authenticating...', 'system');
+                const session = await authenticateUser(jellyfinUrl, user, pass);
+                localStorage.setItem('jellyfin_token', session.accessToken);
+                localStorage.setItem('jellyfin_userid', session.userId);
+                d.log('[System] Re-auth OK.', 'system');
+              }
+            }
+          } catch (e: any) {
+            d.log(`[System] Silent re-auth check failed: ${e.message || e}`, 'system');
+          }
+
+          // Double the delay for exponential backoff up to the cap
+          const nextDelay = Math.min(currentDelay * 2, MAX_DELAY);
+          currentDelay = nextDelay;
+
+          attemptSync();
+        }, currentDelay);
+      }
+    };
+
+    attemptSync();
+  } else {
+    d.log('[System] No saved credentials. Showing Login screen.', 'system');
+    document.removeEventListener('keydown', bootEscape);
+    document.removeEventListener('click', bootEscape);
+    setTimeout(() => { hideBootOverlay(); showLoginOrCards(); }, 500);
+  }
+}
+
+export function setupLoginHandlers() {
+  const form = document.getElementById('login-form') as HTMLFormElement;
+  const errorMsg = document.getElementById('login-error-msg') as HTMLDivElement;
+
+  const demoBtn = document.getElementById('btn-demo-submit') as HTMLButtonElement | null;
+  if (demoBtn) {
+    demoBtn.addEventListener('click', () => {
+      hideLoginOverlay();
+      closeMembershipCardPicker();
+      showBootOverlay();
+      startDemoAndLoad();
+    });
+  }
+
+  if (form) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (errorMsg) errorMsg.innerText = '';
+
+      const submitBtn = document.getElementById('btn-login-submit') as HTMLButtonElement;
+      if (submitBtn) {
+        submitBtn.disabled = true;
+        submitBtn.innerText = 'Connecting...';
+      }
+
+      const rawUrl = (document.getElementById('login-url') as HTMLInputElement).value.trim();
+      const urlInput = normalizeUrl(rawUrl);
+      const userInput = (document.getElementById('login-user') as HTMLInputElement).value.trim();
+      const passInput = (document.getElementById('login-pass') as HTMLInputElement).value;
+      // Jellyseerr is entirely optional -- both fields are blank by default and
+      // saving an empty value clears any previously-saved config, so leaving
+      // them blank silently disables the coming-soon feature.
+      const jellyseerrUrlEl = document.getElementById('login-jellyseerr-url') as HTMLInputElement | null;
+      const jellyseerrKeyEl = document.getElementById('login-jellyseerr-key') as HTMLInputElement | null;
+      const jellyseerrUrlInput = jellyseerrUrlEl?.value.trim() ?? '';
+      const jellyseerrKeyInput = jellyseerrKeyEl?.value.trim() ?? '';
+
+      try {
+        deps?.log(`[System] Contacting Jellyfin server: ${urlInput}`, 'system');
+        const session = await authenticateUser(urlInput, userInput, passInput);
+
+        // Only the manual single-login form remembers username (to prefill);
+        // the password is never persisted in plaintext localStorage.
+        localStorage.setItem('jellyfin_username', userInput);
+
+        if (jellyseerrUrlInput && jellyseerrKeyInput) {
+          localStorage.setItem('jellyseerr_url', jellyseerrUrlInput);
+          localStorage.setItem('jellyseerr_apikey', jellyseerrKeyInput);
+        } else {
+          localStorage.removeItem('jellyseerr_url');
+          localStorage.removeItem('jellyseerr_apikey');
+        }
+
+        // T18: Romm (optional) -- same persistence pattern as Jellyseerr above.
+        // Both fields blank clears any saved config, disabling the game section.
+        const rommUrlInput = (document.getElementById('login-romm-url') as HTMLInputElement | null)?.value.trim() ?? '';
+        const rommKeyInput = (document.getElementById('login-romm-key') as HTMLInputElement | null)?.value.trim() ?? '';
+        if (rommUrlInput && rommKeyInput) {
+          localStorage.setItem('romm_url', rommUrlInput);
+          localStorage.setItem('romm_apikey', rommKeyInput);
+        } else {
+          localStorage.removeItem('romm_url');
+          localStorage.removeItem('romm_apikey');
+        }
+
+        await finishLoginAndLaunch(urlInput, session);
+      } catch (err: any) {
+        deps?.log(`[System] Connection error: ${err.message}`, 'system');
+        if (errorMsg) {
+          let userMsg = err.message || 'Failed to connect to Jellyfin server';
+          if (userMsg.includes('HTTP error 401')) {
+            userMsg = 'Invalid username or password.';
+          } else if (userMsg.includes('Failed to fetch') || userMsg.includes('NetworkError')) {
+            userMsg = `Unable to connect to "${urlInput}". Check the server address, CORS settings, and verify Jellyfin is online.`;
+          }
+          errorMsg.innerText = userMsg;
+        }
+      } finally {
+        if (submitBtn) {
+          submitBtn.disabled = false;
+          submitBtn.innerText = 'Connect & Sync';
+        }
+      }
+    });
+  }
+}

--- a/src/boot-flow.ts
+++ b/src/boot-flow.ts
@@ -25,11 +25,22 @@ import {
 import { buildDemoLibraries, buildDemoGames } from './demo-library';
 import { getSetting } from './settings';
 import { isDemoMode } from './demo-mode';
+import { excludedLibraryIds } from './library-settings';
+import {
+  initSetupFlow,
+  openSetupTerminal,
+  openSetupNotice,
+  closeSetupTerminal,
+  type SetupTerminalScene,
+} from './store-setup-flow';
 
 export interface BootFlowDeps {
   log: (message: string, type?: 'system' | 'cec' | 'video') => void;
-  /** main.ts's ui-state object — this flow owns its isLoginOpen flag. */
-  ui: { isLoginOpen: boolean };
+  /** main.ts's ui-state object — this flow owns isLoginOpen and isSetupOpen. */
+  ui: { isLoginOpen: boolean; isSetupOpen: boolean };
+  /** The live scene (or null before reveal) — the setup terminal's CRT dock. */
+  scene: () => SetupTerminalScene | null;
+  keyClick: () => void;
   /** Publish a fetched/synthesized library list into main.ts's state. */
   setLibraries: (libs: JellyfinLibrary[]) => void;
   /** Publish demo game stock (main.ts's gameMovies). */
@@ -49,8 +60,152 @@ export interface BootFlowDeps {
 
 let deps: BootFlowDeps | null = null;
 
+// Opening-day (#41) plumbing: what the setup terminal should show once the
+// empty scene has revealed, and hooks into the auto-retry loop below so the
+// notice screen's RETRY NOW / CHANGE SERVER rows can drive it.
+let pendingSetup: { notice?: { address: string; detail: string } } | null = null;
+let retryNowHook: (() => void) | null = null;
+let cancelRetryHook: (() => void) | null = null;
+
 export function initBootFlow(d: BootFlowDeps): void {
   deps = d;
+  initSetupFlow({
+    scene: d.scene,
+    ui: d.ui,
+    log: d.log,
+    keyClick: d.keyClick,
+    callbacks: {
+      tryDemo: () => {
+        hideLoginOverlay();
+        closeMembershipCardPicker();
+        showBootOverlay();
+        startDemoAndLoad();
+      },
+      sync: syncForSetup,
+      openStore: () => {
+        showBootOverlay();
+        d.launchStore();
+      },
+      changeServer: () => {
+        cancelRetryHook?.();
+        localStorage.removeItem('jellyfin_url');
+        localStorage.removeItem('jellyfin_username');
+        localStorage.removeItem('jellyfin_token');
+        localStorage.removeItem('jellyfin_userid');
+        d.log('[Setup] Saved server dropped — pick a new distributor.', 'system');
+      },
+      retryNow: () => retryNowHook?.(),
+    },
+  });
+}
+
+/**
+ * Boot (or rebuild) into the EMPTY store — bare shelves, no posters — and
+ * queue the setup terminal to dock once the scene reveals (#41). Serves both
+ * the true first run and the unreachable-server failure state.
+ */
+export function enterOpeningDay(opts?: { notice?: { address: string; detail: string } }): void {
+  if (!deps) return;
+  pendingSetup = { notice: opts?.notice };
+  deps.setLibraries([]);
+  deps.setGames([]);
+  // The empty build takes a second or two; the boot overlay (already up on
+  // first paint, re-raised here for live re-entries like log-out) covers the
+  // teardown/build and drops the moment the bare store is ready.
+  showBootOverlay();
+  deps.launchStore();
+}
+
+/**
+ * Called by main.ts at the scene-reveal moment (textures ready, overlay about
+ * to drop): if an opening-day boot queued the setup terminal, dock it now so
+ * the player wakes at the counter CRT.
+ */
+export function maybeOpenSetupTerminal(): void {
+  if (!pendingSetup) return;
+  const p = pendingSetup;
+  pendingSetup = null;
+  if (p.notice) openSetupNotice(p.notice.address, p.notice.detail);
+  else openSetupTerminal();
+}
+
+/**
+ * CHANGE SERVER / LOG OUT (#41): the empty-store setup terminal is the
+ * re-entry point, not the old DOM form. Flat mode (no 3D counter to dock to)
+ * keeps the form.
+ */
+export function logOutToOpeningDay(): void {
+  if (!deps) return;
+  deps.log('[System] Logging out and resetting Jellyfin session...', 'system');
+  localStorage.removeItem('jellyfin_url');
+  localStorage.removeItem('jellyfin_username');
+  localStorage.removeItem('jellyfin_password');
+  localStorage.removeItem('jellyfin_token');
+  localStorage.removeItem('jellyfin_userid');
+  deps.teardownScene();
+  if (getSetting<string>('bb_render_mode') === 'flat') {
+    showLoginOverlay();
+    return;
+  }
+  enterOpeningDay();
+}
+
+/**
+ * The setup terminal's catalog sync: same stall watchdog + sidecar loaders as
+ * finishLoginAndLaunch, but progress renders as a CRT readout instead of the
+ * boot console, and the carried-library exclusions just chosen on the
+ * checkbox screen are honored (their item sync is skipped entirely).
+ */
+async function syncForSetup(
+  url: string,
+  session: MembershipLoginSession,
+  onStage: (stage: string, pages: number) => void
+): Promise<void> {
+  if (!deps) throw new Error('Boot flow not initialized.');
+  const d = deps;
+  const LOGIN_STALL_MS = 45_000;
+  let stallTimer: ReturnType<typeof setTimeout> | null = null;
+  let onStall: (() => void) | null = null;
+  const armStall = () => {
+    if (stallTimer) clearTimeout(stallTimer);
+    stallTimer = setTimeout(() => onStall?.(), LOGIN_STALL_MS);
+  };
+  const stallPromise = new Promise<never>((_, reject) => {
+    onStall = () => reject(new Error(`No response from Jellyfin for ${LOGIN_STALL_MS / 1000}s`));
+    armStall();
+  });
+  let pages = 0;
+  let lastStage = 'CONTACTING DISTRIBUTOR...';
+  const onProgress = (stage: string) => {
+    armStall();
+    if (stage === 'page') pages++;
+    else lastStage = `SYNCING ${stage.toUpperCase()}`;
+    onStage(lastStage, pages);
+  };
+  let libs: JellyfinLibrary[];
+  try {
+    [libs] = await Promise.all([
+      Promise.race([
+        fetchJellyfinLibrariesAndMovies(url, session.accessToken, session.userId, onProgress, {
+          excludeLibraryIds: excludedLibraryIds(),
+        }),
+        stallPromise,
+      ]),
+      d.loadComingSoon(),
+      d.loadDiscovery(),
+      d.loadGames(),
+    ]);
+  } finally {
+    if (stallTimer) clearTimeout(stallTimer);
+  }
+  d.setLibraries(libs);
+  const gapCount = await d.mergeCollectionGaps(libs);
+  const totalMoviesCount = libs.reduce((acc, lib) => acc + lib.movies.length, 0);
+  d.log(`[System] Loaded ${libs.length} libraries (${totalMoviesCount} titles total). Opening the store...`, 'system');
+  await d.logJellyseerrStatus(gapCount);
+  if (d.gameCount() > 0) {
+    d.log(`[System] Romm: ${d.gameCount()} game(s) loaded for the Video Games section.`, 'system');
+  }
 }
 
 // ─── Login / boot overlays ────────────────────────────────────────────────────
@@ -169,7 +324,9 @@ async function finishLoginAndLaunch(urlInput: string, session: MembershipLoginSe
   try {
     [libs] = await Promise.all([
       Promise.race([
-        fetchJellyfinLibrariesAndMovies(urlInput, session.accessToken, session.userId, armLoginStall),
+        fetchJellyfinLibrariesAndMovies(urlInput, session.accessToken, session.userId, armLoginStall, {
+          excludeLibraryIds: excludedLibraryIds(),
+        }),
         loginTimeout
       ]),
       deps.loadComingSoon(),
@@ -363,6 +520,7 @@ export async function checkCredentialsAndLoad() {
     const STALL_MS = 45_000;
     let currentDelay = 10_000; // starts at 10s
     const MAX_DELAY = 5 * 60 * 1000; // 5min cap
+    let noticeShown = false; // the empty-store failure notice (#41), once
 
     const attemptSync = async () => {
       if (escaped) return;
@@ -385,7 +543,9 @@ export async function checkCredentialsAndLoad() {
         let libs: JellyfinLibrary[];
         [libs] = await Promise.all([
           Promise.race([
-            fetchJellyfinLibrariesAndMovies(jellyfinUrl, activeToken!, activeUserId!, armStall),
+            fetchJellyfinLibrariesAndMovies(jellyfinUrl, activeToken!, activeUserId!, armStall, {
+              excludeLibraryIds: excludedLibraryIds(),
+            }),
             stallPromise
           ]),
           d.loadComingSoon(),
@@ -414,6 +574,11 @@ export async function checkCredentialsAndLoad() {
 
         hideLoginOverlay(); // in case user clicked to dismiss boot screen
         closeMembershipCardPicker();
+        // A recovered notice-mode boot (#41) is docked at the empty store's
+        // setup terminal — leave it cleanly, and re-raise the boot overlay it
+        // hid so the stocked rebuild happens behind the usual reveal.
+        closeSetupTerminal({ keepCamera: true });
+        showBootOverlay();
         // Boot overlay stays up (see waitForFontsAndInit/initializeStoreScene) until
         // every cover texture has loaded, so the store is never revealed mid-load.
         d.launchStore();
@@ -423,6 +588,24 @@ export async function checkCredentialsAndLoad() {
 
         const msg = err?.message ?? (typeof err === 'string' ? err : String(err));
         d.log(`[System] Auto-login failed: ${msg}. Retrying in ${currentDelay / 1000}s...`, 'system');
+
+        // #41: the empty store doubles as the failure state — never a modal
+        // error or an endless dark overlay. The first failure boots the empty
+        // shell with the DISTRIBUTOR NOT ANSWERING notice on the counter CRT
+        // (auto-retry keeps running underneath); later failures just refresh
+        // the notice line. Flat mode has no counter to dock to and keeps the
+        // classic behavior. The boot-escape listener comes off first — its
+        // any-key jump to the card picker would fight the notice menu.
+        if (getSetting<string>('bb_render_mode') !== 'flat') {
+          if (!noticeShown) {
+            noticeShown = true;
+            document.removeEventListener('keydown', bootEscape);
+            document.removeEventListener('click', bootEscape);
+            enterOpeningDay({ notice: { address: jellyfinUrl, detail: msg } });
+          } else {
+            openSetupNotice(jellyfinUrl, msg);
+          }
+        }
 
         retryTimeoutId = setTimeout(async () => {
           if (escaped) return;
@@ -455,12 +638,46 @@ export async function checkCredentialsAndLoad() {
       }
     };
 
+    // The notice screen's rows reach into this loop (#41): RETRY NOW fires an
+    // immediate attempt, CHANGE SERVER stops the loop for good.
+    retryNowHook = () => {
+      if (retryTimeoutId) {
+        clearTimeout(retryTimeoutId);
+        retryTimeoutId = null;
+      }
+      void attemptSync();
+    };
+    cancelRetryHook = () => {
+      escaped = true;
+      if (retryTimeoutId) {
+        clearTimeout(retryTimeoutId);
+        retryTimeoutId = null;
+      }
+      document.removeEventListener('keydown', bootEscape);
+      document.removeEventListener('click', bootEscape);
+    };
+
     attemptSync();
-  } else {
+  } else if (jellyfinUrl) {
+    // A saved server with no session (e.g. after Switch Member): the fanned
+    // membership-card picker, exactly as before.
     d.log('[System] No saved credentials. Showing Login screen.', 'system');
     document.removeEventListener('keydown', bootEscape);
     document.removeEventListener('click', bootEscape);
     setTimeout(() => { hideBootOverlay(); showLoginOrCards(); }, 500);
+  } else {
+    // Nothing saved at all — this is the store's OPENING DAY (#41): boot the
+    // empty shell and wake at the counter CRT's NEW STORE SETUP. No DOM form.
+    // Flat mode (no 3D counter) keeps the classic login overlay.
+    document.removeEventListener('keydown', bootEscape);
+    document.removeEventListener('click', bootEscape);
+    if (getSetting<string>('bb_render_mode') === 'flat') {
+      d.log('[System] No saved credentials. Showing Login screen.', 'system');
+      setTimeout(() => { hideBootOverlay(); showLoginOrCards(); }, 500);
+      return;
+    }
+    d.log('[System] First run — opening day. Setting up at the counter terminal.', 'system');
+    enterOpeningDay();
   }
 }
 

--- a/src/canvas-textures.ts
+++ b/src/canvas-textures.ts
@@ -5,13 +5,14 @@
 import * as THREE from 'three';
 import { getActiveTheme, type StoreTheme } from './themes';
 import { getActiveLogoSpec, storefrontBrandGold } from './logo-spec';
-import { bb93GenreColor, bb93SignageOn } from './genre-colors';
+import { bb93SignageOn } from './genre-colors';
 import {
   drawLogo, getLogoFontString, logoFontFamily, buildLogoShapePath, logoShapeInnerBox,
   logoShapeFitRect,
 } from './logo-renderer';
 import agencyFontUrl from './assets/sairasemicondensed-medium.ttf';
 import { BB_ARCHIVO_BLACK, bundledFontsReady } from './bundled-fonts';
+import { createCategoryPlate1993Texture } from './fixtures/category-plate-1993';
 
 // ─── Anisotropic-filtering budget ────────────────────────────────────────────
 // Grazing-angle surfaces (the carpet and walls receding toward the back wall,
@@ -419,87 +420,12 @@ export function createCategorySignTexture(
 
   // OPT-IN (bb_93_signage, ceiling-nav only — `ribbon` is passed solely by
   // the ceiling-nav catalog entry so endcap placards etc. never restyle):
-  // the footage's COMEDY ceiling marker (Part II 00:58, frames2/scene_002)
-  // is a LAYERED COLLAGE, not a flat ribbon: a family-colored backer
-  // parallelogram tilted one way with a big darker-shade disc riding its
-  // right end and a detached slash piece off its left end, and on top —
-  // tilted slightly the other way — a navy rounded plate with a white
-  // inset outline carrying white BOLD-ITALIC letters that fill it. Painted
-  // on a transparent canvas; the hanging-sign builder renders it as an
-  // alpha-cut card (see ceilingHangingSign's dieCut mode). Other themes keep
-  // the muted rectangles + plain white label.
+  // the 1993 ceiling CATEGORY PLATE. The measured reconstruction and its
+  // mirrored-layout back twin live in fixtures/category-plate-1993.ts (one
+  // source of truth shared with the solid-body fixture builder — frame
+  // citations there). Other themes keep the muted rectangles + plain label.
   if (ribbon && bb93SignageOn()) {
-    canvas.width = 1536;
-    canvas.height = 640;
-    const label = categoryName.toUpperCase();
-    const family = bb93GenreColor(label);
-    const shade = (hex: string, f: number) => {
-      const n = parseInt(hex.slice(1), 16);
-      const ch = (v: number) => Math.round(v * f);
-      return `rgb(${ch(n >> 16 & 255)},${ch(n >> 8 & 255)},${ch(n & 255)})`;
-    };
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    const cx = 768, cy = 320;
-
-    // Backer parallelogram, tilted CCW, with the disc on its right end and
-    // the detached slash just off its left end (all one alpha-cut layer).
-    ctx.save();
-    ctx.translate(cx, cy);
-    ctx.rotate(-0.10);
-    ctx.transform(1, 0, -0.18, 1, 0, 0); // italic-lean the backer like the footage
-    ctx.fillStyle = family;
-    ctx.fillRect(-540, -200, 1080, 400);
-    ctx.fillRect(-640, -200, 62, 400);  // detached slash piece, small gap to the body
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
-    ctx.restore();
-    ctx.save();
-    ctx.translate(cx, cy);
-    ctx.rotate(-0.10);
-    ctx.fillStyle = shade(family, 0.78);
-    ctx.beginPath();
-    ctx.arc(452, 40, 168, 0, Math.PI * 2); // big disc riding the right end
-    ctx.fill();
-    ctx.fillStyle = shade(family, 0.92);
-    ctx.beginPath();
-    ctx.arc(452, 40, 108, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.restore();
-
-    // Navy plate on top, counter-tilted, white outline inset from its edge.
-    ctx.save();
-    ctx.translate(cx - 60, cy);
-    ctx.rotate(0.035);
-    const pw = 880, ph = 320, r = 42;
-    ctx.fillStyle = '#1a2a6e';
-    ctx.beginPath();
-    ctx.roundRect(-pw / 2, -ph / 2, pw, ph, r);
-    ctx.fill();
-    ctx.strokeStyle = '#ffffff';
-    ctx.lineWidth = 14;
-    ctx.beginPath();
-    ctx.roundRect(-pw / 2 + 26, -ph / 2 + 26, pw - 52, ph - 52, r - 18);
-    ctx.stroke();
-
-    // White bold-italic letters filling the plate: hold cap height at the
-    // footage's ~58% of the plate and condense to fit (same sign-shop fit
-    // as the genre fascia — size the visible caps, never the em).
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    let size = Math.round((ph * 0.58) / 0.72);
-    const setFont = () => { ctx.font = `italic 900 ${size}px ${BB_ARCHIVO_BLACK}, sans-serif`; };
-    setFont();
-    const maxW = pw - 110;
-    let squeeze = Math.min(1, maxW / ctx.measureText(label).width);
-    if (squeeze < 0.6) {
-      size = Math.max(50, Math.floor(size * (squeeze / 0.6)));
-      setFont();
-      squeeze = Math.min(1, maxW / ctx.measureText(label).width);
-    }
-    ctx.scale(squeeze, 1);
-    ctx.fillStyle = '#ffffff';
-    ctx.fillText(label, 0, 6);
-    ctx.restore();
-    return toSignTexture(canvas);
+    return createCategoryPlate1993Texture(categoryName, faceAspect);
   }
 
   // The Halcyon board. Every title sign in the store wears the SAME board —

--- a/src/controls-help.ts
+++ b/src/controls-help.ts
@@ -57,12 +57,16 @@ const HELP_SECTIONS: HelpSection[] = [
         hint: 'Case → shelf → store view → sections. Nothing is locked.',
       },
       {
-        id: 'tvpeek', control: '▲ past the top row', action: 'Ceiling TVs',
-        hint: '◀ ▶ change what’s playing · OK jumps to its case · ▼ returns.',
+        id: 'subnav', control: '◀ ▶ in the store view', action: 'Pick a section',
+        hint: 'The marker walks the store left to right · OK flies you there.',
       },
       {
-        id: 'subnav', control: '▼ in the store view', action: 'Jump index',
-        hint: 'Sections & displays: ▼ again for displays · OK flies you there.',
+        id: 'subnavdisplays', control: '▼ in the store view', action: 'The displays',
+        hint: 'Endcaps, promo stands and bins · ▶ steps them · BACK comes up.',
+      },
+      {
+        id: 'tvpeek', control: '▲ in the store view', action: 'Ceiling TVs',
+        hint: '◀ ▶ change what’s playing · OK jumps to its case · ▼ returns.',
       },
     ],
   },

--- a/src/entrance/counter.ts
+++ b/src/entrance/counter.ts
@@ -362,7 +362,7 @@ export function buildCheckoutCounter(
   const dFace = STRIPE_RECESS;            // stripe's visible face, just behind the band face
   const dBack = STRIPE_RECESS + STRIPE_T; // stripe slab's hidden back face
   const slabH = STRIPE_H + 0.02 + (rounded ? 0.12 : 0); // over-tall: tucks into the blue (and their bevels)
-  bandSegs.forEach(({ edge, trimA, trimB }) => {
+  bandSegs.forEach(({ edge, trimA, trimB, e }) => {
     const N = normals[edge];
     const T = tangents[edge];
     const A = P_out[edge];
@@ -385,6 +385,16 @@ export function buildCheckoutCounter(
       { noBevel: true, noCollide: true }); // recessed trim, not a body piece: sharp cut, no collider
     mesh.castShadow = false;
     mesh.receiveShadow = false;
+
+    // ...and CLOSE the channel behind it. The groove is cut clean through the
+    // band (it is the space between two extrusions), while the stripe slab
+    // only fills the outer 0.09 ft of a 1.5 ft depth — so the counter had an
+    // open slot running its whole length, plainly visible as a dark line under
+    // the top edge from the clerk side and through the walk-through gap's cut
+    // ends. This blue filler spans from the stripe's hidden back face to the
+    // band's inner edge, leaving the recess a recess on the customer side only.
+    extrudeSegment(aBack, bBack, e.B_in, e.A_in, GROOVE_HALF * 2, STRIPE_Y - GROOVE_HALF,
+      counterTopBlue, { noBevel: true, noCollide: true }); // body pieces above/below already collide
   });
 
   // ----- Inner counter: angled V-shaped island inside the shield -----

--- a/src/entrance/return-slot.ts
+++ b/src/entrance/return-slot.ts
@@ -42,6 +42,14 @@ import {
 const CHUTE_W = 2.4;
 const CHUTE_H = 3.85;   // just proud of the band top (3.4 + 0.14 cap)
 const CHUTE_D = 0.9;    // protrusion past the band face into the store
+// How far the body runs BACK from the band face. Mirrors counter.ts's bandD
+// (the same layout-agnostic mirroring entrance/index.ts does for BAND_H), so
+// the chute's rear wall lands flush with the inside face of the blue band
+// rather than stopping dead at its outer face — it is a bumped-out SECTION of
+// the counter, not a box parked against it, and at 0.04 ft deep the crown
+// used to leave the counter top running on behind it with a visible step
+// (owner, 2026-08-09).
+const CHUTE_BACK = 1.5;
 const FRONT_T = 0.14;   // face/side wall thickness
 const SLOT_W = 1.0;     // "a little bigger than a VHS length" (case is ~0.73 ft)
 const SLOT_H = 0.3;
@@ -160,7 +168,10 @@ export class ReturnSlot {
     const darkMat = new THREE.MeshStandardMaterial({ color: 0x05070c, roughness: 0.95, metalness: 0.0 });
     this.ownedMats.push(blueMat, whiteMat, darkMat);
 
-    const zRear = -0.04; // tucked a hair into the band face
+    // Rear a hair in FRONT of the band's inner face: flush to the eye, but
+    // never coplanar with the band mesh (which would z-fight over the strip of
+    // chute that stands proud of the counter top).
+    const zRear = -(CHUTE_BACK - 0.01);
     const zFace = CHUTE_D;
 
     const box = (w: number, h: number, d: number, x: number, y: number, z: number, mat: THREE.Material, collide = true) => {

--- a/src/fixture-labels.ts
+++ b/src/fixture-labels.ts
@@ -1,0 +1,49 @@
+// What a floor fixture is CALLED in navigation UI — one implementation shared
+// by the entrance overview's floating cursors (store-overview.ts) and the jump
+// index's DISPLAYS row (store-subnav.ts).
+//
+// It lived only in the jump index, so the overview fell back to raw placement
+// ids and hung tickets reading "PV-DRAPE-TABLE-FRONT" and "PROMO-STAND-BACK"
+// over the store — engineering identifiers, in the biggest type on screen,
+// while the index called the same two fixtures "PREVIOUSLY VIEWED" and
+// "SUMMER SMASH HITS". Same fixtures, same store, two different names.
+import type { SlottedFixture } from './fixtures';
+
+/**
+ * A fixture's live identity string: a promo stand's current campaign topper, a
+ * bin's name, an endcap's title — the same one the browse HUD names it by. The
+ * placement option and then the id are fallbacks, and an id only ever surfaces
+ * for a fixture that named itself nothing at all.
+ */
+export function slottedFixtureLabel(f: SlottedFixture): string {
+  const p = f.placement;
+  return (f.genre || (p.options?.genre as string) || p.id || 'display').toUpperCase();
+}
+
+/**
+ * Qualify repeated labels IN PLACE. Several fixtures share a title in an
+ * uncategorized store (every genre endcap falls back to "Related Movies", every
+ * game gondola to "Video Games"), and a row of identical tickets is unusable.
+ * Prefer the aisle a repeat belongs to; a qualifier that just repeats the title
+ * ("MOVIES · MOVIES") disambiguates nothing, so those get numbered instead.
+ *
+ * Call it after the caller's own ordering pass — the numbering follows list
+ * order, so it should be the order the player actually steps through.
+ */
+export function qualifyDuplicateLabels<T extends { label: string }>(
+  items: T[],
+  fixtureOf: (item: T) => SlottedFixture | undefined,
+): void {
+  const counts = new Map<string, number>();
+  for (const it of items) counts.set(it.label, (counts.get(it.label) ?? 0) + 1);
+  const seen = new Map<string, number>();
+  for (const it of items) {
+    if ((counts.get(it.label) ?? 0) < 2) continue;
+    const base = it.label;
+    const n = (seen.get(base) ?? 0) + 1;
+    seen.set(base, n);
+    const lib = fixtureOf(it)?.placement.options?.libraryName as string | undefined;
+    const qual = lib && lib.toUpperCase() !== base ? lib.toUpperCase() : null;
+    it.label = qual ? `${base} · ${qual}` : `${base} ${n}`;
+  }
+}

--- a/src/fixtures/bargain-bin.ts
+++ b/src/fixtures/bargain-bin.ts
@@ -62,6 +62,9 @@ export class BargainBin implements SlottedFixture {
   private disposables: Array<{ dispose(): void }> = [];
   private slotMovies: Movie[] = [];
   private fillerMovies: Movie[] = [];
+  // False until build() actually puts a tub on the floor — see build()'s
+  // no-stock bail and getFootprint().
+  private built = false;
 
   constructor(placement: FixturePlacement, ctx: FixtureContext) {
     this.placement = placement;
@@ -105,6 +108,12 @@ export class BargainBin implements SlottedFixture {
     const height = this.binHeight();
 
     this.initMovies();
+    // Nothing to dump, no bin. A store with no catalog at all — opening day
+    // (#41), where the whole point is BARE SHELVES, NO STOCK — used to get one
+    // lone tub sign-written "BARGAIN BIN / 3 FOR $10" standing on an otherwise
+    // empty floor, which reads as stock the store hasn't taken delivery of yet.
+    // The empty-tub case is equally wrong on a tiny real library.
+    if (this.slotMovies.length === 0) return;
 
     const group = new THREE.Group();
     group.position.set(this.placement.position.x, 0, this.placement.position.z);
@@ -249,6 +258,7 @@ export class BargainBin implements SlottedFixture {
     this.ctx.scene.add(group);
     this.ctx.addCollider(bin);
     this.ctx.requestShadowRefresh();
+    this.built = true;
   }
 
   // The lowest-audience-score titles across all libraries. Slots duplicate
@@ -380,7 +390,11 @@ export class BargainBin implements SlottedFixture {
   // The tub's collision-relevant footprint is its wider top rim: exactly
   // sideFt face-to-face (same derivation as PreviouslyViewedBin). Floor
   // displays demand double-walkway clearance to everything, walls included.
-  getFootprint(): Footprint {
+  // Null when the bin declined to build (no stock): "no floor footprint" is
+  // also what tells store-shell this fixture isn't on the floor, so nothing
+  // hands an absent bin an overview cursor or a jump-index entry.
+  getFootprint(): Footprint | null {
+    if (!this.built) return null;
     const sideFt = this.binSide();
     return {
       label: `fixture:${this.placement.id}`,

--- a/src/fixtures/category-plate-1993.ts
+++ b/src/fixtures/category-plate-1993.ts
@@ -1,0 +1,315 @@
+import * as THREE from 'three';
+import { BB_ARCHIVO_BLACK } from '../bundled-fonts';
+import { getBackTexture, registerBackTexture } from './sign-fixtures';
+
+/**
+ * The 1993 ceiling category WEDGE — genre wayfinding hung over aisle mouths
+ * and the counter.
+ *
+ * FINAL FORM (owner spec, 2026-08-09, third pass — supersedes both die-cut
+ * builds): a SIMPLE SOLID WEDGE. End-on the profile is an EQUILATERAL
+ * triangle pointing down (all three sides equal: flat top of depth
+ * s = 2h/√3, two sloped faces of the same length meeting in a sharp bottom
+ * edge). One body, no extra pieces: no slash bar, no arrow, no cream strip,
+ * no dark rim. The family-color field covers everything — both sloped
+ * faces AND the triangular end caps ("the end should have that same orange
+ * coloring, it shouldn't be solid black"). Each sloped face carries the
+ * NAVY NAMEPLATE exactly as measured from rUhRHo44CIA f0013: rounded rect,
+ * white inset keyline, genre in white bold-italic caps, counter-tilted
+ * ~-2.4°; the back face repeats it so the genre reads from both sides.
+ *
+ * Mount stays per feedback/049: attached at the ceiling on a short
+ * bar-and-two-drops — no long wires.
+ *
+ * History: the plates measured off the footage are flat layered die-cuts
+ * (backer + slash + curved thick arrow — measurements and gates preserved
+ * in user-assets/fixtures/ceiling-category-plates-1993/); the owner chose
+ * the plain wedge as the app's form and kept only the nameplate from that
+ * spec.
+ */
+
+const SPEC = {
+  navy: '#1a2a6e',
+  trimColor: '#15171f',    // near-black edge trim on EVERY corner edge,
+                           // including the top (owner, 2026-08-09)
+  trimT: 0.055,            // ft — "thicker" border, ~0.66 in square section
+  vignette: 0.30,          // edge darkening painted into the lit face
+  plateHFrac: 0.72,       // nameplate height / sign height h
+  plateAspect: 2.23,      // nameplate w:h (f0013)
+  plateTiltDeg: -2.4,     // counter-tilt, right end high (f0013)
+  plateDXFrac: 0.044,     // nameplate center offset right, / h
+  plateCornerR: 0.15,     // of plate height
+  keyInset: 0.075,        // white keyline inset, of plate height
+  keyStroke: 0.065,
+  capHeightFrac: 0.51,    // letter cap height, of plate height
+  textWidthFrac: 0.87,    // letters fill this much of the plate width
+};
+
+const rad = (d: number) => (d * Math.PI) / 180;
+const SQRT3 = Math.sqrt(3);
+
+// ── Per-genre body color ───────────────────────────────────────────────────
+// Owner 2026-08-09: every DIFFERENT genre/library above gets a DIFFERENT
+// body color (the shared bb93 family grouping is too coarse for the wedges).
+// Attested anchors first; everything else draws a stable distinct pick from
+// a 1993-ish POP palette, with per-session collision probing.
+const WEDGE_COLORS: Record<string, string> = {
+  'COMEDY': '#d9571f',            // rUhRHo44CIA f0013
+  'DRAMA': '#1f6fc4',             // rUhRHo44CIA f0026
+  'ACTION': '#c13066',            // HFNfVDQdMxs f0016 (magenta)
+  'HORROR': '#5b4ba0',
+  'SCI-FI & FANTASY': '#7a3fa8',
+  'ROMANCE': '#d84f8e',
+  'SUSPENSE': '#0f8f8a',
+  'GAMES': '#2e8f4e',             // the games-department wedge
+};
+const WEDGE_PALETTE = [
+  '#d9571f', '#1f6fc4', '#c13066', '#5b4ba0', '#0f8f8a', '#d84f8e',
+  '#b8860b', '#2e8f4e', '#c2452d', '#3f6fd8', '#8a6d1f', '#7a3fa8',
+  '#1f8fb8', '#a83f3f', '#4f8f2e', '#b84fd8',
+];
+const assignedWedgeColors = new Map<string, string>();
+export function wedgeGenreColor(label: string): string {
+  const key = label.toUpperCase();
+  if (WEDGE_COLORS[key]) return WEDGE_COLORS[key];
+  const got = assignedWedgeColors.get(key);
+  if (got) return got;
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) hash = ((hash << 5) - hash + key.charCodeAt(i)) | 0;
+  const taken = new Set([...Object.values(WEDGE_COLORS), ...assignedWedgeColors.values()]);
+  let pick = WEDGE_PALETTE[Math.abs(hash) % WEDGE_PALETTE.length];
+  for (let probe = 0; probe < WEDGE_PALETTE.length && taken.has(pick); probe++) {
+    pick = WEDGE_PALETTE[(Math.abs(hash) + probe + 1) % WEDGE_PALETTE.length];
+  }
+  assignedWedgeColors.set(key, pick);
+  return pick;
+}
+
+// ── Painter ────────────────────────────────────────────────────────────────
+
+const CANVAS_W = 1600;
+
+/**
+ * One sloped face: family-orange field edge to edge, navy nameplate + white
+ * keyline + genre caps. `mirror` paints the physically-correct second side
+ * (layout mirrored so it lands on the same body, glyphs kept readable).
+ */
+function paintFace(canvas: HTMLCanvasElement, label: string, mirror: boolean): void {
+  const S = SPEC;
+  const family = wedgeGenreColor(label);
+  const ctx = canvas.getContext('2d')!;
+  const W = canvas.width, H = canvas.height;
+
+  ctx.save();
+  ctx.fillStyle = family;
+  ctx.fillRect(0, 0, W, H);
+
+  // The face is the SLANT side of the equilateral wedge: its height is
+  // s = h·2/√3, so plate fractions of h scale by √3/2 on the face.
+  const hPx = H * (SQRT3 / 2);
+
+  if (mirror) {
+    ctx.translate(W, 0);
+    ctx.scale(-1, 1);
+  }
+  const ph = S.plateHFrac * hPx;
+  const pw = ph * S.plateAspect;
+  const pr = S.plateCornerR * ph;
+  ctx.translate(W / 2 + S.plateDXFrac * hPx, H / 2);
+  ctx.rotate(rad(S.plateTiltDeg)); // canvas y-down: -2.4° lifts the right end
+  ctx.fillStyle = S.navy;
+  ctx.beginPath();
+  ctx.roundRect(-pw / 2, -ph / 2, pw, ph, pr);
+  ctx.fill();
+  ctx.strokeStyle = '#ffffff';
+  ctx.lineWidth = S.keyStroke * ph;
+  const ki = S.keyInset * ph;
+  ctx.beginPath();
+  ctx.roundRect(-pw / 2 + ki, -ph / 2 + ki, pw - 2 * ki, ph - 2 * ki, Math.max(4, pr - ki));
+  ctx.stroke();
+
+  if (mirror) ctx.scale(-1, 1); // un-mirror the glyphs only
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  // Sign-shop fit: hold the visible cap height, condense to fit the plate.
+  let size = Math.round((ph * S.capHeightFrac) / 0.72);
+  const setFont = () => { ctx.font = `italic 900 ${size}px ${BB_ARCHIVO_BLACK}, sans-serif`; };
+  setFont();
+  const maxW = pw * S.textWidthFrac;
+  let squeeze = Math.min(1, maxW / ctx.measureText(label).width);
+  if (squeeze < 0.6) {
+    size = Math.max(40, Math.floor(size * (squeeze / 0.6)));
+    setFont();
+    squeeze = Math.min(1, maxW / ctx.measureText(label).width);
+  }
+  ctx.scale(squeeze, 1);
+  ctx.fillStyle = '#ffffff';
+  ctx.fillText(label, 0, ph * 0.03);
+  ctx.restore();
+
+  // Lit-from-within VIGNETTE (owner, 2026-08-09): the face doubles as the
+  // emissive map, so darkening the edges makes the glow bloom from the
+  // center like a lightbox.
+  const g = ctx.createRadialGradient(W / 2, H / 2, H * 0.25, W / 2, H / 2, W * 0.62);
+  g.addColorStop(0, 'rgba(0,0,0,0)');
+  g.addColorStop(0.72, 'rgba(0,0,0,0.10)');
+  g.addColorStop(1, `rgba(0,0,0,${SPEC.vignette})`);
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, W, H);
+}
+
+function toTex(canvas: HTMLCanvasElement): THREE.CanvasTexture {
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.minFilter = THREE.LinearMipmapLinearFilter;
+  tex.magFilter = THREE.LinearFilter;
+  tex.generateMipmaps = true;
+  tex.anisotropy = 16;
+  return tex;
+}
+
+/**
+ * Paint the wedge face art. Returns the FRONT texture with the family color
+ * stashed on `userData.bb93Family` (the builder colors the end caps with
+ * it); the mirrored BACK twin is registered so the user-art swap and
+ * disposal paths in fixtures/signage.ts keep working unchanged.
+ *
+ * `faceAspect` is the catalog's w:h (h = the sign's VERTICAL height); the
+ * canvas is cut to the slant face's true aspect w:s.
+ */
+export function createCategoryPlate1993Texture(label: string, faceAspect = 2.48): THREE.Texture {
+  const slantAspect = faceAspect * (SQRT3 / 2);
+  const mk = (mirror: boolean) => {
+    const c = document.createElement('canvas');
+    c.width = CANVAS_W;
+    c.height = Math.round(CANVAS_W / slantAspect / 8) * 8;
+    paintFace(c, label.toUpperCase(), mirror);
+    return c;
+  };
+  const front = toTex(mk(false));
+  front.userData.bb93Family = wedgeGenreColor(label.toUpperCase());
+  registerBackTexture(front, toTex(mk(true)));
+  return front;
+}
+
+// ── Geometry ───────────────────────────────────────────────────────────────
+
+/**
+ * Build the solid equilateral wedge. `w` = width along the aisle, `h` = the
+ * sign's vertical height (the triangle's height; top depth s = 2h/√3). The
+ * caller positions the group in x/z and sets rotation.y = slot yaw.
+ */
+export function buildCategoryPlate1993(
+  texture: THREE.Texture,
+  w: number,
+  h: number,
+  ceilingY: number,
+): THREE.Group {
+  const backTex = getBackTexture(texture); // the registered mirrored twin
+  const group = new THREE.Group();
+  const family: string = texture.userData?.bb93Family ?? '#1f6fc4';
+
+  const s = (2 * h) / SQRT3;      // top depth = slant length (equilateral)
+  const zTop = s / 2;
+  const DROP = 0.18;              // ft between ceiling and the flat top
+  const yTop = ceilingY - DROP;
+  const yApex = yTop - h;
+
+  // DoubleSide: the body must read SOLID from every angle — a culled end
+  // cap reads as a hole straight through the sign (owner report). Emissive
+  // terms make the whole body read lit from within; the faces use their own
+  // art as the emissive map so the painted vignette shapes the glow.
+  const solidMat = new THREE.MeshStandardMaterial({
+    color: family, roughness: 0.6, metalness: 0.0, side: THREE.DoubleSide,
+    emissive: new THREE.Color(family), emissiveIntensity: 0.30,
+  });
+  const faceMat = (tex: THREE.Texture) =>
+    new THREE.MeshStandardMaterial({
+      map: tex, roughness: 0.6, metalness: 0.0,
+      emissive: new THREE.Color('#ffffff'), emissiveMap: tex, emissiveIntensity: 0.55,
+    });
+
+  // Sloped faces: front (+z at top) and back, meeting at the bottom edge.
+  // Simple quads; UV v=0 at the bottom edge, v=1 at the top.
+  const mkFace = (side: 1 | -1, tex: THREE.Texture) => {
+    const geo = new THREE.BufferGeometry();
+    const x0 = -w / 2, x1 = w / 2;
+    // Corners: bottom edge (apex line) then top edge, wound to face outward.
+    const pos = side === 1
+      ? [x0, yApex, 0, x1, yApex, 0, x1, yTop, zTop, x0, yApex, 0, x1, yTop, zTop, x0, yTop, zTop]
+      : [x1, yApex, 0, x0, yApex, 0, x0, yTop, -zTop, x1, yApex, 0, x0, yTop, -zTop, x1, yTop, -zTop];
+    // U runs left→right as seen by THAT side's viewer; the back texture is
+    // the mirrored-layout repaint, so both sides read forward.
+    const uv = [0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1];
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
+    geo.setAttribute('uv', new THREE.Float32BufferAttribute(uv, 2));
+    geo.computeVertexNormals();
+    const mesh = new THREE.Mesh(geo, faceMat(tex));
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    return mesh;
+  };
+  group.add(mkFace(1, texture));
+  group.add(mkFace(-1, backTex));
+
+  // Flat top (family color — mostly hidden under the mount).
+  const top = new THREE.Mesh(new THREE.BoxGeometry(w, 0.012, s), solidMat);
+  top.position.set(0, yTop - 0.006, 0);
+  top.receiveShadow = true;
+  group.add(top);
+
+  // Triangular end caps in the SAME family color (owner: never black).
+  for (const sx of [-1, 1] as const) {
+    const geo = new THREE.BufferGeometry();
+    const x = sx * (w / 2);
+    // Wound so the normal points outward (+x on the right end); the
+    // material is DoubleSide regardless so neither end can ever cull into
+    // a see-through hole.
+    const pos = sx === 1
+      ? [x, yTop, -zTop, x, yTop, zTop, x, yApex, 0]
+      : [x, yTop, zTop, x, yTop, -zTop, x, yApex, 0];
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
+    geo.computeVertexNormals();
+    const cap = new THREE.Mesh(geo, solidMat);
+    cap.castShadow = true;
+    cap.receiveShadow = true;
+    group.add(cap);
+  }
+
+  // Near-black TRIM along EVERY corner edge, including the top (owner,
+  // 2026-08-09): bottom keel, the top face's four edges, and the four
+  // sloped side edges — 9 thin square-section rails half-embedded on the
+  // edge lines, so the border reads from any angle.
+  const T = SPEC.trimT;
+  const trimMat = new THREE.MeshStandardMaterial({ color: SPEC.trimColor, roughness: 0.55, metalness: 0.1 });
+  const rail = (bw: number, bh: number, bd: number, x: number, y: number, z: number, rx = 0) => {
+    const r = new THREE.Mesh(new THREE.BoxGeometry(bw, bh, bd), trimMat);
+    r.position.set(x, y, z);
+    if (rx) r.rotation.x = rx;
+    r.receiveShadow = true;
+    group.add(r);
+  };
+  rail(w + T, T, T, 0, yApex, 0);                    // bottom keel
+  rail(w + T, T, T, 0, yTop, zTop);                  // top front
+  rail(w + T, T, T, 0, yTop, -zTop);                 // top back
+  rail(T, T, s + T, w / 2, yTop, 0);                 // top right
+  rail(T, T, s + T, -w / 2, yTop, 0);                // top left
+  const slopeTilt = Math.atan2(zTop, h);             // 30° for the equilateral ∇
+  for (const sx of [-1, 1]) for (const sz of [-1, 1]) {
+    rail(T, s + T, T, sx * (w / 2), (yTop + yApex) / 2, sz * (zTop / 2), sz * slopeTilt);
+  }
+
+  // Mount per feedback/049: a short bar on the ceiling, two rigid drops.
+  const mountMat = new THREE.MeshStandardMaterial({ color: 0x2a2a2e, roughness: 0.5, metalness: 0.35 });
+  const bar = new THREE.Mesh(new THREE.BoxGeometry(w * 0.55, 0.045, Math.min(0.18, s * 0.25)), mountMat);
+  bar.position.y = ceilingY - 0.0225;
+  bar.receiveShadow = true;
+  group.add(bar);
+  for (const sx of [-1, 1]) {
+    const strap = new THREE.Mesh(new THREE.BoxGeometry(0.035, DROP + 0.02, 0.035), mountMat);
+    strap.position.set(sx * w * 0.24, ceilingY - 0.045 - (DROP + 0.02) / 2 + 0.02, 0);
+    strap.receiveShadow = true;
+    group.add(strap);
+  }
+  return group;
+}

--- a/src/fixtures/sign-fixtures.ts
+++ b/src/fixtures/sign-fixtures.ts
@@ -10,6 +10,14 @@ export function peekBackTexture(tex: THREE.Texture): THREE.Texture | undefined {
   return backTextureCache.get(tex);
 }
 
+// Pre-seed a texture's back twin with something other than the plain flip —
+// e.g. the 1993 category plate's mirrored-LAYOUT side 2, which keeps the
+// die-cut silhouette in place while its glyphs still read forward from
+// behind. Must run before anyone calls getBackTexture(tex).
+export function registerBackTexture(tex: THREE.Texture, back: THREE.Texture): void {
+  backTextureCache.set(tex, back);
+}
+
 // Helper to copy the canvas and create a distinct texture flipped horizontally for readable double-sided signs
 export function getBackTexture(tex: THREE.Texture): THREE.Texture {
   if (backTextureCache.has(tex)) {

--- a/src/fixtures/signage.ts
+++ b/src/fixtures/signage.ts
@@ -6,6 +6,7 @@ import {
   isKnownSignageSlotId,
   validateSignageConfig
 } from '../signage-config';
+import { buildCategoryPlate1993 } from './category-plate-1993';
 import {
   acrylicTentSign,
   ceilingHangingSign,
@@ -387,15 +388,14 @@ export function buildSignage(ctx: FixtureContext, slots: SignSlot[], activeSigna
         fixtureMesh = acrylicTentSign(texture, w, h);
         break;
       case 'ceiling-hanging': {
-        // bb-90s ceiling GENRE panels are die-cut ribbon banners (arrowhead
-        // end, diamond accent, family colors — painted into the texture by
-        // createCategorySignTexture). Promo hangers and other themes stay
-        // rectangular framed boxes.
+        // 1993 ceiling-nav category plates are SOLID rounded die-cut bodies
+        // (fixtures/category-plate-1993.ts — owner rulings feedback/049 +
+        // 2026-08-09). Promo hangers and other themes stay rectangular
+        // framed boxes.
         const nav93 = bb93SignageOn() && slot.category === 'ceiling-nav';
-        fixtureMesh = ceilingHangingSign(
-          texture, w, h, slot.ceilingY ?? 13.5, slot.pos.y,
-          nav93 ? { dieCut: true } : {}
-        );
+        fixtureMesh = nav93
+          ? buildCategoryPlate1993(texture, w, h, slot.ceilingY ?? 13.5)
+          : ceilingHangingSign(texture, w, h, slot.ceilingY ?? 13.5, slot.pos.y);
         break;
       }
       case 'shelf-topper':

--- a/src/genre-colors.ts
+++ b/src/genre-colors.ts
@@ -17,7 +17,10 @@ export const BB93_FAMILY_COLORS: Record<string, string> = {
   'GENERAL': '#1f6fc4',
   'SCI-FI & FANTASY': '#5b4ba0',
   'HORROR': '#5b4ba0',
-  'ACTION': '#5b4ba0',
+  // ACTION is directly attested MAGENTA on the 1993 ceiling plate
+  // (HFNfVDQdMxs f0016, "a magenta/red rounded plate"), not the sci-fi
+  // purple it was previously grouped with.
+  'ACTION': '#c13066',
   'SPECIAL INTEREST': '#b03a2e',
 };
 

--- a/src/jellyfin.ts
+++ b/src/jellyfin.ts
@@ -948,6 +948,112 @@ async function applyCollectionMembership(
   }
 }
 
+/**
+ * The user's video-capable views: one Views call + the non-video blocklist,
+ * shared by the full catalog sync below and the names-only listing the
+ * first-run setup terminal shows (#41).
+ *
+ * The filter is a BLOCKLIST on purpose: mixed movies-and-shows libraries have
+ * reported their CollectionType as "mixed", "unknown", "folders", or nothing
+ * at all depending on server version, so allowlisting known values kept
+ * dropping them (the "my mixed library never shows up" bug). Anything not
+ * explicitly non-video is synced — an empty or non-video generic view
+ * returns 0 Movie/Series/Video items in the item fetch and is discarded
+ * harmlessly. Blocked: music, books, photos, playlists, livetv, trailers,
+ * and boxsets (collections only duplicate items already synced from their
+ * home libraries; membership is tagged via applyCollectionMembership).
+ * Grouped-folder views report Type "UserView" rather than
+ * "CollectionFolder", so both container types are accepted.
+ */
+async function fetchVideoViews(url: string, token: string, userId: string): Promise<any[]> {
+  const viewsResponseStr = await jellyfinRequest(
+    "GET",
+    `${url}/emby/Users/${userId}/Views`,
+    undefined,
+    token
+  );
+
+  let viewsData;
+  try {
+    viewsData = JSON.parse(viewsResponseStr);
+  } catch (e) {
+    throw new Error(viewsResponseStr || "Jellyfin views API returned invalid response.");
+  }
+
+  const viewItems = viewsData.Items || [];
+  const NON_VIDEO_COLLECTION_TYPES = new Set([
+    "music", "books", "photos", "playlists", "livetv", "trailers", "boxsets",
+  ]);
+  return viewItems.filter((v: any) => {
+    const keep =
+      (v.Type === "CollectionFolder" || v.Type === "UserView") &&
+      !NON_VIDEO_COLLECTION_TYPES.has(String(v.CollectionType ?? "").toLowerCase());
+    // Always log the verdict per view — "why is my library missing?" should
+    // be answerable from the console without a debugger.
+    console.info(
+      `[Jellyfin] View "${v.Name}" (Type=${v.Type}, CollectionType=${v.CollectionType ?? "none"}): ${keep ? "syncing" : "skipped (non-video)"}`
+    );
+    return keep;
+  });
+}
+
+export interface LibrarySummary {
+  id: string;
+  name: string;
+}
+
+const KNOWN_LIBS_KEY = 'bb_known_libraries';
+
+/**
+ * Remember the server's FULL video-library list (id + name) whenever a fetch
+ * sees it — the fetchers above/below are the only places that ever see the
+ * complete list, exclusions and all. localStorage-persisted so the Store
+ * Libraries settings page can offer EXCLUDED libraries for re-enabling on
+ * every later boot (#41): an excluded library is absent from the synced
+ * catalog by design, so the catalog alone can never list it again.
+ */
+function rememberKnownLibraries(libs: ReadonlyArray<LibrarySummary>): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(KNOWN_LIBS_KEY, JSON.stringify(libs.map((l) => ({ id: l.id, name: l.name }))));
+  } catch { /* quota — the drawer just misses excluded rows until next boot */ }
+}
+
+/** The last-remembered full server library list ([] before any real fetch). */
+export function knownServerLibraries(): LibrarySummary[] {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(KNOWN_LIBS_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed)
+      ? parsed.filter((l) => l && typeof l.id === 'string' && typeof l.name === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Names-only library listing for the first-run setup terminal (#41): one
+ * Views call, no item sync, so the checkbox screen can appear the moment a
+ * member signs in — the expensive per-library item fetch then runs only for
+ * the libraries the store actually carries.
+ */
+export async function fetchLibraryList(
+  jellyfinUrl: string,
+  token: string,
+  userId: string
+): Promise<LibrarySummary[]> {
+  if (!token || !jellyfinUrl || !userId) {
+    throw new Error("Missing connection credentials.");
+  }
+  const url = jellyfinUrl.replace(/\/$/, "");
+  const views = await fetchVideoViews(url, token, userId);
+  const list = views.map((v: any) => ({ id: String(v.Id), name: String(v.Name) }));
+  rememberKnownLibraries(list);
+  return list;
+}
+
 export async function fetchJellyfinLibrariesAndMovies(
   jellyfinUrl: string,
   token: string,
@@ -956,7 +1062,15 @@ export async function fetchJellyfinLibrariesAndMovies(
   // a big library legitimately takes minutes, so a caller must be able to tell
   // "still working" from "server is gone" without a wall-clock deadline that
   // a large enough catalog can never beat.
-  onProgress?: (stage: string) => void
+  onProgress?: (stage: string) => void,
+  opts?: {
+    /**
+     * Library ids this store does NOT carry (#41): their item sync is skipped
+     * entirely, not fetched-and-hidden. Sourced from the Store Libraries
+     * toggles (Settings → Connection / the setup terminal's checkbox rows).
+     */
+    excludeLibraryIds?: ReadonlySet<string>;
+  }
 ): Promise<JellyfinLibrary[]> {
   if (!token || !jellyfinUrl || !userId) {
     throw new Error("Missing connection credentials.");
@@ -967,47 +1081,22 @@ export async function fetchJellyfinLibrariesAndMovies(
 
   if (onProgress) pageProgressTick = () => onProgress('page');
   try {
-    const viewsResponseStr = await jellyfinRequest(
-      "GET",
-      `${url}/emby/Users/${userId}/Views`,
-      undefined,
-      token
-    );
-
-    let viewsData;
-    try {
-      viewsData = JSON.parse(viewsResponseStr);
-    } catch (e) {
-      throw new Error(viewsResponseStr || "Jellyfin views API returned invalid response.");
-    }
-
-    const viewItems = viewsData.Items || [];
-    // Pick the views that can hold shelf-able video. This is a BLOCKLIST on
-    // purpose: mixed movies-and-shows libraries have reported their
-    // CollectionType as "mixed", "unknown", "folders", or nothing at all
-    // depending on server version, so allowlisting known values kept dropping
-    // them (the "my mixed library never shows up" bug). Anything not
-    // explicitly non-video is synced — an empty or non-video generic view
-    // returns 0 Movie/Series/Video items below and is discarded harmlessly.
-    // Blocked: music, books, photos, playlists, livetv, trailers, and boxsets
-    // (collections only duplicate items already synced from their home
-    // libraries; membership is tagged via applyCollectionMembership).
-    // Grouped-folder views report Type "UserView" rather than
-    // "CollectionFolder", so both container types are accepted.
-    const NON_VIDEO_COLLECTION_TYPES = new Set([
-      "music", "books", "photos", "playlists", "livetv", "trailers", "boxsets",
-    ]);
-    const movieLibraries = viewItems.filter((v: any) => {
-      const keep =
-        (v.Type === "CollectionFolder" || v.Type === "UserView") &&
-        !NON_VIDEO_COLLECTION_TYPES.has(String(v.CollectionType ?? "").toLowerCase());
-      // Always log the verdict per view — "why is my library missing?" should
-      // be answerable from the console without a debugger.
-      console.info(
-        `[Jellyfin] View "${v.Name}" (Type=${v.Type}, CollectionType=${v.CollectionType ?? "none"}): ${keep ? "syncing" : "skipped (non-video)"}`
-      );
-      return keep;
-    });
+    const allVideoViews = await fetchVideoViews(url, token, userId);
+    // The full pre-exclusion list is remembered so the Store Libraries page
+    // can keep offering excluded libraries for re-enabling (#41).
+    rememberKnownLibraries(allVideoViews.map((v: any) => ({ id: String(v.Id), name: String(v.Name) })));
+    const excluded = opts?.excludeLibraryIds;
+    const movieLibraries = excluded?.size
+      ? allVideoViews.filter((v: any) => {
+          const skip = excluded.has(String(v.Id));
+          if (skip) {
+            console.info(
+              `[Jellyfin] View "${v.Name}": skipped (not carried by this store — Settings → Connection → Store Libraries)`
+            );
+          }
+          return !skip;
+        })
+      : allVideoViews;
 
     const librariesList: JellyfinLibrary[] = [];
 

--- a/src/library-settings.ts
+++ b/src/library-settings.ts
@@ -1,0 +1,111 @@
+// Per-library settings, registered DYNAMICALLY once a catalog is known —
+// unlike every static row in settings.ts, these can't exist until a server
+// (or the demo) has told us what libraries there are. Two families share the
+// mechanism:
+//
+//  - STORE LIBRARIES (#41, Settings → Connection → Store Libraries): which
+//    libraries this store carries as aisles. Default ON; switching one off
+//    skips its item sync entirely on the next boot (see excludeLibraryIds in
+//    fetchJellyfinLibrariesAndMovies). First set on the opening-day setup
+//    terminal's checkbox screen; editable from the drawer after. These rows
+//    register from the REMEMBERED full server list (below), not the loaded
+//    catalog — an excluded library is absent from the catalog by design, and
+//    its row must survive so it can be switched back on.
+//
+//  - OVERHEAD TVS (#39, Settings → Playback → Overhead TVs): which libraries
+//    feed the ceiling CRTs' playback pool (ambient-tvs.ts). Default OFF for
+//    every row — none selected means the family-genre heuristic keeps picking,
+//    so existing stores don't change behavior. These rows register from the
+//    CURRENT catalog (a pool can only draw from stock that's actually in the
+//    store — and in the demo that's the demo libraries).
+//
+// Value reads go through raw localStorage scans rather than getSetting():
+// the carried-set is needed at sync time, BEFORE any registration has run on
+// a fresh boot, and the TV pool is read inside the harness-booted scene where
+// main.ts never registers anything. Keys are stable per library id, so a
+// choice survives re-syncs and member switches.
+import { registerSetting } from './settings';
+import { knownServerLibraries } from './jellyfin';
+import type { LibrarySummary } from './jellyfin';
+
+export const CARRY_LIB_PREFIX = 'bb_carrylib_';
+export const TV_LIB_PREFIX = 'bb_tvlib_';
+
+// What each family's visibleWhen closures consult — reassigned on every
+// registration pass, so rows for libraries that disappeared (deleted on the
+// server, or a different server entirely) drop out of the drawer without any
+// registry surgery. Their localStorage keys stay behind harmlessly.
+let carryIds = new Set<string>();
+let tvIds = new Set<string>();
+
+/**
+ * (Re)register both toggle families. `catalogLibs` is the loaded catalog
+ * (real or demo) driving the Overhead TVs rows; the Store Libraries rows come
+ * from the remembered full server list (jellyfin.ts knownServerLibraries —
+ * the only view that still contains EXCLUDED libraries), falling back to the
+ * catalog when nothing is remembered yet (pre-#41 stores that have never run
+ * the setup terminal, and the demo).
+ */
+export function registerLibraryToggles(catalogLibs: ReadonlyArray<LibrarySummary>): void {
+  const remembered = knownServerLibraries();
+  const carryLibs = remembered.length > 0 ? remembered : catalogLibs;
+
+  carryIds = new Set(carryLibs.map((l) => l.id));
+  for (const lib of carryLibs) {
+    const id = lib.id;
+    registerSetting({
+      key: `${CARRY_LIB_PREFIX}${id}`,
+      label: lib.name,
+      kind: 'toggle',
+      group: 'Connection',
+      subpage: 'Store Libraries',
+      default: true,
+      applyMode: 'reload',
+      hint: 'OFF = this store does not carry the library; its sync is skipped.',
+      visibleWhen: () => carryIds.has(id),
+    });
+  }
+
+  tvIds = new Set(catalogLibs.map((l) => l.id));
+  for (const lib of catalogLibs) {
+    const id = lib.id;
+    registerSetting({
+      key: `${TV_LIB_PREFIX}${id}`,
+      label: lib.name,
+      kind: 'toggle',
+      group: 'Playback',
+      subpage: 'Overhead TVs',
+      default: false,
+      applyMode: 'rebuild-scene',
+      hint: 'Feed the ceiling TVs from this library. All OFF = family picks.',
+      visibleWhen: () => tvIds.has(id),
+    });
+  }
+}
+
+function scanPrefix(prefix: string, wanted: '0' | '1'): Set<string> {
+  const out = new Set<string>();
+  if (typeof localStorage === 'undefined') return out;
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(prefix) && localStorage.getItem(key) === wanted) {
+      out.add(key.slice(prefix.length));
+    }
+  }
+  return out;
+}
+
+/** Library ids this store does NOT carry (absent key = carried, the default). */
+export function excludedLibraryIds(): Set<string> {
+  return scanPrefix(CARRY_LIB_PREFIX, '0');
+}
+
+/** Library ids explicitly selected to feed the overhead TVs (none = heuristic). */
+export function tvPoolLibraryIds(): Set<string> {
+  return scanPrefix(TV_LIB_PREFIX, '1');
+}
+
+/** Persist one carried-library choice (the setup terminal's checkbox rows). */
+export function setLibraryCarried(id: string, carried: boolean): void {
+  localStorage.setItem(`${CARRY_LIB_PREFIX}${id}`, carried ? '1' : '0');
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -721,7 +721,9 @@ function updateHUDForMode(mode: string) {
       text = 'OK TO BROWSE THIS SECTION  •  BACK TO EXIT';
       break;
     case 'overview':
-      text = 'ARROWS TO LOOK  •  OK TO FLY TO A SHELF  •  BACK FOR SECTIONS';
+      // The jump index IS this view (store-subnav.ts) — say what its four
+      // directions do, since there is no free-look here to advertise any more.
+      text = '◀ ▶ PICK A SECTION  •  ▼ THE DISPLAYS  •  ▲ THE TVs  •  OK TO GO';
       break;
     case 'genre-select':
       // Genre picker is its own full overlay with its own chrome.

--- a/src/main.ts
+++ b/src/main.ts
@@ -3835,9 +3835,14 @@ async function main() {
       }
     },
     onToggleWalkAround: () => {
-      if (!ui.isPlaybackActive && !ui.isScreensaverActive && !ui.isLoginOpen && !ui.isExitConfirmOpen) {
-        storeScene?.toggleWalkAround();
-      }
+      // Whatever owns the keyboard also owns the camera. This used to check
+      // only playback/screensaver/login/exit-confirm, so F walked away from a
+      // docked CRT — and on opening day that was unrecoverable: NEW STORE
+      // SETUP still swallowed every key (ui.isSetupOpen), while nothing left
+      // could bring the camera back to the terminal. Same trap at the manager
+      // terminal. isAnyOverlayOpen covers all of them, plus the old four.
+      if (ui.isAnyOverlayOpen || ui.isPlaybackActive || ui.isScreensaverActive) return;
+      storeScene?.toggleWalkAround();
     },
     // T22: carry-mode shortcuts. Both are guarded no-ops with the 'Carry &
     // checkout' toggle off (or while any overlay owns the keyboard).

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,11 +15,8 @@ measureDisplayHz();
 const isTauri = !!(window as any).__TAURI_INTERNALS__;
 function closeApp() { isTauri ? getCurrentWindow().close() : window.close(); }
 import {
-  fetchJellyfinLibrariesAndMovies,
   authenticateUser,
   validateToken,
-  fetchPublicUsers,
-  normalizeUrl,
   Movie,
   JellyfinLibrary,
   fetchFirstEpisodeOfSeries,
@@ -51,12 +48,18 @@ import {
 } from './jellyseerr';
 import { fetchGames, launchGame } from './romm';
 import { isGamesOnly, storeCatalog } from './games-only';
+import { isMembershipPickerOpen } from './membership-cards';
 import {
-  openMembershipCardPicker,
-  closeMembershipCardPicker,
-  isMembershipPickerOpen,
-  type MembershipLoginSession,
-} from './membership-cards';
+  initBootFlow,
+  showLoginOverlay,
+  showBootOverlay,
+  hideBootOverlay,
+  showLoginOrCards,
+  switchMember,
+  startDemoAndLoad,
+  checkCredentialsAndLoad,
+  setupLoginHandlers,
+} from './boot-flow';
 import { getActiveTheme, applyThemeCssVars, THEMES, resolveThemeId } from './themes';
 import {
   activeMediaCutoff,
@@ -108,7 +111,7 @@ import type { CandyRow } from './fixtures/period-fixtures';
 import { getCandyDeliveryAdapter } from './candy-delivery';
 import { isDemoMode } from './demo-mode';
 import { startScreensaverAnimation, stopScreensaverAnimation } from './screensaver';
-import { buildDemoLibraries, buildDemoDiscovery, buildDemoGames, makeSyntheticEpisodes, demoPoster } from './demo-library';
+import { buildDemoDiscovery, makeSyntheticEpisodes, demoPoster } from './demo-library';
 import { EMPTY_STAFF_PICKS, loadStaffPicks, StaffPicks } from './staff-picks-loader';
 import { titleMatchKeys } from './staff-picks';
 import {
@@ -1629,89 +1632,6 @@ async function finishConnectionEditsAndReload() {
   setTimeout(() => location.reload(), 400);
 }
 
-// ─── Login Overlay ────────────────────────────────────────────────────────────
-
-function showLoginOverlay() {
-  if (isDemoMode) return; // the demo never logs in
-  closeMembershipCardPicker(); // defensive: idempotent if it wasn't open
-  ui.isLoginOpen = true;
-  const overlay = document.getElementById('login-overlay');
-  if (overlay) {
-    overlay.classList.add('visible');
-    
-    const envUrl = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_URL : undefined;
-    const savedUrl = localStorage.getItem('jellyfin_url') || envUrl;
-    if (savedUrl) {
-      const urlInput = document.getElementById('login-url') as HTMLInputElement;
-      if (urlInput) urlInput.value = savedUrl;
-    }
-
-    const envUser = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_USERNAME : undefined;
-    const savedUsername = localStorage.getItem('jellyfin_username') || envUser;
-    const userInput = document.getElementById('login-user') as HTMLInputElement;
-    if (userInput) {
-      if (savedUsername) userInput.value = savedUsername;
-      userInput.focus();
-    }
-
-    const envPass = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_PASSWORD : undefined;
-    const passInput = document.getElementById('login-pass') as HTMLInputElement;
-    if (passInput && envPass) {
-      passInput.value = envPass;
-    }
-
-    // Jellyseerr (optional) -- same persistence mechanism as the Jellyfin
-    // fields above, just two extra fields that stay blank when unused.
-    const envJellyseerrUrl = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYSEERR_URL : undefined;
-    const savedJellyseerrUrl = localStorage.getItem('jellyseerr_url') || envJellyseerrUrl;
-    const jellyseerrUrlInput = document.getElementById('login-jellyseerr-url') as HTMLInputElement;
-    if (jellyseerrUrlInput) jellyseerrUrlInput.value = savedJellyseerrUrl || '';
-
-    const envJellyseerrKey = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYSEERR_APIKEY : undefined;
-    const savedJellyseerrKey = localStorage.getItem('jellyseerr_apikey') || envJellyseerrKey;
-    const jellyseerrKeyInput = document.getElementById('login-jellyseerr-key') as HTMLInputElement;
-    if (jellyseerrKeyInput) jellyseerrKeyInput.value = savedJellyseerrKey || '';
-
-    // T18: Romm (optional) -- same prefill treatment as Jellyseerr. Column
-    // stays hidden (values still prefilled, just not shown) unless the Video
-    // Games section is switched on in Settings, so opting in still requires a
-    // deliberate settings-drawer toggle before Romm creds are even offered.
-    const envRommUrl = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_ROMM_URL : undefined;
-    const envRommKey = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_ROMM_APIKEY : undefined;
-    const rommUrlInput = document.getElementById('login-romm-url') as HTMLInputElement | null;
-    if (rommUrlInput) rommUrlInput.value = localStorage.getItem('romm_url') || envRommUrl || '';
-    const rommKeyInput = document.getElementById('login-romm-key') as HTMLInputElement | null;
-    if (rommKeyInput) rommKeyInput.value = localStorage.getItem('romm_apikey') || envRommKey || '';
-    const rommColumn = document.getElementById('login-romm-column');
-    if (rommColumn) rommColumn.style.display = getSetting<boolean>('bb_games_enabled') ? '' : 'none';
-  }
-}
-
-function hideLoginOverlay() {
-  ui.isLoginOpen = false;
-  const overlay = document.getElementById('login-overlay');
-  if (overlay) {
-    overlay.classList.remove('visible');
-  }
-}
-
-function hideBootOverlay() {
-  const overlay = document.getElementById('boot-overlay');
-  if (overlay) {
-    overlay.classList.remove('visible');
-  }
-}
-
-// Re-shown after a manual login (the boot overlay is only up by default on the
-// very first paint) so the scene has somewhere opaque to load behind while its
-// textures stream in.
-function showBootOverlay() {
-  const overlay = document.getElementById('boot-overlay');
-  if (overlay) {
-    overlay.classList.add('visible');
-  }
-}
-
 // ─── Feedback Pin (F8) ────────────────────────────────────────────────────────
 // Lets a user who can't read code flag a visual bug in place: F8 grabs the
 // exact camera pose + a screenshot via StoreScene.captureFeedbackSnapshot()
@@ -2783,419 +2703,10 @@ async function waitForFontsAndInit() {
 }
 
 // ─── Credentials / Boot ───────────────────────────────────────────────────────
+// The whole boot/credentials flow lives in boot-flow.ts (extracted at the
+// line-budget ceiling, #41 prerequisite); main.ts hands it state setters and
+// loaders through initBootFlow() inside main() below.
 
-/**
- * Shared "we're authenticated, now go load the store" tail used by both the
- * classic login form and the membership card picker (T17). Never stores a
- * password -- only the resulting session token/userid.
- */
-async function finishLoginAndLaunch(urlInput: string, session: MembershipLoginSession) {
-  logToConsole(`[System] Authenticated successfully as ${session.userName}.`, 'system');
-  localStorage.setItem('jellyfin_url', urlInput);
-  localStorage.setItem('jellyfin_token', session.accessToken);
-  localStorage.setItem('jellyfin_userid', session.userId);
-  localStorage.setItem('jellyfin_last_userid', session.userId); // remembered for next boot's card highlight
-
-  logToConsole('[System] Downloading movie libraries and catalog metadata...', 'system');
-  // Stall watchdog, not a deadline — see the auto-login path for why a fixed
-  // cap on total sync duration is unsurvivable for a large enough library.
-  const LOGIN_STALL_MS = 45_000;
-  let loginStallTimer: ReturnType<typeof setTimeout> | null = null;
-  let onLoginStall: (() => void) | null = null;
-  const armLoginStall = () => {
-    if (loginStallTimer) clearTimeout(loginStallTimer);
-    loginStallTimer = setTimeout(() => onLoginStall?.(), LOGIN_STALL_MS);
-  };
-  const loginTimeout = new Promise<never>((_, reject) => {
-    onLoginStall = () => reject(new Error(`No response from Jellyfin for ${LOGIN_STALL_MS / 1000}s`));
-    armLoginStall();
-  });
-  try {
-    [librariesList] = await Promise.all([
-      Promise.race([
-        fetchJellyfinLibrariesAndMovies(urlInput, session.accessToken, session.userId, armLoginStall),
-        loginTimeout
-      ]),
-      loadComingSoonMovies(),
-      loadDiscoveryMovies(),
-      loadGameMovies()
-    ]);
-  } finally {
-    if (loginStallTimer) clearTimeout(loginStallTimer);
-  }
-  const gapCount = await mergeCollectionGaps(librariesList);
-  const totalMoviesCount = librariesList.reduce((acc, lib) => acc + lib.movies.length, 0);
-
-  logToConsole(`[System] Loaded ${librariesList.length} libraries (${totalMoviesCount} titles total). Launching store...`, 'system');
-  await logJellyseerrStatus(gapCount);
-  if (gameMovies.length > 0) {
-    logToConsole(`[System] Romm: ${gameMovies.length} game(s) loaded for the Video Games section.`, 'system');
-  }
-  hideLoginOverlay();
-  // Bring the boot overlay back up as an opaque loading screen -- it stays
-  // visible (see initializeStoreScene) until every cover texture has loaded.
-  showBootOverlay();
-  waitForFontsAndInit();
-}
-
-/**
- * Boot/re-login entry point (T17): if we know a server URL, try its public
- * user list first and show the fanned membership-card picker; only fall back
- * to the classic single-login form if the server has no saved URL yet, the
- * public user list is disabled, or it comes back empty (single-user server).
- */
-async function showLoginOrCards(reason?: string) {
-  if (isDemoMode) return; // the demo never logs in
-  const savedUrl = localStorage.getItem('jellyfin_url');
-  if (savedUrl) {
-    try {
-      const users = await fetchPublicUsers(savedUrl);
-      if (users.length > 0) {
-        if (reason) logToConsole(`[System] ${reason}`, 'system');
-        logToConsole(`[System] Found ${users.length} membership card(s) on ${savedUrl}.`, 'system');
-        openMembershipCardPicker({
-          serverUrl: savedUrl,
-          users,
-          lastUserId: localStorage.getItem('jellyfin_last_userid'),
-          onLogin: (session) => finishLoginAndLaunch(savedUrl, session),
-          onManualLogin: () => abortBootToLogin(reason),
-          onDemoMode: () => {
-            hideLoginOverlay();
-            closeMembershipCardPicker();
-            showBootOverlay();
-            startDemoAndLoad();
-          },
-          log: (msg) => logToConsole(msg, 'system'),
-        });
-        return;
-      }
-    } catch (e: any) {
-      logToConsole(`[System] Public user list unavailable (${e?.message ?? e}); falling back to login form.`, 'system');
-    }
-  }
-  abortBootToLogin(reason);
-}
-
-/**
- * "Switch Member" affordance (T17), reachable from the settings drawer:
- * tears down the current session/scene (like logging out) but keeps the
- * server URL, then re-shows the membership card picker so another
- * household member can pick their own card without re-typing the server.
- */
-function switchMember() {
-  logToConsole('[System] Switching membership card...', 'system');
-  localStorage.removeItem('jellyfin_token');
-  localStorage.removeItem('jellyfin_userid');
-
-  if (storeScene) {
-    storeScene.destroy();
-    storeScene = null;
-  }
-  if (aisleIndicatorInterval !== null) {
-    clearInterval(aisleIndicatorInterval);
-    aisleIndicatorInterval = null;
-  }
-  updateMovieHUD(null);
-  void showLoginOrCards();
-}
-
-function abortBootToLogin(reason?: string) {
-  hideBootOverlay();
-  showLoginOverlay();
-  if (reason) {
-    const errorMsg = document.getElementById('login-error-msg') as HTMLDivElement;
-    const submitBtn = document.getElementById('btn-login-submit') as HTMLButtonElement;
-    if (submitBtn) { submitBtn.disabled = false; submitBtn.innerText = 'Connect & Sync'; }
-    if (errorMsg) { errorMsg.style.color = 'red'; errorMsg.innerText = reason; }
-  }
-}
-
-/**
- * Demo-mode boot (see src/demo-mode.ts): no credential gate, no Jellyfin
- * fetch, no login overlay ever — stock the store from the synthetic demo
- * library and hand off to the normal texture-gated reveal.
- */
-function startDemoAndLoad() {
-  // First visit defaults to daytime out the windows (the scene otherwise
-  // rolls day/night 50/50 per boot); user-changeable in Store Look after.
-  if (!localStorage.getItem('bb_outside')) localStorage.setItem('bb_outside', 'day');
-  // The games department is off by default (bb_games_enabled, main.ts fetchGames)
-  // because it costs a RomM round-trip nobody asked for. The demo has no RomM and
-  // no round trip — buildDemoGames() is synchronous and local — so that default
-  // was buying nothing here and cost us the whole department: every visitor to
-  // the Pages demo saw a store with no VIDEO GAMES section, which is why the
-  // feature reads as missing to people who have only ever seen the demo. Opt in
-  // on first boot only, so a visitor who switches it off keeps it off.
-  if (!localStorage.getItem('bb_games_enabled')) localStorage.setItem('bb_games_enabled', '1');
-  logToConsole('[System] Demo mode: stocking the store with a placeholder library (no media server).', 'system');
-  librariesList = buildDemoLibraries(900);
-  gameMovies = buildDemoGames(60);
-  waitForFontsAndInit();
-}
-
-async function checkCredentialsAndLoad() {
-  // Security hardening: Purge any stored plaintext password
-  localStorage.removeItem('jellyfin_password');
-
-  const envUrl = (typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_URL : undefined) || '';
-  const envUser = (typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_USERNAME : undefined) || '';
-  const envPass = (typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_PASSWORD : undefined) || '';
-
-  let jellyfinUrl = localStorage.getItem('jellyfin_url') || envUrl;
-  let token = localStorage.getItem('jellyfin_token');
-  let userId = localStorage.getItem('jellyfin_userid');
-
-  // If no saved token/userId, attempt auto-authentication using credentials stored in .env.local / env
-  if ((!token || !userId || !jellyfinUrl) && envUrl && envUser && envPass) {
-    logToConsole('[System] File credentials (.env.local) found. Authenticating automatically...', 'system');
-    try {
-      const session = await authenticateUser(envUrl, envUser, envPass);
-      localStorage.setItem('jellyfin_url', envUrl);
-      localStorage.setItem('jellyfin_username', envUser);
-      localStorage.setItem('jellyfin_token', session.accessToken);
-      localStorage.setItem('jellyfin_userid', session.userId);
-      localStorage.setItem('jellyfin_last_userid', session.userId);
-      jellyfinUrl = envUrl;
-      token = session.accessToken;
-      userId = session.userId;
-      logToConsole(`[System] Auto-authenticated successfully as ${session.userName}.`, 'system');
-
-      if (typeof import.meta.env !== 'undefined') {
-        if (import.meta.env.VITE_JELLYSEERR_URL && import.meta.env.VITE_JELLYSEERR_APIKEY) {
-          localStorage.setItem('jellyseerr_url', import.meta.env.VITE_JELLYSEERR_URL);
-          localStorage.setItem('jellyseerr_apikey', import.meta.env.VITE_JELLYSEERR_APIKEY);
-        }
-        if (import.meta.env.VITE_ROMM_URL && import.meta.env.VITE_ROMM_APIKEY) {
-          localStorage.setItem('romm_url', import.meta.env.VITE_ROMM_URL);
-          localStorage.setItem('romm_apikey', import.meta.env.VITE_ROMM_APIKEY);
-          if (!localStorage.getItem('bb_games_enabled')) {
-            localStorage.setItem('bb_games_enabled', '1');
-          }
-        }
-      }
-    } catch (err: any) {
-      logToConsole(`[System] Auto-authentication from file credentials failed: ${err?.message || err}`, 'system');
-    }
-  }
-
-  let escaped = false;
-  let retryTimeoutId: any = null;
-
-  // Any keypress or click on the boot screen skips auto-connect and goes to login.
-  const bootEscape = (e: Event) => {
-    if (e.type === 'keydown' && (e as KeyboardEvent).key === 'Tab') return; // ignore tab
-    escaped = true;
-    if (retryTimeoutId) {
-      clearTimeout(retryTimeoutId);
-      retryTimeoutId = null;
-    }
-    document.removeEventListener('keydown', bootEscape);
-    document.removeEventListener('click', bootEscape);
-    hideBootOverlay();
-    showLoginOrCards();
-  };
-  document.addEventListener('keydown', bootEscape);
-  document.addEventListener('click', bootEscape);
-
-  if (jellyfinUrl && token && userId) {
-    logToConsole('[System] Saved Jellyfin credentials found. Connecting...', 'system');
-
-    // A STALL timeout, not a deadline. This was a flat 20s cap on the whole
-    // multi-library sync, which a large enough catalog can never beat: the
-    // sync would be killed mid-flight, retried, and killed again forever, so
-    // boot never reached the store and every post-login step (collection
-    // gaps, the Jellyseerr status line, the scene itself) simply never ran.
-    // Sync duration scales with library size and is not a fault; silence is.
-    // The watchdog therefore fires only when the server has sent nothing at
-    // all for this long, and every page resets it.
-    const STALL_MS = 45_000;
-    let currentDelay = 10_000; // starts at 10s
-    const MAX_DELAY = 5 * 60 * 1000; // 5min cap
-
-    const attemptSync = async () => {
-      if (escaped) return;
-
-      const activeToken = localStorage.getItem('jellyfin_token') || token;
-      const activeUserId = localStorage.getItem('jellyfin_userid') || userId;
-
-      let stallTimer: ReturnType<typeof setTimeout> | null = null;
-      let onStall: (() => void) | null = null;
-      const armStall = () => {
-        if (stallTimer) clearTimeout(stallTimer);
-        stallTimer = setTimeout(() => onStall?.(), STALL_MS);
-      };
-      const stallPromise = new Promise<never>((_, reject) => {
-        onStall = () => reject(new Error(`No response from Jellyfin for ${STALL_MS / 1000}s`));
-        armStall();
-      });
-
-      try {
-        [librariesList] = await Promise.all([
-          Promise.race([
-            fetchJellyfinLibrariesAndMovies(jellyfinUrl, activeToken, activeUserId, armStall),
-            stallPromise
-          ]),
-          loadComingSoonMovies(),
-          loadDiscoveryMovies(),
-          loadGameMovies()
-        ]);
-        if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
-
-        if (escaped) return;
-
-        document.removeEventListener('keydown', bootEscape);
-        document.removeEventListener('click', bootEscape);
-        if (retryTimeoutId) {
-          clearTimeout(retryTimeoutId);
-          retryTimeoutId = null;
-        }
-
-        const gapCount = await mergeCollectionGaps(librariesList);
-        const totalMoviesCount = librariesList.reduce((acc, lib) => acc + lib.movies.length, 0);
-        logToConsole(`[System] Connected to Jellyfin. Sync'd ${librariesList.length} libraries (${totalMoviesCount} movies total).`, 'system');
-        await logJellyseerrStatus(gapCount);
-        if (gameMovies.length > 0) {
-          logToConsole(`[System] Romm: ${gameMovies.length} game(s) loaded for the Video Games section.`, 'system');
-        }
-
-        hideLoginOverlay(); // in case user clicked to dismiss boot screen
-        closeMembershipCardPicker();
-        // Boot overlay stays up (see waitForFontsAndInit/initializeStoreScene) until
-        // every cover texture has loaded, so the store is never revealed mid-load.
-        waitForFontsAndInit();
-      } catch (err: any) {
-        if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
-        if (escaped) return;
-
-        const msg = err?.message ?? (typeof err === 'string' ? err : String(err));
-        logToConsole(`[System] Auto-login failed: ${msg}. Retrying in ${currentDelay / 1000}s...`, 'system');
-
-        retryTimeoutId = setTimeout(async () => {
-          if (escaped) return;
-
-          // Before each retry, check if cached token fails validation. If so, attempt to re-auth from cached credentials.
-          const freshToken = localStorage.getItem('jellyfin_token') || token;
-          try {
-            const isValid = await validateToken(jellyfinUrl, freshToken);
-            if (!isValid) {
-              const user = localStorage.getItem('jellyfin_username') || envUser;
-              const pass = localStorage.getItem('jellyfin_password') || envPass;
-              if (user && pass && jellyfinUrl) {
-                logToConsole('[System] Jellyfin token stale — re-authenticating...', 'system');
-                const session = await authenticateUser(jellyfinUrl, user, pass);
-                localStorage.setItem('jellyfin_token', session.accessToken);
-                localStorage.setItem('jellyfin_userid', session.userId);
-                logToConsole('[System] Re-auth OK.', 'system');
-              }
-            }
-          } catch (e: any) {
-            logToConsole(`[System] Silent re-auth check failed: ${e.message || e}`, 'system');
-          }
-
-          // Double the delay for exponential backoff up to the cap
-          const nextDelay = Math.min(currentDelay * 2, MAX_DELAY);
-          currentDelay = nextDelay;
-
-          attemptSync();
-        }, currentDelay);
-      }
-    };
-
-    attemptSync();
-  } else {
-    logToConsole('[System] No saved credentials. Showing Login screen.', 'system');
-    document.removeEventListener('keydown', bootEscape);
-    document.removeEventListener('click', bootEscape);
-    setTimeout(() => { hideBootOverlay(); showLoginOrCards(); }, 500);
-  }
-}
-
-function setupLoginHandlers() {
-  const form = document.getElementById('login-form') as HTMLFormElement;
-  const errorMsg = document.getElementById('login-error-msg') as HTMLDivElement;
-
-  const demoBtn = document.getElementById('btn-demo-submit') as HTMLButtonElement | null;
-  if (demoBtn) {
-    demoBtn.addEventListener('click', () => {
-      hideLoginOverlay();
-      closeMembershipCardPicker();
-      showBootOverlay();
-      startDemoAndLoad();
-    });
-  }
-
-  if (form) {
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      if (errorMsg) errorMsg.innerText = '';
-      
-      const submitBtn = document.getElementById('btn-login-submit') as HTMLButtonElement;
-      if (submitBtn) {
-        submitBtn.disabled = true;
-        submitBtn.innerText = 'Connecting...';
-      }
-
-      const rawUrl = (document.getElementById('login-url') as HTMLInputElement).value.trim();
-      const urlInput = normalizeUrl(rawUrl);
-      const userInput = (document.getElementById('login-user') as HTMLInputElement).value.trim();
-      const passInput = (document.getElementById('login-pass') as HTMLInputElement).value;
-      // Jellyseerr is entirely optional -- both fields are blank by default and
-      // saving an empty value clears any previously-saved config, so leaving
-      // them blank silently disables the coming-soon feature.
-      const jellyseerrUrlEl = document.getElementById('login-jellyseerr-url') as HTMLInputElement | null;
-      const jellyseerrKeyEl = document.getElementById('login-jellyseerr-key') as HTMLInputElement | null;
-      const jellyseerrUrlInput = jellyseerrUrlEl?.value.trim() ?? '';
-      const jellyseerrKeyInput = jellyseerrKeyEl?.value.trim() ?? '';
-
-      try {
-        logToConsole(`[System] Contacting Jellyfin server: ${urlInput}`, 'system');
-        const session = await authenticateUser(urlInput, userInput, passInput);
-
-        // Only the manual single-login form remembers username (to prefill);
-        // the password is never persisted in plaintext localStorage.
-        localStorage.setItem('jellyfin_username', userInput);
-
-        if (jellyseerrUrlInput && jellyseerrKeyInput) {
-          localStorage.setItem('jellyseerr_url', jellyseerrUrlInput);
-          localStorage.setItem('jellyseerr_apikey', jellyseerrKeyInput);
-        } else {
-          localStorage.removeItem('jellyseerr_url');
-          localStorage.removeItem('jellyseerr_apikey');
-        }
-
-        // T18: Romm (optional) -- same persistence pattern as Jellyseerr above.
-        // Both fields blank clears any saved config, disabling the game section.
-        const rommUrlInput = (document.getElementById('login-romm-url') as HTMLInputElement | null)?.value.trim() ?? '';
-        const rommKeyInput = (document.getElementById('login-romm-key') as HTMLInputElement | null)?.value.trim() ?? '';
-        if (rommUrlInput && rommKeyInput) {
-          localStorage.setItem('romm_url', rommUrlInput);
-          localStorage.setItem('romm_apikey', rommKeyInput);
-        } else {
-          localStorage.removeItem('romm_url');
-          localStorage.removeItem('romm_apikey');
-        }
-
-        await finishLoginAndLaunch(urlInput, session);
-      } catch (err: any) {
-        logToConsole(`[System] Connection error: ${err.message}`, 'system');
-        if (errorMsg) {
-          let userMsg = err.message || 'Failed to connect to Jellyfin server';
-          if (userMsg.includes('HTTP error 401')) {
-            userMsg = 'Invalid username or password.';
-          } else if (userMsg.includes('Failed to fetch') || userMsg.includes('NetworkError')) {
-            userMsg = `Unable to connect to "${urlInput}". Check the server address, CORS settings, and verify Jellyfin is online.`;
-          }
-          errorMsg.innerText = userMsg;
-        }
-      } finally {
-        if (submitBtn) {
-          submitBtn.disabled = false;
-          submitBtn.innerText = 'Connect & Sync';
-        }
-      }
-    });
-  }
-}
 
 // ─── Power Action ─────────────────────────────────────────────────────────────
 
@@ -3899,6 +3410,30 @@ async function main() {
   // eagerly here just serialized it ahead of checkCredentialsAndLoad() below
   // for no benefit (flat mode never imports three-scene, so it never paid this
   // cost either way).
+  initBootFlow({
+    log: logToConsole,
+    ui,
+    setLibraries: (libs) => { librariesList = libs; },
+    setGames: (games) => { gameMovies = games; },
+    loadComingSoon: loadComingSoonMovies,
+    loadDiscovery: loadDiscoveryMovies,
+    loadGames: loadGameMovies,
+    mergeCollectionGaps,
+    logJellyseerrStatus,
+    gameCount: () => gameMovies.length,
+    launchStore: () => { void waitForFontsAndInit(); },
+    teardownScene: () => {
+      if (storeScene) {
+        storeScene.destroy();
+        storeScene = null;
+      }
+      if (aisleIndicatorInterval !== null) {
+        clearInterval(aisleIndicatorInterval);
+        aisleIndicatorInterval = null;
+      }
+      updateMovieHUD(null);
+    },
+  });
   setupLoginHandlers();
   setupSearchInputCapture();
   

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,6 @@ import { isGamesOnly, storeCatalog } from './games-only';
 import { isMembershipPickerOpen } from './membership-cards';
 import {
   initBootFlow,
-  showLoginOverlay,
   showBootOverlay,
   hideBootOverlay,
   showLoginOrCards,
@@ -59,7 +58,11 @@ import {
   startDemoAndLoad,
   checkCredentialsAndLoad,
   setupLoginHandlers,
+  maybeOpenSetupTerminal,
+  logOutToOpeningDay,
 } from './boot-flow';
+import { setupTerminalInput } from './store-setup-flow';
+import { registerLibraryToggles } from './library-settings';
 import { getActiveTheme, applyThemeCssVars, THEMES, resolveThemeId } from './themes';
 import {
   activeMediaCutoff,
@@ -152,6 +155,11 @@ let storeComingSoon: Movie[] = [];
 let storeDiscovery: Movie[] = [];
 function refreshStoreCatalog() {
   const catalog = storeCatalog(librariesList, gameMovies);
+  // Per-library toggles (#41 Store Libraries / #39 Overhead TVs) register
+  // here — the one funnel that sees every catalog, login, demo and rebuild
+  // alike. The drawer builds its pages at open time, so late registration is
+  // enough. Synthetic games-only "libraries" are platforms, not libraries.
+  registerLibraryToggles(catalog.libraries.filter((l) => !l.games).map((l) => ({ id: l.id, name: l.name })));
   // Media Release Date pin (#42): everything premiering after the rolling
   // cutoff is absent from the store entirely. Filtered COPIES of the fetched
   // lists — clearing the pin is a rebuild, never a re-sync.
@@ -522,12 +530,16 @@ const ui = {
   // overlay — it's in-scene — but it owns the arrow keys while docked, so it
   // joins isAnyOverlayOpen to keep shelf navigation from running underneath.
   isCounterTerminalOpen: false,
+  // NEW STORE SETUP on the same CRT (#41, store-setup-flow.ts): the opening-
+  // day / failure-state terminal the empty store docks to. Same in-scene-but-
+  // owns-the-keys treatment as the manager terminal above.
+  isSetupOpen: false,
 
   /** True if any overlay is blocking main navigation */
   get isAnyOverlayOpen(): boolean {
     return this.isPowerMenuOpen || this.isSettingsDrawerOpen || this.isLoginOpen || this.isExitConfirmOpen
       || this.isVersionPickerOpen || this.isSearchOpen || this.isCandyCheckoutOpen
-      || this.isFeedbackOpen || this.isCounterTerminalOpen || isMembershipPickerOpen();
+      || this.isFeedbackOpen || this.isCounterTerminalOpen || this.isSetupOpen || isMembershipPickerOpen();
   }
 };
 
@@ -933,6 +945,8 @@ const GROUP_HINTS: Record<SettingGroup, string> = {
 const SUBPAGE_HINTS: Record<string, string> = {
   'Building & Storefront': 'Ceiling, corner step, walls, bulbs, storefront style.',
   'Platforms': 'Which consoles get a section on the Video Games shelf.',
+  'Store Libraries': 'Which server libraries this store carries as aisles.',
+  'Overhead TVs': 'Which libraries feed the ceiling TVs. All off = family picks.',
 };
 
 /** Build the drawer DOM for the current page. Rows are updated in place. */
@@ -2642,6 +2656,9 @@ async function initializeStoreScene(preservePosterCache = false) {
       aisleIndicatorInterval = window.setInterval(updateBrowseHUDVisibility, 200);
 
       logToConsole('[System] All textures loaded. Store ready.', 'system');
+      // Opening day (#41): dock the counter CRT's NEW STORE SETUP before the
+      // overlay drops, so the player wakes already at the terminal.
+      maybeOpenSetupTerminal();
       hideBootOverlay();
       // You've just come in through the doors — ring the entry chime. (May stay
       // silent if the browser hasn't seen a user gesture yet; that's fine.)
@@ -2771,23 +2788,9 @@ async function executePowerMenuAction(btnId: string) {
 
     case 'btn-logout':
       if (isDemoMode) break; // no session in the demo (button is hidden too)
-      logToConsole('[System] Logging out and resetting Jellyfin session...', 'system');
-      localStorage.removeItem('jellyfin_url');
-      localStorage.removeItem('jellyfin_username');
-      localStorage.removeItem('jellyfin_password');
-      localStorage.removeItem('jellyfin_token');
-      localStorage.removeItem('jellyfin_userid');
-      
-      if (storeScene) {
-        storeScene.destroy();
-        storeScene = null;
-      }
-      if (aisleIndicatorInterval !== null) {
-        clearInterval(aisleIndicatorInterval);
-        aisleIndicatorInterval = null;
-      }
-      updateMovieHUD(null);
-      showLoginOverlay();
+      // #41: CHANGE SERVER / LOG OUT re-enters the empty store's NEW STORE
+      // SETUP terminal (flat mode keeps the classic login overlay).
+      logOutToOpeningDay();
       break;
 
     case 'btn-exit':
@@ -3413,6 +3416,8 @@ async function main() {
   initBootFlow({
     log: logToConsole,
     ui,
+    scene: () => storeScene,
+    keyClick: () => retailAudio.playKeyClick(),
     setLibraries: (libs) => { librariesList = libs; },
     setGames: (games) => { gameMovies = games; },
     loadComingSoon: loadComingSoonMovies,
@@ -3508,6 +3513,7 @@ async function main() {
       if (isDemoMode && ui.isPlaybackActive) return; // demo PLAYBACK DISABLED card is up
       if (videoPlayer?.isOpen) { videoPlayer.navigateHorizontal(-1); return; }
       if (ui.isLoginOpen) return;
+      if (ui.isSetupOpen) { void setupTerminalInput('left'); return; }
       if (ui.isSearchOpen) return;
       if (ui.isPowerMenuOpen) return;
       if (ui.isCounterTerminalOpen) { counterTerminalInput('left'); return; }
@@ -3531,6 +3537,7 @@ async function main() {
       if (isDemoMode && ui.isPlaybackActive) return; // demo PLAYBACK DISABLED card is up
       if (videoPlayer?.isOpen) { videoPlayer.navigateHorizontal(1); return; }
       if (ui.isLoginOpen) return;
+      if (ui.isSetupOpen) { void setupTerminalInput('right'); return; }
       if (ui.isSearchOpen) return;
       if (ui.isPowerMenuOpen) return;
       // Right steps back out of the terminal to the counter — the mirror of
@@ -3557,6 +3564,7 @@ async function main() {
       if (isDemoMode && ui.isPlaybackActive) return; // demo PLAYBACK DISABLED card is up
       if (videoPlayer?.isOpen) { videoPlayer.navigateVertical(-1); return; }
       if (ui.isLoginOpen) return;
+      if (ui.isSetupOpen) { void setupTerminalInput('up'); return; }
       if (ui.isSearchOpen) return;
       if (ui.isExitConfirmOpen) return;
 
@@ -3583,6 +3591,7 @@ async function main() {
       if (isDemoMode && ui.isPlaybackActive) return; // demo PLAYBACK DISABLED card is up
       if (videoPlayer?.isOpen) { videoPlayer.navigateVertical(1); return; }
       if (ui.isLoginOpen) return;
+      if (ui.isSetupOpen) { void setupTerminalInput('down'); return; }
       if (ui.isSearchOpen) return;
       if (ui.isExitConfirmOpen) return;
 
@@ -3611,6 +3620,7 @@ async function main() {
         return;
       }
       if (ui.isLoginOpen) return;
+      if (ui.isSetupOpen) { await setupTerminalInput('ok'); return; }
 
       if (ui.isSettingsDrawerOpen) {
         activateSelectedSetting(1);
@@ -3690,6 +3700,7 @@ async function main() {
       if (isDemoMode && ui.isPlaybackActive) { closeDemoPlaybackOverlay(); return; }
       if (videoPlayer?.isOpen) { if (!videoPlayer.handleBack()) videoPlayer.requestClose(); return; }
       if (ui.isLoginOpen) return;
+      if (ui.isSetupOpen) { void setupTerminalInput('back'); return; }
 
       if (ui.isSettingsDrawerOpen) {
         // Back from a group page returns to the category index; back from the
@@ -3744,6 +3755,8 @@ async function main() {
       if (isDemoMode && ui.isPlaybackActive) { closeDemoPlaybackOverlay(); return; }
       if (videoPlayer?.isOpen) { videoPlayer.close(); return; }
       if (ui.isLoginOpen) return;
+      // No power menu over NEW STORE SETUP — there's no store behind it yet.
+      if (ui.isSetupOpen) return;
 
       if (ui.isSettingsDrawerOpen) {
         closeSettingsDrawer();
@@ -3769,7 +3782,7 @@ async function main() {
     },
     onSearch: () => {
       if (storeScene?.isWalkAroundMode) return;
-      if (ui.isLoginOpen || ui.isPlaybackActive || ui.isCandyCheckoutOpen || ui.isVersionPickerOpen) return;
+      if (ui.isLoginOpen || ui.isSetupOpen || ui.isPlaybackActive || ui.isCandyCheckoutOpen || ui.isVersionPickerOpen) return;
       if (ui.isSearchOpen) {
         closeSearch();
       } else {
@@ -3805,7 +3818,8 @@ async function main() {
       // dismissable — Back is its cancel — so auto-cancel it and let the
       // saver take over. Login keeps blocking: it's a typing session.
       if (ui.isExitConfirmOpen && !ui.isPlaybackActive && !ui.isLoginOpen) closeExitConfirm();
-      if (!ui.isPlaybackActive && !ui.isScreensaverActive && !ui.isLoginOpen && !ui.isExitConfirmOpen) {
+      // NEW STORE SETUP is a typing session like login — never screensave it.
+      if (!ui.isPlaybackActive && !ui.isScreensaverActive && !ui.isLoginOpen && !ui.isSetupOpen && !ui.isExitConfirmOpen) {
         ui.isScreensaverActive = true;
         document.getElementById('screensaver-overlay')!.classList.add('visible');
         retailAudio.suspendForIdle();

--- a/src/main.ts
+++ b/src/main.ts
@@ -825,10 +825,22 @@ function updateBrowseHUDVisibility() {
 // buttons can't hold); the keyboard/gamepad HOLD ENTER / HOLD ▼ gestures keep
 // working and the fill bars still double as their live hold-progress meters.
 
+/**
+ * True when nothing owns the keyboard, so a bare-letter shortcut (c / r / x /
+ * f) or a hold gesture may fire. `ui.isAnyOverlayOpen` covers the DOM overlays
+ * and the two in-scene CRT terminals; `isNavOverlayOpen()` covers the
+ * scene-driven ones (▼ jump index, ceiling-TV peek) that `ui.*` cannot see.
+ * Every shortcut goes through here — checking `ui.isAnyOverlayOpen` alone is
+ * what let `c` open the checkout counter underneath a live jump index.
+ */
+function shortcutsAllowed(): boolean {
+  return !!storeScene && !ui.isAnyOverlayOpen && !ui.isPlaybackActive
+    && !ui.isScreensaverActive && !storeScene.isNavOverlayOpen();
+}
+
 /** True when nothing modal/immersive should be eating the hold shortcuts. */
 function holdHintsAllowed(): boolean {
-  return !!storeScene && !storeScene.isWalkAroundMode
-    && !ui.isAnyOverlayOpen && !ui.isPlaybackActive && !ui.isScreensaverActive;
+  return shortcutsAllowed() && !storeScene!.isWalkAroundMode;
 }
 
 /** Show/hide the pills; cheap no-op when nothing changed (called from the HUD poll). */
@@ -2578,6 +2590,7 @@ async function initializeStoreScene(preservePosterCache = false) {
 
     // Left at the checkout counter reaches for the clerk's terminal.
     scene.onCounterTerminal = () => counterTerminalOpen();
+    scene.onOpenSearch = () => { void openSearch(); };
     scene.onEnterFlatMode = () => executePowerMenuAction('btn-flat-mode');
 
     // Library-select (end-cap) left/right nav arrows on the floating locator.
@@ -2639,6 +2652,11 @@ async function initializeStoreScene(preservePosterCache = false) {
       storeScene = scene;
       (window as any).storeScene = storeScene;
       (window as any).librariesList = storeLibraries;
+      // Which overlay owns the keyboard, as the app itself sees it. Several
+      // of these (search, the two in-scene CRT terminals) have no DOM tell, so
+      // a black-box reader can only guess at them; exposing the real object
+      // lets the nav-state verifier assert on the actual input owner.
+      (window as any).__uiState = ui;
 
       // Re-apply the user's explicit live preferences (outside mode, library
       // view) to the fresh scene so a rebuild preserves them.
@@ -3782,15 +3800,20 @@ async function main() {
     },
     onSearch: () => {
       if (storeScene?.isWalkAroundMode) return;
-      if (ui.isLoginOpen || ui.isSetupOpen || ui.isPlaybackActive || ui.isCandyCheckoutOpen || ui.isVersionPickerOpen) return;
-      if (ui.isSearchOpen) {
-        closeSearch();
-      } else {
-        // Close other overlays before opening search
-        if (ui.isPowerMenuOpen) closePowerMenu();
-        if (ui.isExitConfirmOpen) closeExitConfirm();
-        openSearch();
-      }
+      // / while search is up closes it, from anywhere.
+      if (ui.isSearchOpen) { closeSearch(); return; }
+      // The power menu and the exit dialog are lightweight menus that / is
+      // allowed to SUPERSEDE — close them, then open search in their place.
+      if (ui.isPowerMenuOpen) closePowerMenu();
+      if (ui.isExitConfirmOpen) closeExitConfirm();
+      // Everything else owns the keyboard and must not have search stacked on
+      // top of it: the settings drawer, the two in-scene CRT terminals (which
+      // share search's camera dock), the candy/version/membership modals, the
+      // login and setup typing sessions, playback, and the scene-driven jump
+      // index. Testing the individual flags here is what let / open a second
+      // live overlay over the settings drawer and the manager terminal.
+      if (!shortcutsAllowed()) return;
+      openSearch();
     },
     onActivity: () => {
       if (ui.isScreensaverActive) {
@@ -3841,29 +3864,29 @@ async function main() {
       // SETUP still swallowed every key (ui.isSetupOpen), while nothing left
       // could bring the camera back to the terminal. Same trap at the manager
       // terminal. isAnyOverlayOpen covers all of them, plus the old four.
-      if (ui.isAnyOverlayOpen || ui.isPlaybackActive || ui.isScreensaverActive) return;
+      if (!shortcutsAllowed()) return;
       storeScene?.toggleWalkAround();
     },
     // T22: carry-mode shortcuts. Both are guarded no-ops with the 'Carry &
     // checkout' toggle off (or while any overlay owns the keyboard).
     onCheckout: () => {
-      if (ui.isAnyOverlayOpen || ui.isPlaybackActive || ui.isScreensaverActive) return;
+      if (!shortcutsAllowed()) return;
       if (storeScene?.isWalkAroundMode) return;
       storeScene?.enterCheckout();
     },
     onReturnTape: () => {
-      if (ui.isAnyOverlayOpen || ui.isPlaybackActive || ui.isScreensaverActive) return;
+      if (!shortcutsAllowed()) return;
       storeScene?.returnCarriedTape();
     },
     onNotInterested: () => {
-      if (ui.isAnyOverlayOpen || ui.isPlaybackActive || ui.isScreensaverActive) return;
+      if (!shortcutsAllowed()) return;
       handleGapDismiss();
     },
     // T22: hold-select-to-checkout. While a tape is in hand (and nothing modal
     // is on top), holding Enter / gamepad A jumps straight to the counter; a
     // quick tap still performs the normal select action on release.
     isHoldSelectArmed: () => {
-      if (ui.isAnyOverlayOpen || ui.isPlaybackActive || ui.isScreensaverActive) return false;
+      if (!shortcutsAllowed()) return false;
       if (videoPlayer?.isOpen) return false;
       if (storeScene?.isWalkAroundMode) return false;
       return !!storeScene?.canHoldToCheckout();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -651,7 +651,7 @@ export function registerCoreSettings(): void {
     default: true,
     applyMode: 'live',
     apply: (value, scene) => scene.setOverviewStart(!!value),
-    hint: 'Start inside the doors with shelf cursors. Off = cam view.',
+    hint: 'Start inside the doors on the jump index. Off = cam view.',
     hidden: true, // service knob: navigation-flow experiment (T21)
   });
 

--- a/src/signage-catalog.ts
+++ b/src/signage-catalog.ts
@@ -94,11 +94,13 @@ export function getSignDef(id: string): SignDef | undefined {
   // If it's a dynamic ceiling nav sign (e.g. 'ceiling-nav-ACTION' or 'ceiling-nav-COMEDY')
   if (id.startsWith('ceiling-nav-')) {
     const genreOrLibName = id.slice('ceiling-nav-'.length).toUpperCase();
-    // Opt-in bb_93_signage: layered genre marker (backer + disc + navy
-    // plate, ~36in x 15in per the Part II COMEDY sign vs the light fixture
-    // beside it); default keeps the #34 rectangle.
+    // Opt-in bb_93_signage: the solid equilateral category WEDGE (owner
+    // spec 2026-08-09) — 3.1 ft wide, 15 in tall; end-on an equilateral ∇
+    // (top depth 2h/√3 ≈ 17 in). Nameplate proportions from the warped
+    // rUhRHo44CIA f0013 (see fixtures/category-plate-1993.ts). Default
+    // keeps the #34 rectangle.
     const ribbon93 = bb93SignageOn();
-    const size = ribbon93 ? { w: 3.0, h: 1.25 } : { w: 4.2, h: 1.2 };
+    const size = ribbon93 ? { w: 3.1, h: 1.25 } : { w: 4.2, h: 1.2 };
     return {
       id,
       category: 'ceiling-nav',

--- a/src/store-camera.ts
+++ b/src/store-camera.ts
@@ -8,7 +8,7 @@ import * as THREE from 'three';
 import { CASE_WIDTH, CASE_HEIGHT } from './video-case';
 import { FIELD_Z_FRONT, BROWSE_WINDOW_SIZE, AISLE_SHELF_HEIGHTS, WALL_SHELF_HEIGHTS, BOX_SPACING, UNIT_FRAME_HEIGHT, unitDepthAtHeight, BACK_WALL_UNIT_IDX, extraCopiesCount, MovieSlot, STORE_CENTER_X } from './store-layout';
 import { getActiveTheme } from './themes';
-import { OVERVIEW_POS } from './scene-shared';
+import { OVERVIEW_POS, OVERVIEW_PITCH_MIN, OVERVIEW_PITCH_MAX } from './scene-shared';
 import { BB_ARCHIVO_BLACK } from './bundled-fonts';
 import type { StoreScene } from './three-scene';
 
@@ -85,8 +85,18 @@ export function updateCameraTarget(scene: StoreScene) {
 
   // T21: entrance overview — feet planted at the vantage, head-look only.
   // The look target comes from overviewYaw/Pitch and rides the same
-  // targetCameraPos/targetLookAt lerp every other mode uses.
+  // targetCameraPos/targetLookAt lerp every other mode uses. Those two angles
+  // are kept pointing at whatever the jump index has focused (aimOverviewAt
+  // below), so re-deriving the pose here always agrees with the index.
   if (scene.mode === 'overview') {
+    // …except while the index previews a floor DISPLAY (Row 2), which walks
+    // the camera off the vantage to face the fixture. The index owns the
+    // targets then; re-deriving them would snap the camera home mid-preview.
+    if (scene.subNav && scene.subNav.row === 1) {
+      scene.updateSelectionArrow();
+      scene.triggerLibrarySelectUpdate(false);
+      return;
+    }
     const p = OVERVIEW_POS;
     scene.targetCameraPos.copy(p);
     const cp = Math.cos(scene.overviewPitch);
@@ -472,6 +482,29 @@ export function updateCameraTarget(scene: StoreScene) {
   // view, #62).
   scene.updateSelectionArrow();
   scene.triggerLibrarySelectUpdate(scene.mode === 'library-select');
+}
+
+/**
+ * Turn the entrance-overview head-look toward a world point — the marker
+ * floating over whatever the jump index has focused (store-subnav.ts), or an
+ * overview cursor target.
+ *
+ * overviewYaw/overviewPitch ARE the pose for `mode === 'overview'`: every
+ * updateCameraTarget() re-derives the camera from them. So anything that moves
+ * the focus has to move these two angles, or the next unrelated retarget
+ * (a resize, a settings apply, a mode bounce) snaps the view back to a stale
+ * heading. Aims a couple of feet BELOW the marker, at the stock, so a distant
+ * run doesn't tilt the horizon up.
+ */
+export function aimOverviewAt(scene: StoreScene, x: number, y: number, z: number): void {
+  const p = OVERVIEW_POS;
+  const dx = x - p.x, dz = z - p.z;
+  // forward = (-sin yaw, sin pitch, -cos yaw) — see updateCameraTarget().
+  scene.overviewYaw = Math.atan2(-dx, -dz);
+  scene.overviewPitch = THREE.MathUtils.clamp(
+    Math.atan2((y - 2.0) - p.y, Math.hypot(dx, dz)),
+    OVERVIEW_PITCH_MIN, OVERVIEW_PITCH_MAX);
+  updateCameraTarget(scene);
 }
 
 export function createSelectionArrow(scene: StoreScene) {

--- a/src/store-clerk-flow.ts
+++ b/src/store-clerk-flow.ts
@@ -461,6 +461,13 @@ export function showPersonEndcap(scene: StoreScene, person: string, kind: 'actor
     shelf: scene.selectedShelf,
     col: scene.selectedCol,
     nrDirect: scene.isBrowsingNewReleasesDirectly,
+    // A case on a SLOTTED FIXTURE (staff-picks endcap, promo stand, collection
+    // cap) is identified by these two, not by the shelving indices — its
+    // unitIdx is meaningless. Restoring without them rebuilt a shelving slot
+    // key that matched nothing, so Back out of the endcap landed in `inspect`
+    // holding no movie at all.
+    unitSource: scene.selectedUnitSource,
+    fixtureId: scene.selectedFixtureId,
   };
 
   // Locate the initiating shelving unit run.
@@ -831,9 +838,20 @@ export function closePersonEndcap(scene: StoreScene, restore: boolean) {
     scene.selectedShelf = rs.shelf;
     scene.selectedCol = rs.col;
     scene.isBrowsingNewReleasesDirectly = rs.nrDirect;
+    scene.selectedUnitSource = rs.unitSource;
+    scene.selectedFixtureId = rs.fixtureId;
     scene.mode = rs.mode;
     scene.isFlipped = false; scene.heroSpine = false;
     scene.updateColsCount();
+    // The stock behind those coordinates can be gone by now — the title was
+    // dismissed or ordered while the endcap was up, or the slot was restocked.
+    // `inspect` with nothing to inspect is a dead end (a hero case with no
+    // movie, and Enter/flip acting on null), so fall back to the shelf view
+    // rather than restoring a mode the selection can no longer support.
+    if (scene.mode === 'inspect' && !scene.getSelectedMovie()) {
+      scene.mode = 'browse';
+      scene.onConsoleLog("[System] That title is no longer on the shelf.", "system");
+    }
     if (scene.onModeChange) scene.onModeChange(scene.mode);
     scene.updateCameraTarget();
     if (scene.onSelectionChange) scene.onSelectionChange(scene.getSelectedMovie());

--- a/src/store-nav.ts
+++ b/src/store-nav.ts
@@ -566,8 +566,10 @@ export function moveUp(scene: StoreScene) {
     // Already on row 1: ▲ opens the ceiling-TV peek (store-tv-peek.ts, pin
     // 051) rather than closing the index — the index stays open underneath.
     // Where the build has no ambient TVs at all, fall back to the old
-    // close-on-▲.
+    // close-on-▲ — except at the ROOT index, which is the floor: closing it
+    // there would leave the store with no navigation layer at all.
     if (enterTvPeek(scene)) return;
+    if (scene.subNav?.root) return;
     closeSubNav(scene, true);
     return;
   }
@@ -580,7 +582,9 @@ export function moveUp(scene: StoreScene) {
     return;
   }
   if (scene.mode === 'overview') {
-    scene.overviewLook(0, 1);
+    // ▲ at the overview belongs to the index (its Row 1 opens the ceiling-TV
+    // peek); reaching here means the view came up without one — raise it.
+    scene.showOverviewVisuals();
     return;
   }
   if (scene.mode === 'library-select') {
@@ -687,6 +691,13 @@ export function wrapOverShelfTop(scene: StoreScene) {
 /** ←/→ while an overlay owns them. Returns true when the press was consumed. */
 export function navOverlayArrow(scene: StoreScene, dir: number): boolean {
   scene.requestRender();
+  // At the entrance overview the index owns ←/→ outright — there is no cursor
+  // ring behind it any more (store-overview.ts). Re-raise it if some path put
+  // us in this view without one rather than letting the press fall through to
+  // a browse cursor nobody can see.
+  if (scene.mode === 'overview' && !subNavActive(scene) && !tvPeekActive(scene)) {
+    scene.showOverviewVisuals();
+  }
   return tvPeekCycle(scene, dir) || subNavArrow(scene, dir);
 }
 
@@ -725,9 +736,16 @@ export function debugNavOverlay(scene: StoreScene) {
   return { peek: debugTvPeek(scene), subnav: debugSubNav(scene) };
 }
 
-/** True while the jump index is up (main.ts fades the browse HUD under it). */
+/**
+ * True while the jump index is up AS AN OVERLAY — i.e. covering some other
+ * view, which is what makes main.ts fade that view's HUD under it and gag the
+ * bare-letter shortcuts. The ROOT index (the entrance overview's own
+ * navigation) is not covering anything: it IS the view, so its HUD hint
+ * belongs on screen and `c` / `f` / `/` work there exactly as in any other
+ * base view.
+ */
 export function isSubNavOpen(scene: StoreScene): boolean {
-  return subNavActive(scene);
+  return subNavActive(scene) && !scene.subNav?.root;
 }
 
 /**
@@ -736,10 +754,12 @@ export function isSubNavOpen(scene: StoreScene): boolean {
  * `ui.isAnyOverlayOpen` (they're in-scene, not DOM), so every shortcut that
  * guards on that flag has to consult this one too, or c / f / r / x fire
  * straight through a live index and drop you at the counter (or into
- * walk-around) with the index still floating over the screen.
+ * walk-around) with the index still floating over the screen. The root index
+ * is excluded for the reason isSubNavOpen gives: it is a base view, not a
+ * layer over one.
  */
 export function isNavOverlayOpen(scene: StoreScene): boolean {
-  return subNavActive(scene) || tvPeekActive(scene);
+  return isSubNavOpen(scene) || tvPeekActive(scene);
 }
 
 export function moveSeriesEpisodeSelection(scene: StoreScene, dir: number): boolean {
@@ -783,14 +803,12 @@ export function moveDown(scene: StoreScene) {
   if (subNavDown(scene)) return;       // jump index: row 1 -> row 2
   if (scene.mode === 'backroom') return; // couch view — no vertical nav
   // ▼ IN THE SHELF-SELECT VIEWS opens the jump index (owner ruling
-  // 2026-08-06). It used to live on the bottom shelf row, one press off the
-  // floor deep inside browsing — nowhere anyone reaches for a menu. Both
-  // pulled-back "choose where to go" framings get it, since which one is home
-  // depends on the overview-start setting. Unconditional by owner's choice:
-  // ◄ ► ▲ still walk the floating cursor, and the index itself lists every
-  // library, genre and display, so nothing becomes unreachable.
+  // 2026-08-06). At the entrance overview it is already up — it IS that view's
+  // navigation now (owner ruling 2026-08-09), so ▼ there was consumed above by
+  // subNavDown on its way to the DISPLAYS row. This is the seccam
+  // library-select root (bb_overview_start=0), which still opens it on demand.
   if (scene.mode === 'overview' || scene.mode === 'library-select') {
-    openSubNav(scene);
+    openSubNav(scene, scene.mode === 'overview');
     return;
   }
   if (scene.mode === 'person-endcap') {

--- a/src/store-nav.ts
+++ b/src/store-nav.ts
@@ -730,6 +730,18 @@ export function isSubNavOpen(scene: StoreScene): boolean {
   return subNavActive(scene);
 }
 
+/**
+ * True while a scene-driven overlay owns the keyboard — the ▼ jump index or
+ * the ceiling-TV peek nested in it. These are NOT tracked by main.ts's
+ * `ui.isAnyOverlayOpen` (they're in-scene, not DOM), so every shortcut that
+ * guards on that flag has to consult this one too, or c / f / r / x fire
+ * straight through a live index and drop you at the counter (or into
+ * walk-around) with the index still floating over the screen.
+ */
+export function isNavOverlayOpen(scene: StoreScene): boolean {
+  return subNavActive(scene) || tvPeekActive(scene);
+}
+
 export function moveSeriesEpisodeSelection(scene: StoreScene, dir: number): boolean {
   const movie = scene.getSelectedMovie();
   if (scene.mode !== 'inspect' || !movie?.isSeries) return false;

--- a/src/store-overview.ts
+++ b/src/store-overview.ts
@@ -1,13 +1,25 @@
-// Overview (security-cam library-select) cursor mode — extracted from
-// StoreScene (three-scene.ts keeps one-line delegating stubs): building the
-// floating cursor targets (sections, genre placards, fixtures, checkout),
-// focus stepping, the free-look, and entering browse from a cursor. Every
-// function takes the StoreScene as its first parameter and reads/writes
-// scene state exactly as the original methods did.
-import * as THREE from 'three';
+// The entrance overview — the vantage you stand at when the store is not
+// showing you a shelf. Extracted from StoreScene (three-scene.ts keeps
+// one-line delegating stubs): the target list (sections, genre placards,
+// fixtures, checkout) and entering browse from one of those targets.
+//
+// NAVIGATION LIVES IN THE JUMP INDEX (store-subnav.ts), not here. Until
+// 2026-08-09 this module also ran an arrow-stepped cursor ring with its own
+// free-look, so the store booted into one navigation layer and the index —
+// the layer that owns ▲ "look up at the store TVs", ▼ "the displays", and a
+// named list of every destination — was a press away underneath it. Two
+// answers to the same question, and the boot one landed on whichever cursor
+// happened to sit nearest the middle of the frame. The ring is gone: entering
+// the overview raises the index (showOverviewVisuals), leaving it takes the
+// index down (hideOverviewVisuals), and every arrow in this view belongs to
+// the index. What survives here is the TARGET list, which is still how a
+// query ("browse HORROR", a harness checkpoint, the search box) resolves a
+// name to a shelf.
 import { OverviewCursors, OverviewCursorTarget, NEW_RELEASES_CURSOR_LIB, CHECKOUT_CURSOR_LIB, FIXTURE_CURSOR_LIB, FLAT_MODE_CURSOR_LIB } from './overview-cursors';
 import { BROWSE_WINDOW_SIZE, AISLE_SHELF_HEIGHTS, SECTION_COLS, UNIT_SIDE_CAPACITY, BACK_WALL_UNIT_IDX, SECTION_CAPACITY, sideEntrySlot, ShelvingUnit } from './store-layout';
-import { OVERVIEW_POS, OVERVIEW_LOOK_STEP, OVERVIEW_YAW_CLAMP, OVERVIEW_PITCH_MIN, OVERVIEW_PITCH_MAX } from './scene-shared';
+import { OVERVIEW_POS } from './scene-shared';
+import { openSubNav, closeSubNav, forgetSubNav, subNavSelect } from './store-subnav';
+import { aimOverviewAt } from './store-camera';
 import { isEndcapKind } from './fixtures/genre-endcap';
 import { slottedFixtureLabel, qualifyDuplicateLabels } from './fixture-labels';
 import type { StoreScene } from './three-scene';
@@ -208,14 +220,23 @@ export function setOverviewCrosshairVisible(scene: StoreScene, v: boolean): void
 
 export function showOverviewVisuals(scene: StoreScene): void {
   // feedback/003: the per-run chevron cloud stays hidden — the single big
-  // selection arrow (shared with the seccam view) marks the focused run and
-  // ←/→ steps through runs in screen order. The cursor set is still built:
-  // it remains the target list and the confirm path for overviewEnterBrowse.
+  // selection arrow (shared with the seccam view) marks the focused
+  // destination. The cursor set is still built: it remains the target list and
+  // the confirm path for a QUERY (overviewEnterBrowse('HORROR')).
   scene.ensureOverviewCursors();
+  // The jump index IS this view's navigation (see the module header). Raising
+  // it here rather than in enterOverview() covers every way the overview comes
+  // back up — walking out of walk mode, undocking the search CRT, a settings
+  // apply — with one rule instead of one call site each.
+  if (scene.mode === 'overview') openSubNav(scene, true);
   scene.updateSelectionArrow();
 }
 
 export function hideOverviewVisuals(scene: StoreScene): void {
+  // Called on the way OUT of the overview (or while something else takes the
+  // camera): drop the index with it, or it would keep owning the arrow keys
+  // from under walk mode / the desk CRT / the back room.
+  forgetSubNav(scene);
   scene.overviewCursors?.setVisible(false);
   scene.setOverviewCrosshairVisible(false);
   // Called before scene.mode changes on the way out of the overview, so hide
@@ -223,8 +244,13 @@ export function hideOverviewVisuals(scene: StoreScene): void {
   if (scene.mode === 'overview' && scene.selectionArrow) scene.selectionArrow.visible = false;
 }
 
+/**
+ * Point the cursor set at whatever is nearest the current head-look. Only the
+ * QUERY path cares about this now (the index owns the focus the player sees),
+ * so it declines while the index is up rather than fighting it for the camera.
+ */
 export function updateOverviewFocus(scene: StoreScene): void {
-  if (!scene.overviewCursors) return;
+  if (!scene.overviewCursors || scene.subNav) return;
   const cp = Math.cos(scene.overviewPitch);
   scene._ovForward.set(
     -Math.sin(scene.overviewYaw) * cp,
@@ -240,44 +266,8 @@ export function applyOverviewFocus(scene: StoreScene, idx: number): void {
   const t = cursors.targets[idx];
   if (!t) return;
   cursors.setFocused(idx);
-  const p = OVERVIEW_POS;
-  const dx = t.x - p.x, dz = t.z - p.z;
-  // forward = (-sin yaw, sin pitch, -cos yaw) — see updateCameraTarget().
-  scene.overviewYaw = Math.atan2(-dx, -dz);
-  // Aim a couple of feet below the floating marker (at the shelves), not at
-  // the marker itself, so distant runs don't tilt the horizon up.
-  scene.overviewPitch = THREE.MathUtils.clamp(
-    Math.atan2((t.y - 2.0) - p.y, Math.hypot(dx, dz)),
-    OVERVIEW_PITCH_MIN, OVERVIEW_PITCH_MAX);
+  aimOverviewAt(scene, t.x, t.y, t.z); // also retargets the camera
   scene.updateSelectionArrow();
-  scene.updateCameraTarget();
-  scene.triggerLibrarySelectUpdate(false); // keeps the HUD locator label fresh
-}
-
-export function overviewFocusStep(scene: StoreScene, dir: number): void {
-  const cursors = scene.ensureOverviewCursors();
-  const n = cursors.targets.length;
-  if (n === 0) return;
-  const p = OVERVIEW_POS;
-  const yawOf = (i: number) => {
-    const t = cursors.targets[i];
-    return Math.atan2(-(t.x - p.x), -(t.z - p.z));
-  };
-  // Positive yaw is further LEFT, so left→right order is yaw descending.
-  const order = Array.from({ length: n }, (_, i) => i).sort((a, b) => yawOf(b) - yawOf(a));
-  const pos = order.indexOf(cursors.focusedIdx);
-  const next = pos < 0 ? (dir > 0 ? 0 : n - 1) : (pos + dir + n) % n;
-  scene.applyOverviewFocus(order[next]);
-}
-
-export function overviewLook(scene: StoreScene, dYaw: number, dPitch: number): void {
-  scene.overviewYaw = THREE.MathUtils.clamp(
-    scene.overviewYaw + dYaw * OVERVIEW_LOOK_STEP,
-    -OVERVIEW_YAW_CLAMP, OVERVIEW_YAW_CLAMP);
-  scene.overviewPitch = THREE.MathUtils.clamp(
-    scene.overviewPitch + dPitch * OVERVIEW_LOOK_STEP,
-    OVERVIEW_PITCH_MIN, OVERVIEW_PITCH_MAX);
-  scene.updateCameraTarget();
   scene.triggerLibrarySelectUpdate(false); // keeps the HUD locator label fresh
 }
 
@@ -290,16 +280,21 @@ export function enterOverview(scene: StoreScene): void {
   scene.isBrowsingNewReleasesDirectly = false;
   scene.overviewYaw = 0;
   scene.overviewPitch = 0;
-  scene.showOverviewVisuals();
-  scene.updateOverviewFocus();
+  scene.showOverviewVisuals(); // raises the jump index and aims the view at it
+  scene.updateOverviewFocus(); // no-op while the index is up (see above)
   if (scene.onModeChange) scene.onModeChange(scene.mode);
   if (scene.onGenreMenuUpdate) scene.onGenreMenuUpdate('', [], 0, false);
   scene.updateCameraTarget();
-  scene.onConsoleLog('[System] Entrance overview — ←/→ to pick a section, Enter to browse.', 'system');
+  scene.onConsoleLog(
+    '[System] Inside the store — ◄ ► pick a section, ▼ the displays, ▲ the TVs, OK to go.', 'system');
 }
 
 export function overviewEnterBrowse(scene: StoreScene, query?: string): boolean {
   if (scene.mode !== 'overview') return false;
+  // No name given: "go where the player is pointing" — which is the jump
+  // index's focus, the only focus this view shows.
+  if (!query && scene.subNav) return subNavSelect(scene);
+  if (scene.subNav) closeSubNav(scene, false); // a query overrides it
   const cursors = scene.ensureOverviewCursors();
   let idx = cursors.focusedIdx;
   if (query) {

--- a/src/store-overview.ts
+++ b/src/store-overview.ts
@@ -9,6 +9,7 @@ import { OverviewCursors, OverviewCursorTarget, NEW_RELEASES_CURSOR_LIB, CHECKOU
 import { BROWSE_WINDOW_SIZE, AISLE_SHELF_HEIGHTS, SECTION_COLS, UNIT_SIDE_CAPACITY, BACK_WALL_UNIT_IDX, SECTION_CAPACITY, sideEntrySlot, ShelvingUnit } from './store-layout';
 import { OVERVIEW_POS, OVERVIEW_LOOK_STEP, OVERVIEW_YAW_CLAMP, OVERVIEW_PITCH_MIN, OVERVIEW_PITCH_MAX } from './scene-shared';
 import { isEndcapKind } from './fixtures/genre-endcap';
+import { slottedFixtureLabel, qualifyDuplicateLabels } from './fixture-labels';
 import type { StoreScene } from './three-scene';
 
 export function buildOverviewCursorTargets(scene: StoreScene): OverviewCursorTarget[] {
@@ -70,14 +71,14 @@ export function buildOverviewCursorTargets(scene: StoreScene): OverviewCursorTar
   // configuration they had no reachable entry point at all. Cursors float
   // lower than the shelf ones: these fixtures are waist-height islands, so a
   // gondola-height ticket would read as belonging to the run behind them.
+  const fixtureTargets: OverviewCursorTarget[] = [];
   scene.slottedFixtures.forEach((f, standIdx) => {
     // Endcaps (genre AND collection) get no standalone cursor (user request):
     // they're browsed by walking off their run's entrance-end column
     // (store-nav flow-through).
     if (isEndcapKind(f.placement.kind)) return;
-    const label = ((f.placement.options?.genre as string) || f.placement.id || 'display').toUpperCase();
-    targets.push({
-      label,
+    fixtureTargets.push({
+      label: slottedFixtureLabel(f),
       x: f.placement.position.x,
       y: 5.1,
       z: f.placement.position.z,
@@ -87,6 +88,11 @@ export function buildOverviewCursorTargets(scene: StoreScene): OverviewCursorTar
       col: 0,
     });
   });
+  // Number the repeats (four game gondolas all call themselves VIDEO GAMES) in
+  // left-to-right order, the order the cursor ring steps them in.
+  fixtureTargets.sort((a, b) => (a.x - b.x) || (a.z - b.z));
+  qualifyDuplicateLabels(fixtureTargets, (t) => scene.slottedFixtures[t.unitIdxInLibrary]);
+  targets.push(...fixtureTargets);
   // T22: the front-counter checkout waypoint. Always present (not just in
   // carry mode): the clerk's desk terminal — Left at the counter — is the
   // diegetic settings/power menu, so the counter must stay reachable by

--- a/src/store-setup-flow.ts
+++ b/src/store-setup-flow.ts
@@ -1,0 +1,318 @@
+// NEW STORE SETUP (#41) — the CONTROLLER behind the opening-day counter
+// terminal. The empty store boots, the camera docks at the checkout CRT (the
+// manager-terminal camera dock), and this flow walks the player from "bare
+// shelves" to a stocked store: distributor row → server address typed on the
+// CRT → membership card pick (the existing DOM picker; CRT sign-in when the
+// server lists no public users) → library checkbox rows (which aisles this
+// store carries, persisted via library-settings) → FIRST SHIPMENT ARRIVING.
+//
+// Same split as counter-terminal-flow.ts: the screens themselves are pure
+// (store-setup-screens.ts, unit-tested); this file is only glue — render onto
+// the scene's CRT, route remote presses and typed keys, run the Jellyfin
+// calls, persist choices, and hand the stocked-store launch back to
+// boot-flow.ts through the callbacks it was initialized with.
+import {
+  fetchPublicUsers,
+  fetchLibraryList,
+  authenticateUser,
+  normalizeUrl,
+} from './jellyfin';
+import {
+  openMembershipCardPicker,
+  isMembershipPickerOpen,
+  type MembershipLoginSession,
+} from './membership-cards';
+import { excludedLibraryIds, setLibraryCarried } from './library-settings';
+import {
+  SetupScreen,
+  SetupKey,
+  initialHomeScreen,
+  setupScreenKey,
+  setupScreenChar,
+  setupScreenBackspace,
+  setupScreenLines,
+} from './store-setup-screens';
+
+export interface SetupTerminalScene {
+  setTerminalText(lines: string[] | null, cursorLine?: number): void;
+  enterSearchMode(): void;
+  exitSearchMode(): void;
+}
+
+export interface SetupFlowDeps {
+  scene: () => SetupTerminalScene | null;
+  /** main.ts's ui-state object — the flow owns its isSetupOpen flag. */
+  ui: { isSetupOpen: boolean };
+  log: (message: string, type?: 'system' | 'cec' | 'video') => void;
+  keyClick: () => void;
+  callbacks: {
+    /** TRY A DEMO STORE — boot-flow's demo path (scene rebuilds stocked). */
+    tryDemo(): void;
+    /**
+     * Full catalog sync for the chosen server/member, honoring the carried-
+     * library exclusions just persisted. Progress lands back on the CRT via
+     * onStage. Resolves with the catalog loaded into main.ts state; throws on
+     * failure (the flow returns to the home screen with the error).
+     */
+    sync(
+      url: string,
+      session: MembershipLoginSession,
+      onStage: (stage: string, pages: number) => void
+    ): Promise<void>;
+    /** Reveal the stocked store (boot overlay + scene rebuild). */
+    openStore(): void;
+    /** Notice screen's CHANGE SERVER: drop the saved server + stop retries. */
+    changeServer(): void;
+    /** Notice screen's RETRY NOW: kick the auto-retry immediately. */
+    retryNow(): void;
+  };
+}
+
+let deps: SetupFlowDeps | null = null;
+let screen: SetupScreen = initialHomeScreen();
+// The authenticated connection carried between the member pick and the sync.
+let pendingUrl = '';
+let pendingSession: MembershipLoginSession | null = null;
+
+export function initSetupFlow(d: SetupFlowDeps): void {
+  deps = d;
+}
+
+function render(): void {
+  if (!deps?.ui.isSetupOpen) return;
+  const scene = deps.scene();
+  if (!scene) return;
+  const { lines, cursorLine } = setupScreenLines(screen);
+  scene.setTerminalText(lines, cursorLine);
+  // Verification hook (same idiom as __promoStands & co): what the setup CRT
+  // is showing right now, for scripts that drive the real first-run flow.
+  (window as any).__setupScreen = { kind: screen.kind, lines, cursorLine };
+}
+
+// Typed characters for the address / member-name / password fields — captured
+// ahead of InputManager's bubble listener, exactly like the search terminal.
+// Arrows, OK and Back are NOT handled here: they arrive through main.ts's
+// input callbacks (setupTerminalInput below), so remotes and gamepads drive
+// the menus identically to a keyboard.
+function onTypedKey(e: KeyboardEvent): void {
+  if (!deps?.ui.isSetupOpen || isMembershipPickerOpen()) return;
+  const typing =
+    (screen.kind === 'home' && screen.row === 1) ||
+    (screen.kind === 'manual-auth' && (screen.row === 0 || screen.row === 1));
+  if (!typing) return;
+  if (e.key === 'Backspace') {
+    screen = setupScreenBackspace(screen);
+  } else if (e.key.length === 1 && !e.ctrlKey && !e.altKey && !e.metaKey) {
+    const next = setupScreenChar(screen, e.key);
+    if (next === screen) return;
+    screen = next;
+  } else {
+    return;
+  }
+  deps.keyClick();
+  render();
+  e.preventDefault();
+  e.stopPropagation();
+}
+
+/** First-run entry: dock the camera and show NEW STORE SETUP. */
+export function openSetupTerminal(): void {
+  if (!deps) return;
+  openWith(initialHomeScreen(localStorage.getItem('jellyfin_url')));
+  deps.log('[Setup] Opening day — NEW STORE SETUP is on the counter CRT.');
+}
+
+/**
+ * Later-boot failure entry (#41: the empty store doubles as the failure
+ * state): same dock, but the terminal reports the unreachable distributor.
+ * Safe to call again while open — a failed background retry just updates the
+ * detail line.
+ */
+export function openSetupNotice(address: string, detail: string): void {
+  if (!deps) return;
+  const row = screen.kind === 'notice' ? screen.row : 0;
+  openWith({ kind: 'notice', address, detail: detail.toUpperCase(), row });
+}
+
+function openWith(s: SetupScreen): void {
+  if (!deps) return;
+  screen = s;
+  if (!deps.ui.isSetupOpen) {
+    deps.ui.isSetupOpen = true;
+    window.addEventListener('keydown', onTypedKey, true);
+    deps.scene()?.enterSearchMode(); // camera dock only — the text is ours
+  }
+  render();
+}
+
+/**
+ * Leave setup. keepCamera=true when the scene is about to be torn down and
+ * rebuilt stocked (demo / FIRST SHIPMENT) — snapping the camera back or
+ * resetting the CRT would flash for one frame under the boot overlay.
+ */
+export function closeSetupTerminal(opts?: { keepCamera?: boolean }): void {
+  if (!deps?.ui.isSetupOpen) return;
+  deps.ui.isSetupOpen = false;
+  window.removeEventListener('keydown', onTypedKey, true);
+  if (!opts?.keepCamera) deps.scene()?.exitSearchMode();
+}
+
+async function dial(address: string): Promise<void> {
+  if (!deps) return;
+  const url = normalizeUrl(address.trim());
+  screen = { kind: 'dialing', address: url, step: 'LOOKING UP MEMBERSHIP CARDS...' };
+  render();
+  let users;
+  try {
+    users = await fetchPublicUsers(url);
+  } catch (e: any) {
+    deps.log(`[Setup] No answer from ${url}: ${e?.message ?? e}`);
+    screen = { ...initialHomeScreen(address), row: 1, error: 'NO ANSWER. CHECK THE ADDRESS + CORS.' };
+    render();
+    return;
+  }
+  if (users.length > 0) {
+    deps.log(`[Setup] Found ${users.length} membership card(s) on ${url}.`);
+    screen = { kind: 'members', count: users.length };
+    render();
+    openMembershipCardPicker({
+      serverUrl: url,
+      users,
+      lastUserId: localStorage.getItem('jellyfin_last_userid'),
+      onLogin: (session) => afterAuth(url, session),
+      // "Sign in manually" from the picker lands on the CRT sign-in screen —
+      // the DOM login form is no longer part of first-run.
+      onManualLogin: () => {
+        screen = { kind: 'manual-auth', row: 0, username: '', password: '' };
+        render();
+      },
+      onDemoMode: () => runDemo(),
+      log: (msg) => deps?.log(msg),
+    });
+  } else {
+    screen = { kind: 'manual-auth', row: 0, username: '', password: '' };
+    render();
+  }
+}
+
+async function manualSignIn(): Promise<void> {
+  if (!deps || screen.kind !== 'manual-auth') return;
+  const { username, password } = screen;
+  const url = pendingUrl || normalizeUrl(localStorage.getItem('jellyfin_url') || '');
+  screen = { kind: 'dialing', address: url, step: `SIGNING IN ${username.toUpperCase().slice(0, 26)}...` };
+  render();
+  try {
+    const session = await authenticateUser(url, username.trim(), password);
+    await afterAuth(url, session);
+  } catch (e: any) {
+    const msg = String(e?.message ?? e);
+    screen = {
+      kind: 'manual-auth', row: 2, username, password: '',
+      error: msg.includes('401') ? 'SIGN-IN REFUSED. CHECK NAME + PASSWORD.' : 'SIGN-IN FAILED. SERVER UNREACHABLE.',
+    };
+    render();
+  }
+}
+
+/** Authenticated — persist the session, then offer the library checkboxes. */
+async function afterAuth(url: string, session: MembershipLoginSession): Promise<void> {
+  if (!deps) return;
+  pendingUrl = url;
+  pendingSession = session;
+  localStorage.setItem('jellyfin_url', url);
+  localStorage.setItem('jellyfin_token', session.accessToken);
+  localStorage.setItem('jellyfin_userid', session.userId);
+  localStorage.setItem('jellyfin_last_userid', session.userId);
+  deps.log(`[Setup] Authenticated as ${session.userName}.`);
+  screen = { kind: 'dialing', address: url, step: 'PULLING THE CATALOG LIST...' };
+  render();
+  try {
+    const libs = await fetchLibraryList(url, session.accessToken, session.userId);
+    if (libs.length === 0) {
+      screen = { ...initialHomeScreen(url), error: 'THE DISTRIBUTOR LISTS NO LIBRARIES.' };
+      render();
+      return;
+    }
+    const excluded = excludedLibraryIds();
+    screen = {
+      kind: 'libraries',
+      rows: libs.map((l) => ({ id: l.id, name: l.name, carried: !excluded.has(l.id) })),
+      row: 0,
+    };
+    render();
+  } catch (e: any) {
+    deps.log(`[Setup] Library list failed: ${e?.message ?? e}`);
+    screen = { ...initialHomeScreen(url), error: 'COULD NOT LIST LIBRARIES. RETRY.' };
+    render();
+  }
+}
+
+async function runSync(): Promise<void> {
+  if (!deps || screen.kind !== 'libraries' || !pendingSession) return;
+  for (const row of screen.rows) setLibraryCarried(row.id, row.carried);
+  const url = pendingUrl;
+  const session = pendingSession;
+  screen = { kind: 'sync', stage: 'CONTACTING DISTRIBUTOR...', pages: 0 };
+  render();
+  try {
+    await deps.callbacks.sync(url, session, (stage, pages) => {
+      screen = { kind: 'sync', stage, pages };
+      render();
+    });
+  } catch (e: any) {
+    deps.log(`[Setup] Catalog sync failed: ${e?.message ?? e}`);
+    screen = { ...initialHomeScreen(url), error: 'CATALOG SYNC FAILED. TRY AGAIN.' };
+    render();
+    return;
+  }
+  screen = { kind: 'arriving' };
+  render();
+  closeSetupTerminal({ keepCamera: true });
+  deps.callbacks.openStore();
+}
+
+function runDemo(): void {
+  if (!deps) return;
+  closeSetupTerminal({ keepCamera: true });
+  deps.callbacks.tryDemo();
+}
+
+/** One remote/keyboard press while the setup terminal is up. */
+export async function setupTerminalInput(kind: SetupKey): Promise<void> {
+  if (!deps?.ui.isSetupOpen || isMembershipPickerOpen()) return;
+  const { state, action } = setupScreenKey(screen, kind);
+  if (state !== screen || action) deps.keyClick();
+  screen = state;
+  if (!action) {
+    render();
+    return;
+  }
+  switch (action) {
+    case 'connect':
+      if (screen.kind === 'home') await dial(screen.address);
+      return;
+    case 'demo':
+      runDemo();
+      return;
+    case 'sign-in':
+      await manualSignIn();
+      return;
+    case 'back-home':
+      screen = initialHomeScreen(pendingUrl || localStorage.getItem('jellyfin_url'));
+      render();
+      return;
+    case 'open-store':
+      await runSync();
+      return;
+    case 'retry':
+      screen = { kind: 'dialing', address: localStorage.getItem('jellyfin_url') || '', step: 'RETRYING NOW...' };
+      render();
+      deps.callbacks.retryNow();
+      return;
+    case 'change-server':
+      deps.callbacks.changeServer();
+      screen = initialHomeScreen(localStorage.getItem('jellyfin_url'));
+      render();
+      return;
+  }
+}

--- a/src/store-setup-flow.ts
+++ b/src/store-setup-flow.ts
@@ -160,14 +160,30 @@ export function closeSetupTerminal(opts?: { keepCamera?: boolean }): void {
 async function dial(address: string): Promise<void> {
   if (!deps) return;
   const url = normalizeUrl(address.trim());
+  // Remember the dialed server IMMEDIATELY, not at afterAuth(): both routes to
+  // the CRT sign-in screen below (an empty card list, a refused one) skip
+  // afterAuth entirely, and manualSignIn() reads pendingUrl. Without this it
+  // fell back to localStorage's jellyfin_url — unset on a true first run — and
+  // authenticated against '', i.e. the app's own origin, so a single-user
+  // Jellyfin (public card list empty) could NEVER be connected to from here.
+  pendingUrl = url;
   screen = { kind: 'dialing', address: url, step: 'LOOKING UP MEMBERSHIP CARDS...' };
   render();
   let users;
   try {
     users = await fetchPublicUsers(url);
   } catch (e: any) {
-    deps.log(`[Setup] No answer from ${url}: ${e?.message ?? e}`);
-    screen = { ...initialHomeScreen(address), row: 1, error: 'NO ANSWER. CHECK THE ADDRESS + CORS.' };
+    const msg = String(e?.message ?? e);
+    deps.log(`[Setup] No membership card list from ${url}: ${msg}`);
+    // A server that ANSWERED and refused the list (public users switched off,
+    // a reverse proxy blocking /Users/Public) is perfectly usable — it just
+    // can't fan the cards out. Sign in by name instead of dead-ending on the
+    // home screen, which is what the DOM login form has always done. Only a
+    // server that said nothing at all is a bad address.
+    screen = /HTTP error \d+/.test(msg)
+      ? { kind: 'manual-auth', row: 0, username: '', password: '',
+          error: 'NO CARD LIST HERE. SIGN IN BY NAME.' }
+      : { ...initialHomeScreen(address), row: 1, error: 'NO ANSWER. CHECK THE ADDRESS + CORS.' };
     render();
     return;
   }
@@ -199,6 +215,14 @@ async function manualSignIn(): Promise<void> {
   if (!deps || screen.kind !== 'manual-auth') return;
   const { username, password } = screen;
   const url = pendingUrl || normalizeUrl(localStorage.getItem('jellyfin_url') || '');
+  if (!url) {
+    // Belt and braces for the bug the pendingUrl assignment in dial() fixes:
+    // never authenticate against an empty URL (which resolves to the app's own
+    // origin and fails forever) — send them back to type an address.
+    screen = { ...initialHomeScreen(), row: 1, error: 'TYPE THE SERVER ADDRESS FIRST.' };
+    render();
+    return;
+  }
   screen = { kind: 'dialing', address: url, step: `SIGNING IN ${username.toUpperCase().slice(0, 26)}...` };
   render();
   try {

--- a/src/store-setup-screens.ts
+++ b/src/store-setup-screens.ts
@@ -1,0 +1,283 @@
+// NEW STORE SETUP (#41) — the pure state machine behind the opening-day
+// counter terminal. Same split as the media-date screen (#42): this module is
+// state + reducers + line renderers only (no DOM, no network, no scene), so
+// it unit-tests under node and the harness can render any screen verbatim;
+// store-setup-flow.ts owns the wiring (camera dock, Jellyfin calls, typed-key
+// capture, persistence).
+//
+// Renderer contract: drawTerminal (entrance/index.ts) hard-clips lines at 40
+// characters and shows ~10 body rows under its banner, so every screen here
+// budgets 10 lines and pre-clips what matters (addresses clip from the LEFT —
+// the end of a URL is the part being typed).
+
+export type SetupKey = 'up' | 'down' | 'left' | 'right' | 'ok' | 'back';
+
+export type SetupAction =
+  | 'connect'       // home: dial the typed address
+  | 'demo'          // stock the demo store instead
+  | 'retry'         // notice: retry the saved server now
+  | 'change-server' // notice: drop the saved server, back to a blank home
+  | 'open-store'    // libraries: choices made, sync + stock
+  | 'sign-in'       // manual-auth: authenticate the typed name/password
+  | 'back-home';    // manual-auth: abandon sign-in
+
+/** One provider row today; the list is the seam PLEX (#32) slots into. */
+export const SETUP_PROVIDERS = ['JELLYFIN'] as const;
+
+export interface SetupLibraryRow {
+  id: string;
+  name: string;
+  carried: boolean;
+}
+
+export type SetupHomeScreen = { kind: 'home'; row: number; provider: number; address: string; error?: string };
+
+export type SetupScreen =
+  | SetupHomeScreen
+  | { kind: 'dialing'; address: string; step: string }
+  | { kind: 'members'; count: number }
+  | { kind: 'manual-auth'; row: number; username: string; password: string; error?: string }
+  | { kind: 'libraries'; rows: SetupLibraryRow[]; row: number; error?: string }
+  | { kind: 'sync'; stage: string; pages: number }
+  | { kind: 'arriving' }
+  | { kind: 'notice'; address: string; detail: string; row: number };
+
+export function initialHomeScreen(savedAddress?: string | null): SetupHomeScreen {
+  return { kind: 'home', row: 1, provider: 0, address: savedAddress || 'http://' };
+}
+
+// Home rows: 0 DISTRIBUTOR / 1 SERVER ADDRESS / 2 CONNECT / 3 TRY A DEMO STORE
+const HOME_ROWS = 4;
+// Manual-auth rows: 0 MEMBER NAME / 1 PASSWORD / 2 SIGN IN / 3 BACK
+const AUTH_ROWS = 4;
+// Notice rows: 0 RETRY NOW / 1 CHANGE SERVER / 2 TRY A DEMO STORE
+const NOTICE_ROWS = 3;
+// The libraries screen windows its checkbox rows into this many visible lines.
+const LIB_WINDOW = 6;
+
+/** A typed printable character lands in whichever field the cursor is on. */
+export function setupScreenChar(s: SetupScreen, ch: string): SetupScreen {
+  if (ch.length !== 1) return s;
+  if (s.kind === 'home' && s.row === 1 && ch !== ' ') {
+    return { ...s, address: s.address + ch, error: undefined };
+  }
+  if (s.kind === 'manual-auth' && s.row === 0) return { ...s, username: s.username + ch, error: undefined };
+  if (s.kind === 'manual-auth' && s.row === 1) return { ...s, password: s.password + ch, error: undefined };
+  return s;
+}
+
+export function setupScreenBackspace(s: SetupScreen): SetupScreen {
+  if (s.kind === 'home' && s.row === 1) return { ...s, address: s.address.slice(0, -1), error: undefined };
+  if (s.kind === 'manual-auth' && s.row === 0) return { ...s, username: s.username.slice(0, -1), error: undefined };
+  if (s.kind === 'manual-auth' && s.row === 1) return { ...s, password: s.password.slice(0, -1), error: undefined };
+  return s;
+}
+
+export function setupScreenKey(s: SetupScreen, key: SetupKey): { state: SetupScreen; action?: SetupAction } {
+  switch (s.kind) {
+    case 'home': {
+      if (key === 'up' || key === 'down') {
+        const row = (s.row + (key === 'up' ? -1 : 1) + HOME_ROWS) % HOME_ROWS;
+        return { state: { ...s, row } };
+      }
+      if (key === 'ok') {
+        if (s.row === 0 || s.row === 1) return { state: { ...s, row: s.row + 1 } }; // BIOS-style: OK advances
+        if (s.row === 2) {
+          const addr = s.address.trim();
+          if (!addr || addr === 'http://' || addr === 'https://') {
+            return { state: { ...s, row: 1, error: 'TYPE THE SERVER ADDRESS FIRST.' } };
+          }
+          return { state: s, action: 'connect' };
+        }
+        return { state: s, action: 'demo' };
+      }
+      // left/right on the DISTRIBUTOR row cycle providers (one today).
+      if ((key === 'left' || key === 'right') && s.row === 0) {
+        const n = SETUP_PROVIDERS.length;
+        return { state: { ...s, provider: (s.provider + (key === 'left' ? -1 : 1) + n) % n } };
+      }
+      return { state: s };
+    }
+    case 'dialing':
+    case 'members':
+    case 'sync':
+    case 'arriving':
+      return { state: s }; // in-flight screens take no menu input
+    case 'manual-auth': {
+      if (key === 'up' || key === 'down') {
+        const row = (s.row + (key === 'up' ? -1 : 1) + AUTH_ROWS) % AUTH_ROWS;
+        return { state: { ...s, row } };
+      }
+      if (key === 'ok') {
+        if (s.row === 0 || s.row === 1) return { state: { ...s, row: s.row + 1 } };
+        if (s.row === 2) {
+          if (!s.username.trim()) return { state: { ...s, row: 0, error: 'TYPE A MEMBER NAME FIRST.' } };
+          return { state: s, action: 'sign-in' };
+        }
+        return { state: s, action: 'back-home' };
+      }
+      if (key === 'back') return { state: s, action: 'back-home' };
+      return { state: s };
+    }
+    case 'libraries': {
+      const total = s.rows.length + 1; // + OPEN THE STORE
+      if (key === 'up' || key === 'down') {
+        const row = (s.row + (key === 'up' ? -1 : 1) + total) % total;
+        return { state: { ...s, row } };
+      }
+      if (key === 'ok') {
+        if (s.row < s.rows.length) {
+          const rows = s.rows.map((r, i) => (i === s.row ? { ...r, carried: !r.carried } : r));
+          return { state: { ...s, rows, error: undefined } };
+        }
+        if (!s.rows.some((r) => r.carried)) {
+          return { state: { ...s, error: 'CARRY AT LEAST ONE LIBRARY.' } };
+        }
+        return { state: s, action: 'open-store' };
+      }
+      return { state: s };
+    }
+    case 'notice': {
+      if (key === 'up' || key === 'down') {
+        const row = (s.row + (key === 'up' ? -1 : 1) + NOTICE_ROWS) % NOTICE_ROWS;
+        return { state: { ...s, row } };
+      }
+      if (key === 'ok') {
+        if (s.row === 0) return { state: s, action: 'retry' };
+        if (s.row === 1) return { state: s, action: 'change-server' };
+        return { state: s, action: 'demo' };
+      }
+      return { state: s };
+    }
+  }
+}
+
+// ─── Renderers ────────────────────────────────────────────────────────────────
+
+/** Clip from the LEFT so the character being typed stays on screen. */
+function clipTail(text: string, max: number): string {
+  return text.length <= max ? text : '…' + text.slice(-(max - 1));
+}
+
+function sel(active: boolean, label: string): string {
+  return `${active ? '>' : ' '} ${label}`;
+}
+
+export function setupScreenLines(s: SetupScreen): { lines: string[]; cursorLine: number } {
+  switch (s.kind) {
+    case 'home': {
+      const provider = SETUP_PROVIDERS[s.provider];
+      // Short labels on purpose: the value column gets 25 of the 40 chars, so
+      // a typical http://<lan-ip>:8096 shows whole instead of clipped.
+      const addr = clipTail(s.address, s.row === 1 ? 24 : 25) + (s.row === 1 ? '_' : '');
+      const lines = [
+        'NEW STORE SETUP — OPENING DAY',
+        '',
+        'BARE SHELVES, NO STOCK. PICK A',
+        'DISTRIBUTOR TO SUPPLY THIS STORE.',
+        '',
+        sel(s.row === 0, `DISTRIBUTOR  ${provider}`),
+        sel(s.row === 1, `ADDRESS      ${addr}`),
+        sel(s.row === 2, 'CONNECT'),
+        sel(s.row === 3, 'TRY A DEMO STORE'),
+      ];
+      if (s.error) lines.push(s.error.slice(0, 40));
+      return { lines, cursorLine: 5 + s.row };
+    }
+    case 'dialing':
+      return {
+        lines: [
+          'NEW STORE SETUP — OPENING DAY',
+          '',
+          'DIALING DISTRIBUTOR...',
+          clipTail(s.address, 40),
+          '',
+          s.step.slice(0, 40),
+        ],
+        cursorLine: 5,
+      };
+    case 'members':
+      return {
+        lines: [
+          'MEMBERSHIP CHECK',
+          '',
+          `${s.count} MEMBERSHIP CARD(S) ON FILE.`,
+          'PICK YOURS ON THE COUNTER.',
+        ],
+        cursorLine: 3,
+      };
+    case 'manual-auth': {
+      const user = clipTail(s.username, 20) + (s.row === 0 ? '_' : '');
+      const pass = '*'.repeat(Math.min(s.password.length, 20)) + (s.row === 1 ? '_' : '');
+      const lines = [
+        'MEMBERSHIP SIGN-IN',
+        '',
+        'NO MEMBERSHIP CARDS ON FILE HERE.',
+        'SIGN IN BY NAME.',
+        '',
+        sel(s.row === 0, `MEMBER NAME   ${user}`),
+        sel(s.row === 1, `PASSWORD      ${pass}`),
+        sel(s.row === 2, 'SIGN IN'),
+        sel(s.row === 3, 'BACK'),
+      ];
+      if (s.error) lines.push(s.error.slice(0, 40));
+      return { lines, cursorLine: 5 + s.row };
+    }
+    case 'libraries': {
+      // Window the checkbox rows around the cursor; OPEN THE STORE stays last.
+      const onOpen = s.row >= s.rows.length;
+      const cursorRow = onOpen ? Math.max(0, s.rows.length - 1) : s.row;
+      let start = Math.max(0, Math.min(cursorRow - (LIB_WINDOW - 1), s.rows.length - LIB_WINDOW));
+      if (s.rows.length <= LIB_WINDOW) start = 0;
+      // Keep the cursor inside the window when it walks upward too.
+      if (cursorRow < start) start = cursorRow;
+      const visible = s.rows.slice(start, start + LIB_WINDOW);
+      const carriedCount = s.rows.filter((r) => r.carried).length;
+      const lines = [
+        "CHOOSE THIS STORE'S LIBRARIES",
+        'OK TICKS A BOX. AISLES BUILD FOR',
+        `EVERY LIBRARY CARRIED. (${carriedCount} OF ${s.rows.length})`,
+      ];
+      visible.forEach((r, i) => {
+        const idx = start + i;
+        lines.push(sel(!onOpen && idx === s.row, `[${r.carried ? 'X' : ' '}] ${r.name.toUpperCase().slice(0, 32)}`));
+      });
+      const openLineIdx = lines.length;
+      lines.push(sel(onOpen, s.error ? s.error : 'OPEN THE STORE'));
+      const cursorLine = onOpen ? openLineIdx : 3 + (s.row - start);
+      return { lines, cursorLine };
+    }
+    case 'sync':
+      return {
+        lines: [
+          'CATALOG SYNC IN PROGRESS',
+          '',
+          s.stage.slice(0, 40),
+          s.pages > 0 ? `PAGES RECEIVED: ${s.pages}` : '',
+          '',
+          'A LARGE CATALOG TAKES A MINUTE.',
+          'THE STORE OPENS WHEN STOCK LANDS.',
+        ],
+        cursorLine: 2,
+      };
+    case 'arriving':
+      return {
+        lines: ['FIRST SHIPMENT ARRIVING', '', 'STOCKING SHELVES...'],
+        cursorLine: 2,
+      };
+    case 'notice': {
+      const lines = [
+        'DISTRIBUTOR NOT ANSWERING',
+        clipTail(s.address, 40),
+        s.detail.slice(0, 40),
+        '',
+        sel(s.row === 0, 'RETRY NOW'),
+        sel(s.row === 1, 'CHANGE SERVER'),
+        sel(s.row === 2, 'TRY A DEMO STORE'),
+        '',
+        'RETRYING QUIETLY IN THE BACKGROUND.',
+      ];
+      return { lines, cursorLine: 4 + s.row };
+    }
+  }
+}

--- a/src/store-shell.ts
+++ b/src/store-shell.ts
@@ -2368,7 +2368,10 @@ export function buildStore(scene: StoreScene) {
         if (ok) scene.onConsoleLog(`[Clerk] Ordered "${movie.title}" through Jellyseerr.`, 'system');
         return ok;
       },
-      onSearch: () => scene.enterSearchMode(),
+      // Route through main.ts's openSearch() so ui.isSearchOpen is set and Back
+      // can close it; the bare enterSearchMode() fallback is for hosts that
+      // wire no handler (the harness), where a stuck dock is harmless.
+      onSearch: () => (scene.onOpenSearch ? scene.onOpenSearch() : scene.enterSearchMode()),
       onLog: (msg) => scene.onConsoleLog(msg, 'system'),
       onBlip: () => retailAudio.playBoxPickup(),
     },

--- a/src/store-shell.ts
+++ b/src/store-shell.ts
@@ -2423,6 +2423,21 @@ export function buildStore(scene: StoreScene) {
       genreName
     };
   });
+  // GAMES wedge (owner, 2026-08-09): the games department gets its own
+  // ceiling-nav hanger, centered over the game-section units (slotted
+  // fixtures are installed earlier in this same build pass).
+  const gameUnits = scene.slottedFixtures.filter(f => f.placement?.id?.startsWith('game-section'));
+  if (gameUnits.length) {
+    const gx = gameUnits.reduce((s, f) => s + f.placement.position.x, 0) / gameUnits.length;
+    const gz = gameUnits.reduce((s, f) => s + f.placement.position.z, 0) / gameUnits.length;
+    ceilingSlots.push({
+      id: 'ceiling-nav-games-dept',
+      category: 'ceiling-nav',
+      pos: new THREE.Vector3(gx, 9.75, gz),
+      yaw: Math.atan2(STORE_CENTER_X - gx, counterMidZ - gz),
+      genreName: 'GAMES'
+    });
+  }
 
   const signageSlots: SignSlot[] = [
     ...ceilingSlots,

--- a/src/store-shell.ts
+++ b/src/store-shell.ts
@@ -2196,8 +2196,17 @@ export function buildStore(scene: StoreScene) {
     fixture.build();
     const footprint = fixture.getFootprint?.();
     if (footprint) fixtureFootprints.push(footprint);
-    if ('getSlots' in fixture && typeof (fixture as any).getSlots === 'function') {
-      scene.slottedFixtures.push(fixture as SlottedFixture);
+    const slotted = 'getSlots' in fixture && typeof (fixture as any).getSlots === 'function'
+      ? (fixture as SlottedFixture) : null;
+    // A fixture that DECLINED to build is not on the floor: an era-gated POP
+    // kit outside its period, a promo stand whose campaign chain came up
+    // empty, a bargain bin with nothing to dump on opening day. Each reports
+    // no slots AND no footprint. Keep those out of the browsable set entirely
+    // — the entrance overview builds a floating cursor for every entry here,
+    // so an unbuilt one parked a ticket over bare carpet (the empty
+    // opening-day store showed "PROMO-STAND-BACK" hanging over nothing).
+    if (slotted && (slotted.getSlots().length > 0 || footprint)) {
+      scene.slottedFixtures.push(slotted);
       // No auto stand-points around an endcap: it abuts its aisle run, so
       // the ringed dests would park the clerk against (or inside) the
       // shelving it touches — she approaches it like the aisle itself.
@@ -2334,39 +2343,49 @@ export function buildStore(scene: StoreScene) {
       yaw: Math.PI / 2, kind: 'wall', key: `wall:right:${fz}`,
     });
   }
-  scene.clerk = new StoreClerk(scene.plan, clerkFloorDests, scene.shelvingUnits, {
-    // Only offer to chat while the player is free-roaming the floor.
-    isAvailable: () => scene.mode === 'walk-around',
-    getMovies: () => {
-      const map = new Map<string, Movie>();
-      scene.libraries.forEach((lib) => lib.movies.forEach((m) => map.set(m.id, m)));
-      return Array.from(map.values());
+  // Opening day (#41): no stock, no staff. The empty shell is a store that has
+  // not taken delivery yet — a clerk working the floor of it reads as a bug,
+  // and she has nothing to stock, recommend or check out (owner call
+  // 2026-08-09). She arrives with the first shipment, i.e. with the very next
+  // scene build, since a stocked store rebuilds this whole function.
+  const storeHasStock = scene.libraries.some((lib) => lib.movies.length > 0)
+    || scene.gameMovies.length > 0;
+  if (storeHasStock) {
+    const clerk = new StoreClerk(scene.plan, clerkFloorDests, scene.shelvingUnits, {
+      // Only offer to chat while the player is free-roaming the floor.
+      isAvailable: () => scene.mode === 'walk-around',
+      getMovies: () => {
+        const map = new Map<string, Movie>();
+        scene.libraries.forEach((lib) => lib.movies.forEach((m) => map.set(m.id, m)));
+        return Array.from(map.values());
+      },
+      getLocalContext: () => scene.localRecommendPool(),
+      // "Order it for me": the clerk-dialog twin of the inspect-view request
+      // press — the shared orderTitle flow, with her toast muted because
+      // she's already talking to you in the dialog.
+      onRequest: async (movie) => {
+        const ok = await scene.orderTitle(movie, { clerkLine: false });
+        if (ok) scene.onConsoleLog(`[Clerk] Ordered "${movie.title}" through Jellyseerr.`, 'system');
+        return ok;
+      },
+      onSearch: () => scene.enterSearchMode(),
+      onLog: (msg) => scene.onConsoleLog(msg, 'system'),
+      onBlip: () => retailAudio.playBoxPickup(),
     },
-    getLocalContext: () => scene.localRecommendPool(),
-    // "Order it for me": the clerk-dialog twin of the inspect-view request
-    // press — the shared orderTitle flow, with her toast muted because
-    // she's already talking to you in the dialog.
-    onRequest: async (movie) => {
-      const ok = await scene.orderTitle(movie, { clerkLine: false });
-      if (ok) scene.onConsoleLog(`[Clerk] Ordered "${movie.title}" through Jellyseerr.`, 'system');
-      return ok;
-    },
-    onSearch: () => scene.enterSearchMode(),
-    onLog: (msg) => scene.onConsoleLog(msg, 'system'),
-    onBlip: () => retailAudio.playBoxPickup(),
-  },
-  scene.clerkNavGrid,
-  entranceClerkNav
-    ? { register: entranceClerkNav.register, terminals: entranceClerkNav.terminals }
-    : null);
-  // AO-excluded: she's a billboard sprite + blob-shadow plane — screen-space
-  // AO on a flat sprite is a halo artifact, and excluding her means her
-  // roaming never invalidates the frozen AO term (see the GTAO wrapper).
-  // aoBlendMask: also knock the AO *blend* out of her pixels each frame, or
-  // the shelf shadows behind her get multiplied straight across the sprite.
-  scene.clerk.group.userData.excludeFromSSAO = true;
-  scene.clerk.group.userData.aoBlendMask = true;
-  scene.scene.add(scene.clerk.group);
+    scene.clerkNavGrid,
+    entranceClerkNav
+      ? { register: entranceClerkNav.register, terminals: entranceClerkNav.terminals }
+      : null);
+    // AO-excluded: she's a billboard sprite + blob-shadow plane — screen-space
+    // AO on a flat sprite is a halo artifact, and excluding her means her
+    // roaming never invalidates the frozen AO term (see the GTAO wrapper).
+    // aoBlendMask: also knock the AO *blend* out of her pixels each frame, or
+    // the shelf shadows behind her get multiplied straight across the sprite.
+    clerk.group.userData.excludeFromSSAO = true;
+    clerk.group.userData.aoBlendMask = true;
+    scene.scene.add(clerk.group);
+    scene.clerk = clerk;
+  }
 
   // --- Dynamic Store Signage system ---
   const getLineGenreName = (lineId: number): string => {

--- a/src/store-subnav.ts
+++ b/src/store-subnav.ts
@@ -1,8 +1,18 @@
-// The SUB-NAV JUMP INDEX — ▼ from the pulled-back shelf-select views, i.e.
-// the framing you boot into (see store-nav.ts moveDown). It opened from the
-// BOTTOM SHELF ROW until 2026-08-06, when the owner moved it: a jump menu
-// belongs on the view where you are already choosing where to go, not one
-// press off the floor in the middle of browsing a run.
+// The JUMP INDEX — the store's ONE navigation layer, and what you are in the
+// moment the doors close behind you.
+//
+// It opened from the BOTTOM SHELF ROW until 2026-08-06, when the owner moved it
+// onto the pulled-back "choose where to go" views (a jump menu belongs where
+// you are already choosing a destination, not one press off the floor in the
+// middle of a run). It became the ROOT itself on 2026-08-09: the entrance
+// overview used to boot with its own arrow-stepped cursor ring, so you landed
+// in one navigation mode and had to press ▼ to reach the real one — two layers
+// answering the same question, with ▲ (look up at the store TVs) live in only
+// one of them. The cursor ring is gone; store-overview.ts's showOverviewVisuals
+// opens this index as the overview's nav layer, and it stays open for as long
+// as that view is up. `root: true` marks that instance: Back does not close it
+// (there is nothing underneath), and its focus is remembered across a trip into
+// an aisle so backing out returns the marker to where you left it.
 //
 // Two rows, both driven by ←/→ with ▲/▼ switching between them. There is no
 // DOM for this (owner call: the indexes are logical, not chrome) — the
@@ -12,9 +22,12 @@
 // branch). One marker over the focused destination, exactly as feedback/003
 // settled it — never a cloud of per-target signs.
 //
-//   Row 1  LIBRARIES & GENRES — every library in store order, then the New
-//          Releases wall, then the genre sections that PHYSICALLY exist as
-//          shelf sections. Genre → location is resolved through the same
+//   Row 1  LIBRARIES & GENRES — the checkout counter, every library, the New
+//          Releases wall, and the genre sections that PHYSICALLY exist as
+//          shelf sections, all in ONE left-to-right run across the store as
+//          seen from the vantage (sortByScreenOrder). ◄ and ► move the marker
+//          left and right through the room, never through a list order the
+//          room can't show you. Genre → location is resolved through the same
 //          StorePlan data the overview's genre cursors use
 //          (StoreScene.genreCursorTargets → layout.sectionLabels +
 //          entryBlockOrder), so a section is listed only when the plan can
@@ -27,10 +40,11 @@
 //          gondolas. Moving the highlight GLIDES the camera to face that
 //          fixture, so stepping the row is literally walking the displays.
 //
-// The user never leaves browse mode: the cursor is untouched while the index
-// is open, the full return state is snapshotted on open, and Back restores it
-// exactly (browse stays the escape floor — backAction's clamp is unaffected
-// because closing the index swallows that one press).
+// Opened from browse (not the case today, but the open/close contract is
+// unchanged): the cursor is untouched while the index is up, the full return
+// state is snapshotted on open, and Back restores it exactly. At the ROOT
+// there is no such return — Back declines here and store-nav.ts's
+// navOverlayBack hands the press to backAction's own floor clamp.
 //
 // ▲ from Row 1 no longer closes the index (2026-08-06, pin 051): it opens the
 // ceiling-TV peek instead (store-tv-peek.ts) — subNavUp here just declines
@@ -48,6 +62,7 @@ import {
   enterEndcapCursor, enterFixtureCursor, enterShelfCursor,
 } from './browse-cursor';
 import { OVERVIEW_POS } from './scene-shared';
+import { aimOverviewAt } from './store-camera';
 import { isEndcapKind } from './fixtures/genre-endcap';
 import { slottedFixtureLabel, qualifyDuplicateLabels } from './fixture-labels';
 import { retailAudio } from './audio';
@@ -79,7 +94,12 @@ export interface SubNavState {
   row: number;
   sel: number[];
   ret: BrowseReturn;
+  /** The store's root nav layer (opened with the entrance overview itself). */
+  root: boolean;
 }
+
+/** Where the ROOT index's marker was when you last left it (label, per row). */
+export interface SubNavFocusMemory { row: number; label: string; }
 
 // Shelf-row markers float at the overview cursor's height (just above the
 // signboards); fixture markers hover over their own topper instead — a
@@ -101,7 +121,14 @@ const WALKUP_EYE_Y = 5.2;
 const SUBNAV_GLIDE_LERP = 0.35;
 
 export function subNavActive(scene: StoreScene): boolean {
-  return scene.subNav !== null;
+  const state = scene.subNav;
+  if (!state) return false;
+  // The root index belongs to the entrance view and comes down with it
+  // (store-overview.ts hideOverviewVisuals). If the mode moved on some other
+  // way, it is stale — drop it here rather than let a dead index keep eating
+  // the arrow keys in a mode that has its own use for them.
+  if (state.root && scene.mode !== 'overview') { forgetSubNav(scene); return false; }
+  return true;
 }
 
 // ─── Row contents ────────────────────────────────────────────────────────────
@@ -111,6 +138,25 @@ function shelfItem(
   side: 'front' | 'back', col: number, x: number, y: number, z: number,
 ): SubNavItem {
   return { label: label.toUpperCase(), kind, libraryIdx, unitIdxInLibrary, side, col, fixtureIdx: -1, x, y, z, yaw: 0, lookY: 3 };
+}
+
+/**
+ * Put a row in the order the player SEES it: left to right across the store
+ * from the entrance vantage.
+ *
+ * ◄ / ► are a direction in the room, not a step through a list — an index
+ * whose rows ran in build order (all the libraries, then the New Releases
+ * wall, then every genre section) sent the marker leaping from the far right
+ * of the store back to an aisle you already walked past. Ordering by bearing
+ * from the vantage is what the entrance overview's own cursor ring did before
+ * the index replaced it, and it is the property that makes the marker's travel
+ * match the key you pressed. Positive yaw is further LEFT, so left→right is
+ * yaw DESCENDING.
+ */
+function sortByScreenOrder(items: SubNavItem[]): void {
+  const p = OVERVIEW_POS;
+  const yawOf = (i: SubNavItem) => Math.atan2(-(i.x - p.x), -(i.z - p.z));
+  items.sort((a, b) => yawOf(b) - yawOf(a));
 }
 
 /**
@@ -131,17 +177,18 @@ function declutter(items: SubNavItem[]): void {
 }
 
 /**
- * Row 1: the checkout counter, libraries in store order, the New Releases
- * wall, then genre sections.
+ * Row 1: the checkout counter, every library, the New Releases wall and the
+ * genre sections — sorted into one left-to-right sweep of the room.
  *
- * The counter leads because it is the one destination that is not stock: it is
- * where you pay, where the clerk stands, and — through Left at the counter —
+ * The counter is here because it is the one destination that is not stock: it
+ * is where you pay, where the clerk stands, and — through Left at the counter —
  * the ONLY way into the manager terminal, i.e. every setting the app has. The
  * index listed every library, genre and display but not the counter, so a
  * player navigating by the index (the whole point of the index) could reach
  * every shelf in the building and never the register or the settings behind
- * it. The entrance overview's own CHECKOUT cursor was the sole route, several
- * arrow presses deep in a ring of aisle tickets.
+ * it. It used to LEAD the row for that reason; now it simply sits where it
+ * stands in the store, which is easier to find, not harder — you point at the
+ * counter by looking at the counter.
  */
 function buildLibraryRow(scene: StoreScene): SubNavItem[] {
   const out: SubNavItem[] = [];
@@ -195,11 +242,12 @@ function buildLibraryRow(scene: StoreScene): SubNavItem[] {
       11.0, 8.6, scene.backWallZ + 3.0)); // wall shelving is taller than gondolas
   }
   const row = out.concat(genres);
+  sortByScreenOrder(row);
   declutter(row);
   return row;
 }
 
-/** Row 2: every slotted floor fixture, ordered front of store → back. */
+/** Row 2: every slotted floor fixture, in the same left-to-right sweep. */
 function buildDisplayRow(scene: StoreScene): SubNavItem[] {
   const out: SubNavItem[] = [];
   scene.slottedFixtures.forEach((f, fixtureIdx) => {
@@ -222,9 +270,10 @@ function buildDisplayRow(scene: StoreScene): SubNavItem[] {
       lookY: heights.length > 0 ? (heights[0] + heights[heights.length - 1]) / 2 + 0.4 : 3.0,
     });
   });
-  // Front of the store first, so stepping right walks deeper in — then number
-  // any repeated titles in that same stepping order.
-  out.sort((a, b) => (b.z - a.z) || (a.x - b.x));
+  // Left to right, like Row 1 (it used to run front-of-store → back, so ►
+  // walked you deeper in rather than sideways) — then number any repeated
+  // titles in that same stepping order.
+  sortByScreenOrder(out);
   qualifyDuplicateLabels(out, (it) => scene.slottedFixtures[it.fixtureIdx]);
   declutter(out);
   return out;
@@ -246,11 +295,19 @@ function previewCurrent(scene: StoreScene, state: SubNavState): void {
   if (state.row === 1) {
     faceFixture(scene, item, PREVIEW_DIST, PREVIEW_EYE_Y);
     scene.targetLookAt.y = item.y + PREVIEW_LOOK_LIFT; // frame marker AND stock
+  } else if (scene.mode === 'overview') {
+    // At the overview the head-look angles ARE the camera pose, so pan by
+    // aiming them (store-camera.ts aimOverviewAt) rather than by writing the
+    // targets directly — anything that retargets the camera later then still
+    // finds the view pointing at the focused destination.
+    aimOverviewAt(scene, item.x, item.y, item.z);
+    scene.cameraGlideLerp = SUBNAV_GLIDE_LERP;
+    scene.requestRender();
   } else {
-    // Row 1 reads from the entrance overview's vantage — the viewpoint the
+    // Opened over some other view (the seccam library-select root): read Row 1
+    // from the entrance vantage anyway — that is the viewpoint the
     // arrow-over-the-run framing is designed for (from a browse pose two feet
-    // off the shelf the far destinations are unreadable). Stepping the row
-    // pans the look marker-to-marker while the camera holds that vantage.
+    // off the shelf the far destinations are unreadable).
     scene.targetCameraPos.copy(OVERVIEW_POS);
     scene.targetLookAt.set(item.x, item.y, item.z);
     scene.cameraGlideLerp = SUBNAV_GLIDE_LERP;
@@ -262,26 +319,47 @@ function previewCurrent(scene: StoreScene, state: SubNavState): void {
 function applyRow(scene: StoreScene, state: SubNavState): void {
   scene.updateSelectionArrow(); // reads scene.subNav — the while-open branch
   previewCurrent(scene, state);
+  // The root index outlives any one trip into an aisle: remember where its
+  // marker was so backing out of a shelf puts it back, instead of resetting to
+  // the far end of the store every time.
+  const item = state.rows[state.row][state.sel[state.row]];
+  if (state.root && item) scene.subNavRootFocus = { row: state.row, label: item.label };
 }
 
 // ─── Open / close ────────────────────────────────────────────────────────────
 
-/** ▼ in the shelf-select views. Always handled (the index always has Row 1). */
-export function openSubNav(scene: StoreScene): boolean {
+/**
+ * Open the index. `root` marks the store's own nav layer — the one
+ * store-overview.ts raises with the entrance view and never takes down (see
+ * the module header). Always handled: the index always has Row 1.
+ */
+export function openSubNav(scene: StoreScene, root = false): boolean {
   if (scene.subNav) return true;
   const rows = [buildLibraryRow(scene), buildDisplayRow(scene)];
-  // Open on the first STOCK destination, not on the counter that now leads
-  // Row 1: ▼ is pressed to go shopping, and swinging the camera to the
-  // register every time would be a jarring default. The counter sits one ◀
-  // from here (the row wraps), which is the whole point of putting it first —
-  // it is the immediate neighbour of the landing selection, and you see it
-  // labelled the moment you step that way.
-  // Open on the first STOCK destination — ▼ is pressed to go shopping, so the
-  // non-shelf entries at the head of the row (counter, 2D mode) are stepped to
-  // deliberately, never landed on.
+  // Land on the player's FIRST LIBRARY. This is where they are standing when
+  // the store finishes loading, so it has to be a place they meant to go — a
+  // library of their own, named on the marker, and the same one every time.
+  // Not "the first entry in the row", which after the spatial sort is whatever
+  // happens to stand at the left edge of the room (a genre placard, the
+  // counter), and not the old overview cursor ring's pick, which was whichever
+  // marker landed nearest the middle of the frame — routinely a bargain bin.
+  const libraryItems = rows[0].filter((i) => i.kind === 'library');
+  const firstLibrary = libraryItems.length
+    ? rows[0].indexOf(libraryItems.reduce((a, b) => (b.libraryIdx < a.libraryIdx ? b : a)))
+    : -1;
   const firstStock = rows[0].findIndex((i) => i.kind !== 'checkout' && i.kind !== 'flat-mode');
-  scene.subNav = { rows, row: 0, sel: [Math.max(0, firstStock), 0], ret: captureBrowseReturn(scene) };
-  applyRow(scene, scene.subNav);
+  const landing = firstLibrary >= 0 ? firstLibrary : firstStock;
+  const state: SubNavState = {
+    rows, row: 0, sel: [Math.max(0, landing), 0], ret: captureBrowseReturn(scene), root,
+  };
+  // Coming back out of an aisle: pick up where the marker was left.
+  const mem = root ? scene.subNavRootFocus : null;
+  if (mem) {
+    const i = rows[mem.row]?.findIndex((it) => it.label === mem.label) ?? -1;
+    if (i >= 0) { state.row = mem.row; state.sel[mem.row] = i; }
+  }
+  scene.subNav = state;
+  applyRow(scene, state);
   retailAudio.playKeyClick();
   scene.onConsoleLog(
     `[System] Jump index — ${rows[0].length} counter/libraries/genres, ${rows[1].length} displays.`, 'system');
@@ -310,7 +388,7 @@ export function forgetSubNav(scene: StoreScene): void {
 
 /** ←/→ inside the active row (wraps — a remote has no way to "scroll faster"). */
 export function subNavArrow(scene: StoreScene, dir: number): boolean {
-  const state = scene.subNav;
+  const state = subNavActive(scene) ? scene.subNav! : null;
   if (!state) return false;
   const items = state.rows[state.row];
   if (items.length > 0) {
@@ -329,7 +407,7 @@ export function subNavArrow(scene: StoreScene, dir: number): boolean {
  * only where the build has no ambient TVs to peek at.
  */
 export function subNavUp(scene: StoreScene): boolean {
-  const state = scene.subNav;
+  const state = subNavActive(scene) ? scene.subNav! : null;
   if (!state || state.row === 0) return false;
   state.row = 0;
   applyRow(scene, state); // back to the overview vantage, arrow on the row-1 focus
@@ -345,7 +423,7 @@ export function subNavUp(scene: StoreScene): boolean {
  * the peek is up.
  */
 export function subNavRefresh(scene: StoreScene): boolean {
-  const state = scene.subNav;
+  const state = subNavActive(scene) ? scene.subNav! : null;
   if (!state) return false;
   applyRow(scene, state);
   return true;
@@ -353,7 +431,7 @@ export function subNavRefresh(scene: StoreScene): boolean {
 
 /** ▼: Row 1 → Row 2 (and swallowed on Row 2 — there is no third row). */
 export function subNavDown(scene: StoreScene): boolean {
-  const state = scene.subNav;
+  const state = subNavActive(scene) ? scene.subNav! : null;
   if (!state) return false;
   // An empty display row (bare test store) is unreachable rather than a
   // cursor-less dead zone the arrows silently rattle around in.
@@ -378,10 +456,10 @@ export function subNavDown(scene: StoreScene): boolean {
  *                                    close and leave the cursor where it was
  */
 export function subNavSelect(scene: StoreScene): boolean {
-  const state = scene.subNav;
+  const state = subNavActive(scene) ? scene.subNav! : null;
   if (!state) return false;
   const item = state.rows[state.row][state.sel[state.row]];
-  if (!item) return closeSubNav(scene, true);
+  if (!item) return subNavBack(scene) || true; // empty row: nothing to confirm
   closeSubNav(scene, false);
   retailAudio.playKeyClick();
 
@@ -443,20 +521,37 @@ export function subNavSelect(scene: StoreScene): boolean {
   return true;
 }
 
-/** Back always closes (and restores) — never falls through to backAction. */
+/**
+ * Back closes (and restores) an index opened over something.
+ *
+ * The ROOT index has nothing under it to restore, and closing it would strand
+ * the player in a view with no navigation at all — so there Back means "up one
+ * level": from the DISPLAYS row back to the sections row, and at the sections
+ * row it declines, leaving backAction's own root clamp to answer the press.
+ */
 export function subNavBack(scene: StoreScene): boolean {
+  const state = subNavActive(scene) ? scene.subNav! : null;
+  if (state?.root) {
+    if (state.row === 0) return false;
+    state.row = 0;
+    applyRow(scene, state);
+    retailAudio.playKeyClick();
+    scene.requestRender();
+    return true;
+  }
   return closeSubNav(scene, true);
 }
 
 /** Harness probe (`subnav` checkpoint). */
 export function debugSubNav(scene: StoreScene): {
-  open: boolean; row: number; sel: number[];
+  open: boolean; root: boolean; row: number; sel: number[];
   rows: string[][]; selected: string; kind: string;
 } {
   const state = scene.subNav;
   const item = state ? state.rows[state.row][state.sel[state.row]] : undefined;
   return {
     open: !!state,
+    root: !!state?.root,
     row: state?.row ?? -1,
     sel: state ? state.sel.slice() : [],
     rows: state ? state.rows.map((r) => r.map((i) => i.label)) : [],

--- a/src/store-subnav.ts
+++ b/src/store-subnav.ts
@@ -52,7 +52,7 @@ import { isEndcapKind } from './fixtures/genre-endcap';
 import { retailAudio } from './audio';
 import type { StoreScene } from './three-scene';
 
-export type SubNavKind = 'library' | 'new-releases' | 'genre' | 'fixture' | 'endcap';
+export type SubNavKind = 'library' | 'new-releases' | 'genre' | 'fixture' | 'endcap' | 'checkout';
 
 export interface SubNavItem {
   label: string;
@@ -128,10 +128,30 @@ function declutter(items: SubNavItem[]): void {
   }
 }
 
-/** Row 1: libraries in store order, the New Releases wall, then genre sections. */
+/**
+ * Row 1: the checkout counter, libraries in store order, the New Releases
+ * wall, then genre sections.
+ *
+ * The counter leads because it is the one destination that is not stock: it is
+ * where you pay, where the clerk stands, and — through Left at the counter —
+ * the ONLY way into the manager terminal, i.e. every setting the app has. The
+ * index listed every library, genre and display but not the counter, so a
+ * player navigating by the index (the whole point of the index) could reach
+ * every shelf in the building and never the register or the settings behind
+ * it. The entrance overview's own CHECKOUT cursor was the sole route, several
+ * arrow presses deep in a ring of aisle tickets.
+ */
 function buildLibraryRow(scene: StoreScene): SubNavItem[] {
   const out: SubNavItem[] = [];
   const genres: SubNavItem[] = [];
+  out.push({
+    label: 'CHECKOUT COUNTER',
+    kind: 'checkout',
+    libraryIdx: -1, unitIdxInLibrary: -1, side: 'front', col: 0, fixtureIdx: -1,
+    // Same anchor the overview's CHECKOUT cursor floats on: just above the
+    // counter band's store-facing apex.
+    x: 11.0, y: 5.4, z: scene.deskApexZ() + 0.6, yaw: 0, lookY: 3.0,
+  });
   for (let libIdx = 0; libIdx < scene.libraries.length; libIdx++) {
     const units = scene.shelvingUnits.filter((u) => u.libraryIdx === libIdx);
     if (units.length === 0) continue;
@@ -251,11 +271,18 @@ function applyRow(scene: StoreScene, state: SubNavState): void {
 export function openSubNav(scene: StoreScene): boolean {
   if (scene.subNav) return true;
   const rows = [buildLibraryRow(scene), buildDisplayRow(scene)];
-  scene.subNav = { rows, row: 0, sel: [0, 0], ret: captureBrowseReturn(scene) };
+  // Open on the first STOCK destination, not on the counter that now leads
+  // Row 1: ▼ is pressed to go shopping, and swinging the camera to the
+  // register every time would be a jarring default. The counter sits one ◀
+  // from here (the row wraps), which is the whole point of putting it first —
+  // it is the immediate neighbour of the landing selection, and you see it
+  // labelled the moment you step that way.
+  const firstStock = rows[0].findIndex((i) => i.kind !== 'checkout');
+  scene.subNav = { rows, row: 0, sel: [Math.max(0, firstStock), 0], ret: captureBrowseReturn(scene) };
   applyRow(scene, scene.subNav);
   retailAudio.playKeyClick();
   scene.onConsoleLog(
-    `[System] Jump index — ${rows[0].length} libraries/genres, ${rows[1].length} displays.`, 'system');
+    `[System] Jump index — ${rows[0].length} counter/libraries/genres, ${rows[1].length} displays.`, 'system');
   scene.requestRender();
   return true;
 }
@@ -355,6 +382,15 @@ export function subNavSelect(scene: StoreScene): boolean {
   if (!item) return closeSubNav(scene, true);
   closeSubNav(scene, false);
   retailAudio.playKeyClick();
+
+  if (item.kind === 'checkout') {
+    // Straight to the register — the same waypoint the overview's CHECKOUT
+    // cursor confirms into, and from there Left opens the manager terminal.
+    scene.enterCheckout();
+    scene.onConsoleLog(`[System] Jumping to "${item.label}".`, 'system');
+    scene.requestRender();
+    return true;
+  }
 
   if (item.kind === 'new-releases') {
     // Reuse the New Releases entry logic wholesale (the same hop the overview

--- a/src/store-subnav.ts
+++ b/src/store-subnav.ts
@@ -49,6 +49,7 @@ import {
 } from './browse-cursor';
 import { OVERVIEW_POS } from './scene-shared';
 import { isEndcapKind } from './fixtures/genre-endcap';
+import { slottedFixtureLabel, qualifyDuplicateLabels } from './fixture-labels';
 import { retailAudio } from './audio';
 import type { StoreScene } from './three-scene';
 
@@ -192,12 +193,8 @@ function buildDisplayRow(scene: StoreScene): SubNavItem[] {
     // campaign chain came up empty. Both report no slots AND no footprint —
     // never index a destination that isn't physically there.
     if (f.getSlots().length === 0 && !f.getFootprint?.()) return;
-    // `genre` is the fixture's own live identity string (a promo stand's
-    // campaign topper, a bin's name, an endcap's title) — the same one the
-    // browse HUD names it by; the placement option and the id are fallbacks.
-    const label = (f.genre || (p.options?.genre as string) || p.id || 'display').toUpperCase();
     out.push({
-      label,
+      label: slottedFixtureLabel(f),
       kind: isEndcapKind(p.kind) ? 'endcap' : 'fixture',
       libraryIdx: -1, unitIdxInLibrary: -1, side: 'front', col: 0,
       fixtureIdx,
@@ -208,25 +205,10 @@ function buildDisplayRow(scene: StoreScene): SubNavItem[] {
       lookY: heights.length > 0 ? (heights[0] + heights[heights.length - 1]) / 2 + 0.4 : 3.0,
     });
   });
-  // Front of the store first, so stepping right walks deeper in.
+  // Front of the store first, so stepping right walks deeper in — then number
+  // any repeated titles in that same stepping order.
   out.sort((a, b) => (b.z - a.z) || (a.x - b.x));
-  // Several endcaps share a title in an uncategorized store (they all fall
-  // back to "Related Movies"), and a row of identical tickets is unusable —
-  // qualify the repeats with the aisle they stand at the end of.
-  const counts = new Map<string, number>();
-  for (const it of out) counts.set(it.label, (counts.get(it.label) ?? 0) + 1);
-  const seen = new Map<string, number>();
-  for (const it of out) {
-    if ((counts.get(it.label) ?? 0) < 2) continue;
-    const base = it.label;
-    const n = (seen.get(base) ?? 0) + 1;
-    seen.set(base, n);
-    const lib = scene.slottedFixtures[it.fixtureIdx]?.placement.options?.libraryName as string | undefined;
-    // A qualifier that repeats the title ("MOVIES · MOVIES") disambiguates
-    // nothing — number those instead.
-    const qual = lib && lib.toUpperCase() !== base ? lib.toUpperCase() : null;
-    it.label = qual ? `${base} · ${qual}` : `${base} ${n}`;
-  }
+  qualifyDuplicateLabels(out, (it) => scene.slottedFixtures[it.fixtureIdx]);
   declutter(out);
   return out;
 }

--- a/src/store-subnav.ts
+++ b/src/store-subnav.ts
@@ -53,7 +53,8 @@ import { slottedFixtureLabel, qualifyDuplicateLabels } from './fixture-labels';
 import { retailAudio } from './audio';
 import type { StoreScene } from './three-scene';
 
-export type SubNavKind = 'library' | 'new-releases' | 'genre' | 'fixture' | 'endcap' | 'checkout';
+export type SubNavKind = 'library' | 'new-releases' | 'genre' | 'fixture' | 'endcap' | 'checkout'
+  | 'flat-mode';
 
 export interface SubNavItem {
   label: string;
@@ -153,6 +154,22 @@ function buildLibraryRow(scene: StoreScene): SubNavItem[] {
     // counter band's store-facing apex.
     x: 11.0, y: 5.4, z: scene.deskApexZ() + 0.6, yaw: 0, lookY: 3.0,
   });
+  // 2D MODE rides beside the counter for exactly the reason the counter itself
+  // is here: it was reachable ONLY from the entrance overview's arrow layer, so
+  // a player navigating by the index could never leave 3D — and on a store
+  // rooted at library-select (bb_overview_start=0) that layer is not built at
+  // all, leaving the power menu as the sole route. Offered only when a host has
+  // wired the handler; the harness and the asset viewer have not, and a dead
+  // row entry is worse than no entry.
+  if (scene.onEnterFlatMode) {
+    out.push({
+      label: '2D MODE',
+      kind: 'flat-mode',
+      libraryIdx: -1, unitIdxInLibrary: -1, side: 'front', col: 0, fixtureIdx: -1,
+      // The overview parks its own 2D MODE cursor here, just right of CHECKOUT.
+      x: 14.5, y: 5.4, z: scene.deskApexZ() + 0.6, yaw: 0, lookY: 3.0,
+    });
+  }
   for (let libIdx = 0; libIdx < scene.libraries.length; libIdx++) {
     const units = scene.shelvingUnits.filter((u) => u.libraryIdx === libIdx);
     if (units.length === 0) continue;
@@ -259,7 +276,10 @@ export function openSubNav(scene: StoreScene): boolean {
   // from here (the row wraps), which is the whole point of putting it first —
   // it is the immediate neighbour of the landing selection, and you see it
   // labelled the moment you step that way.
-  const firstStock = rows[0].findIndex((i) => i.kind !== 'checkout');
+  // Open on the first STOCK destination — ▼ is pressed to go shopping, so the
+  // non-shelf entries at the head of the row (counter, 2D mode) are stepped to
+  // deliberately, never landed on.
+  const firstStock = rows[0].findIndex((i) => i.kind !== 'checkout' && i.kind !== 'flat-mode');
   scene.subNav = { rows, row: 0, sel: [Math.max(0, firstStock), 0], ret: captureBrowseReturn(scene) };
   applyRow(scene, scene.subNav);
   retailAudio.playKeyClick();
@@ -364,6 +384,15 @@ export function subNavSelect(scene: StoreScene): boolean {
   if (!item) return closeSubNav(scene, true);
   closeSubNav(scene, false);
   retailAudio.playKeyClick();
+
+  if (item.kind === 'flat-mode') {
+    // Hands off to the same power-menu action the overview cursor confirms
+    // into; the store is about to be torn down for the flat shell, so there is
+    // no camera move to make here.
+    scene.onConsoleLog('[System] Switching to 2D mode.', 'system');
+    scene.onEnterFlatMode?.();
+    return true;
+  }
 
   if (item.kind === 'checkout') {
     // Straight to the register — the same waypoint the overview's CHECKOUT

--- a/src/store-walk.ts
+++ b/src/store-walk.ts
@@ -257,6 +257,10 @@ export function toggleWalkAround(scene: StoreScene) {
   } else {
     // Enter walk around mode
     scene.savedModeBeforeWalk = scene.mode;
+    // Let go of any counter-CRT camera dock first (search / manager terminal /
+    // NEW STORE SETUP). A stash left behind makes the next enterSearchMode()
+    // think it is still docked and quietly do nothing.
+    scene.releaseSearchDock();
     // T21: the overview's cursors/crosshair are mode dressing — hide them
     // while walking (restored on exit above).
     if (scene.mode === 'overview') scene.hideOverviewVisuals();

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -1548,6 +1548,17 @@ export class StoreScene {
     this.entrance?.setTerminalText(null); // desk CRTs back to the idle rental screen
   }
 
+  /**
+   * Walking away from the counter (store-walk.ts) drops the dock WITHOUT
+   * restoring its stashed pose — walk mode is about to take the camera anyway.
+   * Leaving the stash set is what made a later enterSearchMode() a silent
+   * no-op ("already docked"), so the CRT could never be reached again.
+   */
+  public releaseSearchDock(): void {
+    this.searchPreCameraPos = null;
+    this.searchPreLookAt = null;
+  }
+
   // Everything a swappable fixture (ambient TVs, entrance, ...) needs from the
   // scene, bundled so fixture classes never hold a reference to StoreScene.
   public fixtureContext(): FixtureContext {

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -696,6 +696,9 @@ export class StoreScene {
       shelf: number;
       col: number;
       nrDirect: boolean;
+      // Fixture-hosted cases are identified by these, not by unitIdx.
+      unitSource: 'shelving' | 'fixture';
+      fixtureId: string | null;
     };
   } | null = null;
   public slottedFixtures: SlottedFixture[] = [];
@@ -851,6 +854,14 @@ export class StoreScene {
   // only reports the intent — the menu's contents and key handling live in
   // main.ts alongside the power menu they mirror.
   public onCounterTerminal?: () => void;
+  // Same split for the search terminal: anything in-scene that offers "let me
+  // search" (the clerk dialog's option 1) must raise it through main.ts's
+  // openSearch(), which owns ui.isSearchOpen and therefore the Back key that
+  // closes it again. Calling enterSearchMode() directly instead docks the
+  // camera with nobody owning it, and since the dock is never released the
+  // NEXT enterSearchMode() early-returns — killing search and the manager
+  // terminal for the rest of the session.
+  public onOpenSearch?: () => void;
   public onEnterFlatMode?: () => void;
   public onBrowseConfirm?: () => void;
 
@@ -3486,6 +3497,8 @@ export class StoreScene {
   public navOverlaySelect(): boolean { return nav.navOverlaySelect(this); }
   public navOverlayBack(): boolean { return nav.navOverlayBack(this); }
   public isSubNavOpen(): boolean { return nav.isSubNavOpen(this); }
+  /** A scene-driven overlay (jump index / TV peek) owns the keys — see store-nav. */
+  public isNavOverlayOpen(): boolean { return nav.isNavOverlayOpen(this); }
   public debugNavOverlay() { return nav.debugNavOverlay(this); }
 
   // Deprecated: the genre menu is gone (shelves are permanently sorted into the

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -3083,27 +3083,16 @@ export class StoreScene {
 
   public hideOverviewVisuals(): void { return overview.hideOverviewVisuals(this); }
 
-  // Initial focus when (re)entering the overview: pick the cursor nearest the
-  // current aim so the arrow starts on something sensible straight ahead.
-  // After that, focus is purely index-driven (overviewFocusStep) — feedback/003.
+  // Pick the cursor nearest the current aim, for the query/confirm path only —
+  // declines while the jump index is up, which at the overview is always
+  // (store-overview.ts: the index is that view's navigation).
   public updateOverviewFocus(): void { return overview.updateOverviewFocus(this); }
 
   // Focus a cursor by index: highlight it, park the big arrow over it, and
   // turn the head toward it (the camera-target lerp makes the turn a smooth pan).
   public applyOverviewFocus(idx: number): void { return overview.applyOverviewFocus(this, idx); }
 
-  // feedback/003: ←/→ walk the cursor list in screen order (left→right as seen
-  // from the vantage), wrapping at the ends. Sorting a couple dozen indices on
-  // a keypress is nothing; doing it here (not cached) keeps it correct across
-  // cursor-set rebuilds (carry-mode toggles etc.).
-  public overviewFocusStep(dir: number): void { return overview.overviewFocusStep(this, dir); }
-
-  // Arrow-key head-look (up/down only since feedback/003): tilt the view by a
-  // fixed step, clamped so you can't stare at the ceiling/floor. Key repeat
-  // (and the gamepad auto-repeat in input.ts) makes a held arrow a smooth pan.
-  public overviewLook(dYaw: number, dPitch: number): void { return overview.overviewLook(this, dYaw, dPitch); }
-
-  // Stand at the entrance-overview vantage with the shelf cursors up. The
+  // Stand at the entrance-overview vantage with the jump index up. The
   // beginning browsing point when overviewStart is on; also the harness's
   // `--state overview` target.
   public enterOverview(): void { return overview.enterOverview(this); }
@@ -3395,8 +3384,10 @@ export class StoreScene {
   // stuck (the info panel wouldn't change). The public move* wrappers advance past
   // any run of the same movie id so each keypress lands on a genuinely new title.
   // requestRender() here wakes the on-demand renderer (issue #24) for the keystroke.
-  public moveLeft() { if (this.navOverlayArrow(-1)) return; this.requestRender(); if (this.claspCursorActive) this.exitClaspCursor(); if (this.mode === 'backroom') { this.backRoomMove(-1); return; } if (this.mode === 'overview') { this.overviewFocusStep(-1); return; } if (this.mode === 'checkout') { this.onCounterTerminal?.(); return; } this.moveSkippingDuplicates('left'); }
-  public moveRight() { if (this.navOverlayArrow(1)) return; this.requestRender(); if (this.claspCursorActive) this.exitClaspCursor(); if (this.mode === 'backroom') { this.backRoomMove(1); return; } if (this.mode === 'overview') { this.overviewFocusStep(1); return; } if (this.mode === 'checkout' && this.openTipJar()) return; this.moveSkippingDuplicates('right'); }
+  // (At the entrance overview navOverlayArrow above always consumes these —
+  // the jump index owns ←/→ there, and raises itself if it somehow isn't up.)
+  public moveLeft() { if (this.navOverlayArrow(-1)) return; this.requestRender(); if (this.claspCursorActive) this.exitClaspCursor(); if (this.mode === 'backroom') { this.backRoomMove(-1); return; } if (this.mode === 'checkout') { this.onCounterTerminal?.(); return; } this.moveSkippingDuplicates('left'); }
+  public moveRight() { if (this.navOverlayArrow(1)) return; this.requestRender(); if (this.claspCursorActive) this.exitClaspCursor(); if (this.mode === 'backroom') { this.backRoomMove(1); return; } if (this.mode === 'checkout' && this.openTipJar()) return; this.moveSkippingDuplicates('right'); }
 
   /**
    * The counter's other side press: Left docks to the manager terminal, Right
@@ -3487,12 +3478,15 @@ export class StoreScene {
 
   public moveDown() { return nav.moveDown(this); }
 
-  // Browse overlays that keep mode==='browse' and own the arrow keys while up
-  // (like the clasp cursor): the ceiling-TV peek (store-tv-peek.ts, entered by
-  // ▲ past the top shelf row) and the sub-nav jump index (store-subnav.ts,
-  // opened by ▼ at the bottom row). State + delegating stubs only.
+  // Scene-driven overlays that own the arrow keys while up (like the clasp
+  // cursor): the ceiling-TV peek (store-tv-peek.ts, ▲ at the index's Row 1)
+  // and the JUMP INDEX (store-subnav.ts) — which at the entrance overview is
+  // not an overlay at all but that view's own navigation, raised with it and
+  // never taken down. State + delegating stubs only.
   public tvPeek: peek.TvPeekState | null = null;
   public subNav: subnav.SubNavState | null = null;
+  /** Where the root index's marker was left, so backing out returns to it. */
+  public subNavRootFocus: subnav.SubNavFocusMemory | null = null;
   public navOverlayArrow(dir: number): boolean { return nav.navOverlayArrow(this, dir); }
   public navOverlaySelect(): boolean { return nav.navOverlaySelect(this); }
   public navOverlayBack(): boolean { return nav.navOverlayBack(this); }
@@ -3548,9 +3542,11 @@ export class StoreScene {
     if (this.mode === 'person-endcap' && this.personEndcap) {
       return this.personEndcap.person.toUpperCase();
     }
-    // T21: at the entrance overview the locator names the focused shelf cursor.
+    // T21: at the entrance overview the locator names the focused destination
+    // — the jump index's marker, which is what the player is pointing at.
     if (this.mode === 'overview') {
-      return this.overviewCursors?.focusedLabel || 'STORE OVERVIEW';
+      return this.debugNavOverlay().subnav.selected
+        || this.overviewCursors?.focusedLabel || 'STORE OVERVIEW';
     }
     if (this.selectedLibraryIdx === this.libraries.length) {
       return "NEW RELEASES";

--- a/tests/store-setup-screens.test.ts
+++ b/tests/store-setup-screens.test.ts
@@ -1,0 +1,161 @@
+// Issue #41 — unit tests for the NEW STORE SETUP terminal's pure screens:
+// row navigation, typed-field editing, the guard rails (no empty address, at
+// least one carried library), the actions each screen can emit, and the
+// 40-column line contract drawTerminal enforces.
+//
+//   npm run test:setup
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  initialHomeScreen,
+  setupScreenKey,
+  setupScreenChar,
+  setupScreenBackspace,
+  setupScreenLines,
+  type SetupScreen,
+} from '../src/store-setup-screens.ts';
+
+function lines(s: SetupScreen): string[] {
+  return setupScreenLines(s).lines;
+}
+
+test('home: starts on the address row with the saved address prefilled', () => {
+  const s = initialHomeScreen('http://tv:8096');
+  assert.equal(s.row, 1);
+  assert.equal(s.address, 'http://tv:8096');
+  assert.match(lines(s)[0], /NEW STORE SETUP/);
+});
+
+test('home: up/down wrap through the four rows', () => {
+  let s = initialHomeScreen();
+  s = setupScreenKey(s, 'down').state as typeof s;
+  assert.equal((s as any).row, 2);
+  s = setupScreenKey(setupScreenKey(s, 'down').state, 'down').state as typeof s;
+  assert.equal((s as any).row, 0); // wrapped past TRY A DEMO STORE
+  s = setupScreenKey(s, 'up').state as typeof s;
+  assert.equal((s as any).row, 3);
+});
+
+test('home: typing lands in the address only while its row is focused', () => {
+  let s: SetupScreen = initialHomeScreen('http://');
+  s = setupScreenChar(s, 'x');
+  assert.equal((s as any).address, 'http://x');
+  s = setupScreenBackspace(s);
+  assert.equal((s as any).address, 'http://');
+  const onProvider = setupScreenKey(s, 'up').state; // row 0
+  assert.equal((setupScreenChar(onProvider, 'x') as any).address, 'http://');
+});
+
+test('home: CONNECT without an address is refused with an error line', () => {
+  let s: SetupScreen = initialHomeScreen();
+  s = setupScreenKey(s, 'down').state; // CONNECT
+  const { state, action } = setupScreenKey(s, 'ok');
+  assert.equal(action, undefined);
+  assert.match((state as any).error, /ADDRESS/);
+});
+
+test('home: CONNECT with an address emits connect; demo row emits demo', () => {
+  let s: SetupScreen = { ...initialHomeScreen('http://tv:8096'), row: 2 };
+  assert.equal(setupScreenKey(s, 'ok').action, 'connect');
+  s = { ...s, row: 3 };
+  assert.equal(setupScreenKey(s, 'ok').action, 'demo');
+});
+
+test('home: OK on the distributor/address rows advances BIOS-style', () => {
+  let s: SetupScreen = { ...initialHomeScreen(), row: 0 };
+  s = setupScreenKey(s, 'ok').state;
+  assert.equal((s as any).row, 1);
+  s = setupScreenKey(s, 'ok').state;
+  assert.equal((s as any).row, 2);
+});
+
+test('manual-auth: sign-in requires a member name; back emits back-home', () => {
+  let s: SetupScreen = { kind: 'manual-auth', row: 2, username: '', password: '' };
+  const refused = setupScreenKey(s, 'ok');
+  assert.equal(refused.action, undefined);
+  assert.match((refused.state as any).error, /MEMBER NAME/);
+  s = { kind: 'manual-auth', row: 2, username: 'dave', password: '' };
+  assert.equal(setupScreenKey(s, 'ok').action, 'sign-in');
+  s = { kind: 'manual-auth', row: 3, username: '', password: '' };
+  assert.equal(setupScreenKey(s, 'ok').action, 'back-home');
+});
+
+test('manual-auth: the password renders masked, never in clear', () => {
+  const s: SetupScreen = { kind: 'manual-auth', row: 1, username: 'dave', password: 'hunter2' };
+  const all = lines(s).join('\n');
+  assert.ok(!all.includes('hunter2'));
+  assert.match(all, /\*{7}/);
+});
+
+test('libraries: OK toggles a row; OPEN THE STORE needs one carried', () => {
+  let s: SetupScreen = {
+    kind: 'libraries',
+    rows: [
+      { id: 'a', name: 'Movies', carried: true },
+      { id: 'b', name: 'Kids', carried: false },
+    ],
+    row: 0,
+  };
+  s = setupScreenKey(s, 'ok').state;
+  assert.equal((s as any).rows[0].carried, false);
+  const refused = setupScreenKey({ ...(s as any), row: 2 }, 'ok');
+  assert.equal(refused.action, undefined);
+  assert.match((refused.state as any).error, /AT LEAST ONE/);
+  s = setupScreenKey(s, 'ok').state; // toggle Movies back on
+  assert.equal(setupScreenKey({ ...(s as any), row: 2 }, 'ok').action, 'open-store');
+});
+
+test('libraries: long lists window around the cursor and keep OPEN last', () => {
+  const rows = Array.from({ length: 12 }, (_, i) => ({ id: String(i), name: `Library ${i}`, carried: true }));
+  const s: SetupScreen = { kind: 'libraries', rows, row: 11 };
+  const { lines: ls, cursorLine } = setupScreenLines(s);
+  assert.match(ls[cursorLine], /LIBRARY 11/);
+  assert.match(ls[ls.length - 1], /OPEN THE STORE/);
+  const home: SetupScreen = { kind: 'libraries', rows, row: 0 };
+  const first = setupScreenLines(home);
+  assert.match(first.lines[first.cursorLine], /LIBRARY 0/);
+});
+
+test('notice: rows emit retry / change-server / demo', () => {
+  const base: SetupScreen = { kind: 'notice', address: 'http://tv:8096', detail: 'NO ANSWER', row: 0 };
+  assert.equal(setupScreenKey(base, 'ok').action, 'retry');
+  assert.equal(setupScreenKey({ ...base, row: 1 }, 'ok').action, 'change-server');
+  assert.equal(setupScreenKey({ ...base, row: 2 }, 'ok').action, 'demo');
+});
+
+test('every screen honors the 40-column CRT clip', () => {
+  const long = 'http://a-truly-unreasonably-long-hostname.example.com:8096/jellyfin';
+  const screens: SetupScreen[] = [
+    { ...initialHomeScreen(long), error: 'X'.repeat(60) },
+    { kind: 'dialing', address: long, step: 'S'.repeat(60) },
+    { kind: 'members', count: 12 },
+    { kind: 'manual-auth', row: 0, username: 'u'.repeat(60), password: 'p'.repeat(60) },
+    { kind: 'libraries', rows: [{ id: 'a', name: 'N'.repeat(80), carried: true }], row: 0 },
+    { kind: 'sync', stage: 'S'.repeat(80), pages: 12345 },
+    { kind: 'arriving' },
+    { kind: 'notice', address: long, detail: 'D'.repeat(80), row: 0 },
+  ];
+  for (const s of screens) {
+    for (const line of lines(s)) {
+      assert.ok(line.length <= 40, `line over 40 cols: "${line}" (${line.length})`);
+    }
+  }
+});
+
+test('cursorLine always points at a real line', () => {
+  const screens: SetupScreen[] = [
+    initialHomeScreen(),
+    { kind: 'dialing', address: 'http://tv', step: 'DIALING...' },
+    { kind: 'members', count: 2 },
+    { kind: 'manual-auth', row: 3, username: '', password: '' },
+    { kind: 'libraries', rows: [{ id: 'a', name: 'Movies', carried: true }], row: 1 },
+    { kind: 'sync', stage: 'SYNC', pages: 0 },
+    { kind: 'arriving' },
+    { kind: 'notice', address: 'http://tv', detail: 'NO ANSWER', row: 2 },
+  ];
+  for (const s of screens) {
+    const { lines: ls, cursorLine } = setupScreenLines(s);
+    assert.ok(cursorLine >= 0 && cursorLine < ls.length, `cursor ${cursorLine} outside ${ls.length} lines for ${s.kind}`);
+  }
+});


### PR DESCRIPTION
Release **v0.3.0** — 15 commits on `dev` since v0.2.1. Closes #41 and #39 (closing keywords are in the commits).

### One navigation layer (5 commits)
- The jump index **is** the entrance view now. The old arrow-stepped cursor ring is deleted — booting into one nav mode and pressing ▼ to reach the real one was the bug.
- Root index lands on your **first library**, and both rows sort by bearing so ◄ ► walk the room instead of the build order.
- ▲ at the root opens the ceiling-TV peek in one press from boot.
- Four input-ownership / state-restore bugs fixed; `2D MODE` reachable from the index; the checkout counter is an index destination.

### Opening day (3 commits)
- First run is the store's opening day: **NEW STORE SETUP** on the counter CRT instead of a login box (#41).
- An empty store is actually empty — no bargain bin, no clerk, no ghost cursors.
- Signing in to a server that lists no public users no longer dead-ends (that's every hardened Jellyfin).

### Store fixtures (3 commits)
- Tape-return chute runs back to the counter's inside face; the open slot under the counter top is closed.
- 1993 ceiling category wedges: solid lit equilateral bodies, per-genre colors, GAMES.

### Other
- Ambient ceiling TVs: choose which libraries feed the playback pool (#39).
- `boot-flow.ts` extracted out of `main.ts`.

### Verification
- `npm run build` green (tsc + file-budget checks).
- `tools/verify_nav_states.mjs` green on **both** roots, baselines refreshed.
- Harness checkpoints re-shot for the nav work: overview / subnav / tvpeek / escspam / endcapbrowse / nrbrowse / browse / clasp / counterterm / backroom, plus a zero-library opening-day store.

**Not verified in this PR:** no fresh run of the perf tracer or the Docker image build — the tag push will exercise the latter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ao5sS692CKaLMuQUqMGGK
