### PR TITLE
Release v0.4.0 — mobile reach, image quality, and the mirror rework

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -4,12 +4,20 @@
 #   docker run -d --name halcyon --network host --restart unless-stopped \
 #     ghcr.io/halcyon-video/halcyon-video
 #
-# Runs on release tags (vX.Y.Z) and by hand (workflow_dispatch). amd64 only
-# for now: the arm64 half of the v0.2.0 publish died in `npm ci` with a V8
-# "Illegal instruction" under QEMU user emulation (the classic node-on-alpine
-# qemu failure), and emulating around it is a losing game — arm64 comes back
-# as a separate job on GitHub's native ubuntu-24.04-arm runners with a
-# manifest merge, tracked as a follow-up.
+# Runs on release tags (vX.Y.Z) and by hand (workflow_dispatch).
+#
+# amd64 AND arm64. The arm64 half of the v0.2.0 publish died in `npm ci` with a
+# V8 "Illegal instruction" under QEMU user emulation (the classic node-on-alpine
+# qemu failure), so arm64 was dropped rather than emulated around. It is back
+# here the way that failure said it had to be: each architecture builds on its
+# OWN native runner (GitHub's ubuntu-24.04-arm is free for public repos), pushes
+# an untagged image BY DIGEST, and a final job stitches the digests into one
+# multi-arch manifest that carries the tags. No QEMU anywhere.
+#
+# This matters more than a nice-to-have: the README and FAQ both pitch running
+# the store on a Raspberry Pi via 2.5D mode, and `docker run` is the documented
+# install — an amd64-only image sent every ARM self-hoster into `exec format
+# error` (issue #48).
 #
 # NOTE: the very first published package is PRIVATE by default — flip it to
 # public once under the org's Packages → halcyon-video → settings, or pulls
@@ -25,13 +33,82 @@ permissions:
   contents: read
   packages: write
 
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
 jobs:
-  publish:
-    runs-on: ubuntu-latest
+  build:
+    name: build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            slug: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            slug: arm64
     steps:
       - uses: actions/checkout@v4
 
-      # No setup-qemu: it existed only to emulate the arm64 build (see header).
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Labels only here — the tags are applied once, by the merge job, to the
+      # manifest list. Tagging each single-arch image would have the two
+      # architectures fight over the same tag, last writer winning.
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE }}
+
+      - uses: docker/build-push-action@v6
+        id: build
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Per-arch cache scope: one shared scope would have each build evict
+          # the other's layers every run.
+          cache-from: type=gha,scope=${{ matrix.slug }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.slug }}
+
+      # The merge job reconstructs image@sha256:<name> from these filenames, so
+      # the "sha256:" prefix is stripped here (shell expansion, not an Actions
+      # expression — those have no substring operators).
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p /tmp/digests
+          digest='${{ steps.build.outputs.digest }}'
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: merge manifest
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -44,18 +121,20 @@ jobs:
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ env.IMAGE }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=branch
 
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create the multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json }}') \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Show what landed
+        run: |
+          docker buildx imagetools inspect \
+            "${{ env.IMAGE }}:$(jq -cr '.tags[0] | split(":")[1]' <<< '${{ steps.meta.outputs.json }}')"

--- a/README.md
+++ b/README.md
@@ -44,12 +44,20 @@ The short answers, so you don't have to go looking for them.
 | | |
 |---|---|
 | **Run in Docker?** | Yes — one `docker run`, or `docker compose up -d` from a clone. [Quick start ↓](#quick-start) |
-| **Do video games?** | Yes — point it at [RomM](https://github.com/rommapp/romm) and a whole department appears: per-platform bays, period-correct boxes and jewel cases, and "renting" one launches it. [More ↓](#the-games-department) |
+| **Do video games?** | Yes — point it at [RomM](https://github.com/rommapp/romm) and a whole department appears: per-platform bays, period-correct boxes and jewel cases. [More ↓](#the-games-department) |
 | **Work with Plex or Emby?** | Not yet — Jellyfin today. The media layer is one module and adapters are the top roadmap item ([#32](https://github.com/halcyon-video/halcyon-video/issues/32)). |
 | **Run on a Raspberry Pi?** | Yes — **2.5D mode** runs the same store as plain HTML/CSS. [More ↓](#25d-mode--the-same-store-for-a-raspberry-pi) |
 | **Work away from home?** | Yes — **Remote Play** streams the live store to any browser, with its own TURN relay for off-LAN viewers. [More ↓](#remote-play--the-store-in-your-pocket) |
 | **Look like *my* video store?** | Yes — brand, logo, colors, themes, fixtures and sign art are all data you drop in a folder, not code. [More ↓](#make-it-yours) |
-| **Work with no media server at all?** | Yes — that's the demo link above. |
+| **Work with no media server at all?** | The demo does — it ships its own synthetic catalog, which is the link above. Shelving *your* files needs Jellyfin; there's no built-in folder scanner. |
+
+### Jump to
+
+**Get it running:** [Quick start](#quick-start) — npm, Docker, or HTPC kiosk · [FAQ](#faq)
+
+**See it:** [Browse the aisles](#browse-the-aisles) · [Pick up a case](#pick-up-a-case) · [Rent it like it's 1994](#rent-it-like-its-1994) · [The clerk](#the-clerk) · [Discovery](#discovery--the-store-stocks-what-youre-missing) · [Games](#the-games-department) · [Watching something](#watching-something)
+
+**Set it up:** [Manager terminal](#the-manager-terminal) · [Make it yours](#make-it-yours) · [2.5D mode](#25d-mode--the-same-store-for-a-raspberry-pi) · [Remote Play](#remote-play--the-store-in-your-pocket) · [Integrations](#integrations-at-a-glance)
 
 ---
 
@@ -187,8 +195,7 @@ at boot. She isn't decoration:
 
 - **She walks the store on grid-A\*** over the real floor plan — restocks
   shelves with a high/mid/low reach cycle, types at the terminal, idles at the
-  register. (There's a pathing audit that simulates seven minutes of her
-  roaming and fails CI if she ever clips through a fixture.)
+  register. (The pathfinder is pure math and unit-tested: `npm run test:nav`.)
 - **"ASK FOR RECOMMENDATIONS!"** clasps clipped to the shelf lips summon her to
   wherever you're standing, and her suggestion is scoped to the section you're
   in.
@@ -230,16 +237,13 @@ store quietly merchandises around your collection:
 
 Point it at **[RomM](https://github.com/rommapp/romm)** and a freestanding
 gondola appears: per-platform bays with brand-colored blades — SNES and N64
-cardboard boxes in landscape, PlayStation jewel cases, Genesis clamshells — 13
-platform toggles, top-rated titles first. "Renting" a game launches it: a
-native emulator under Tauri, or RomM's in-browser EmulatorJS player otherwise.
-Off by default; zero requests when disabled.
+cardboard boxes in landscape, PlayStation jewel cases, Genesis clamshells — 21
+platform toggles, top-rated titles first. Off by default; zero requests when
+disabled.
 
-Set **Emulator Command** in the manager terminal's Video Games page —
-`retroarch -L /path/to/core.so {path}`, where `{path}` becomes the rom. The
-desktop app spawns that as an argument array (never a shell) and only if the
-program is on a fixed emulator allowlist, so a typo fails closed instead of
-running something else. Leave it blank for the browser player.
+This is a **browsing** department: your ROM library, shelved and faced out the
+way a rental store would have merchandised it. Picking a game up doesn't
+currently start it playing.
 
 ![The video games department](docs/screenshots/games-department.jpg)
 
@@ -275,10 +279,8 @@ the clerk's desk CRT:
 
 ![MANAGER TERMINAL — SYSTEM CONTROL](docs/screenshots/manager-terminal.jpg)
 
-System control is *diegetic*: settings, 2D mode, system suspend, **HDMI-CEC
-display off/on**, log out, quit — the same actions as the glass-card power menu
-(`P`), rendered in 40-column amber. On an HTPC the store can put the TV to
-sleep and wake it from inside the fiction.
+System control is *diegetic*: settings, 2D mode, log out, quit — the same
+actions as the glass-card power menu (`P`), rendered in 40-column amber.
 
 ### Settings — paginated, thumbnailed, remote-first
 
@@ -383,7 +385,10 @@ default 2) and viewers past the cap are turned away until one frees up.
 
 ---
 
-## Little things you'll notice anyway
+<details>
+<summary><b>Little things you'll notice anyway</b> — the bargain bin, live-synthesized audio, the idle screensaver, F8 bug reports</summary>
+
+<br>
 
 - The **bargain bin** is genuinely your library's worst-audience-scored titles,
   leaning in a rummage jumble. Critic scores are pointedly ignored.
@@ -402,9 +407,14 @@ default 2) and viewers past the cap are turned away until one frees up.
 - Press **F8** anywhere to file a visual bug: it snapshots exactly what you saw
   plus the camera pose and config, replayable later shot-for-shot.
 
+</details>
+
 ---
 
-## Built to run forever
+<details>
+<summary><b>Built to run forever</b> — render-on-demand idle, no per-frame allocations, systemd kiosk deployment</summary>
+
+<br>
 
 This app's steady state is *days on a shelf*, and it's engineered like it:
 
@@ -422,6 +432,8 @@ This app's steady state is *days on a shelf*, and it's engineered like it:
 - Line budgets are enforced by the build; features live in composable scene
   modules, not one god file.
 
+</details>
+
 ---
 
 ## Integrations at a glance
@@ -430,14 +442,17 @@ This app's steady state is *days on a shelf*, and it's engineered like it:
 |---|---|
 | **Jellyfin** (required — or demo mode) | The store, browsing, walk mode, playback, rentals, living room, clerk, themes, brand editor |
 | **Jellyseerr** (optional) | Recommendation clasps, REQUEST / COMING SOON cases, collection gaps, discovery shelving, staff picks, FOR YOU endcaps, "order it for me" |
-| **RomM** (optional) | The video-game department, native or in-browser game launching |
-| **Tauri build** (optional) | mpv playback command, HDMI-CEC control, system suspend, native game launch, CORS-free proxying |
+| **RomM** (optional) | The video-game department: per-platform bays, real carton proportions, your cover scans |
+| **The server on the same machine as the TV** | mpv playback — real HDR and original lossless audio, no transcode |
 | Nothing at all | `?demo=1` — the full store on a synthetic library, no server, playback disabled |
 
 Every integration degrades by *absence*, not error: unconfigured features are
 never built, and callers never branch.
 
-### What talks to the internet
+<details>
+<summary><b>What talks to the internet</b> — nothing, unless you switch on Jellyseerr discovery (TMDB cover art) or Remote Play (one STUN query). Details ▸</summary>
+
+<br>
 
 The store is built to run on your own network. Fonts, textures and every other
 asset ship inside the bundle, and Jellyfin, Jellyseerr and RomM are your own
@@ -460,6 +475,8 @@ address did this reach you from?") and one answer, during connection setup. Your
 own TURN relay carries the actual traffic when a direct link can't be made. Note
 that the query happens whenever a session negotiates, including on your own LAN
 — an offline-only mode that drops it is on the roadmap rather than done.
+
+</details>
 
 ---
 
@@ -555,6 +572,9 @@ night, new releases, a full bag. That's the register the whole app aims for.
 ## Roadmap
 
 - Plex / Emby source adapters (most requested)
+- A published desktop build — the Tauri shell exists in-tree but isn't
+  released yet; it's what unlocks HDMI-CEC display control, system suspend,
+  and launching a game in a native emulator
 - More period fixtures and eras
 - VR walk mode experiments
 - More clerk conversations, more rituals

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:releasedate": "node --experimental-strip-types --test tests/media-release-date.test.ts tests/media-date-screen.test.ts",
     "test:playbackflow": "node --experimental-strip-types --test tests/playback-flow.test.ts",
     "test:setup": "node --experimental-strip-types --test tests/store-setup-screens.test.ts",
+    "test:subs": "node --experimental-strip-types --test tests/subtitle-delivery.test.ts",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "halcyon-video",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/canvas-textures.ts
+++ b/src/canvas-textures.ts
@@ -1258,7 +1258,9 @@ export function createWallTextures(palette = getActiveTheme().palette): {
   const wallTex = new THREE.CanvasTexture(wallCanvas);
   wallTex.colorSpace = THREE.SRGBColorSpace;
   wallTex.wrapS = wallTex.wrapT = THREE.RepeatWrapping;
-  wallTex.anisotropy = aniso(8);
+  // 16, matching carpet/ceiling/asphalt in this module: the walls are the
+  // longest sightline in the store, so they are the surface that most wants it.
+  wallTex.anisotropy = aniso(16);
 
   // Orange-peel height -> normal map.
   const wallHeight = document.createElement('canvas');
@@ -1756,7 +1758,11 @@ export function createWireMeshTexture(): THREE.Texture {
   tex.generateMipmaps = true;
   tex.minFilter = THREE.LinearMipmapLinearFilter;
   tex.magFilter = THREE.LinearFilter;
-  
+  // The 2000s wire shelving is seen edge-on down the length of every aisle —
+  // the grazing-angle case the rest of this module sets anisotropy for. Without
+  // it the grid collapses into mip mush exactly where the run is longest.
+  tex.anisotropy = aniso(16);
+
   return tex;
 }
 

--- a/src/device-gate.ts
+++ b/src/device-gate.ts
@@ -1,0 +1,224 @@
+// Device gate — the first thing a stranger's browser hits.
+//
+// Two devices reach the store and can't use it, and both used to fail silently:
+//
+//   1. A PHONE. The 3D store renders fine on a phone — it just has no input.
+//      Every control is a remote/arrow-key press (browse cursor, jump index,
+//      flip), and there is no touch handling anywhere in the app, so a visitor
+//      gets a beautiful room and a HUD reading "◀ ▶ PICK A SECTION" with
+//      nothing to press. ~40% of the launch-thread referral uniques came from
+//      the Reddit mobile app (issue #47), so this is the single most-hit dead
+//      end in the project.
+//
+//   2. A BROWSER WITHOUT WebGL2 — a VM, a locked-down work laptop, an old
+//      tablet, software rendering. StoreScene's constructor throws, main.ts
+//      catches it, logs "Falling back to 2D UI" to a console panel nobody has
+//      open, and hides the boot overlay. The result is a blank room.
+//
+// Both have the same answer, and it already exists: 2.5D flat mode is built out
+// of real DOM elements with click handlers (src/flat/), so a tap works, and it
+// needs no WebGL at all. This gate detects the two cases and offers that mode
+// instead of letting either fail. It is NOT a "sorry, come back on a desktop"
+// card — it is a door to the same library in the mode that device can actually
+// drive.
+//
+// Deliberately self-contained: its own <style>, no dependency on the 3D stack,
+// no dependency on styles.css having loaded. It runs on the paths where things
+// are already going wrong, so it assumes as little as possible. The only thing
+// it borrows is the house emblem in index.html's <defs> and the theme's palette
+// custom properties (never a hardcoded house color — see CLAUDE.md signage
+// rule 2), each with a fallback for the case where the theme never applied.
+import { getSetting, setSetting } from './settings';
+
+/** Remembered answer, so a returning visitor is never asked twice. */
+const ANSWER_KEY = 'bb_device_gate';
+const TOUR_URL = 'https://youtu.be/TCkEpeL8Y3w';
+
+export type GateReason = 'no-webgl2' | 'touch-primary';
+
+/**
+ * Can this browser build the 3D store at all? A throwaway probe context, freed
+ * immediately: a WebGL2 context left alive here would count against the
+ * browser's per-page context limit and could cost StoreScene its own.
+ */
+function hasWebGL2(): boolean {
+  try {
+    const gl = document.createElement('canvas').getContext('webgl2');
+    if (!gl) return false;
+    gl.getExtension('WEBGL_lose_context')?.loseContext();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A finger is the only pointer here. All three conditions matter: a touchscreen
+ * laptop is `coarse` but still has a keyboard and hover, and a 10-foot TV UI
+ * reports no hover but is large and driven by a remote the 3D store handles
+ * natively. Phones and small tablets are what's left.
+ */
+function isTouchPrimary(): boolean {
+  if (typeof window.matchMedia !== 'function') return false;
+  return window.matchMedia('(pointer: coarse)').matches
+      && window.matchMedia('(hover: none)').matches
+      && Math.min(window.innerWidth, window.innerHeight) < 700;
+}
+
+/** Why this device needs the gate, or null if it can drive the 3D store. */
+export function detectGateReason(): GateReason | null {
+  // ?nogate=1 is the escape hatch for verification tools that need to drive the
+  // real boot path on a device shape that would otherwise be gated.
+  if (new URLSearchParams(location.search).has('nogate')) return null;
+  // Already answered on this device, or already living in flat mode: nothing to
+  // ask. (A returning 2.5D visitor should just get 2.5D.)
+  if (localStorage.getItem(ANSWER_KEY)) return null;
+  if (getSetting<string>('bb_render_mode') === 'flat') return null;
+
+  if (!hasWebGL2()) return 'no-webgl2';
+  if (isTouchPrimary()) return 'touch-primary';
+  return null;
+}
+
+const COPY: Record<GateReason, { head: string; body: string; canStay: boolean }> = {
+  'touch-primary': {
+    head: 'Built for TVs and desktops',
+    body: 'The 3D store is walked with a remote or the arrow keys, so there’s '
+        + 'nothing here to tap. The 2D store is the same library, same shelves, '
+        + 'built to be touched.',
+    canStay: true,
+  },
+  'no-webgl2': {
+    head: 'This browser can’t run the 3D store',
+    body: 'Walking the aisles needs WebGL2, which this browser or graphics driver '
+        + 'doesn’t offer. The 2D store is plain HTML — same library, and it '
+        + 'needs none of it.',
+    // No point offering a 3D store that provably cannot start.
+    canStay: false,
+  },
+};
+
+function styleTag(): HTMLStyleElement {
+  const s = document.createElement('style');
+  s.textContent = `
+  #device-gate {
+    position: fixed; inset: 0; z-index: 2000;
+    display: flex; align-items: center; justify-content: center;
+    padding: 24px; box-sizing: border-box;
+    background: var(--bg-dark, #05070d);
+    font-family: var(--font-body, system-ui, -apple-system, sans-serif);
+    color: #fff; overflow-y: auto;
+  }
+  #device-gate .dg-card {
+    width: 100%; max-width: 460px; text-align: center;
+  }
+  #device-gate .dg-logo { width: min(240px, 62vw); margin: 0 auto 28px; display: block; }
+  #device-gate h1 {
+    font-family: var(--font-title, var(--font-body, system-ui), sans-serif);
+    font-size: clamp(24px, 7vw, 34px); line-height: 1.15; margin: 0 0 14px;
+    letter-spacing: 0.01em;
+  }
+  #device-gate p {
+    font-size: clamp(15px, 4vw, 17px); line-height: 1.5; margin: 0 0 28px;
+    color: rgba(255,255,255,0.76);
+  }
+  #device-gate button, #device-gate a.dg-btn {
+    display: block; width: 100%; box-sizing: border-box;
+    /* 52px keeps every target above the ~44px comfortable-tap floor. */
+    min-height: 52px; margin: 0 0 12px; padding: 15px 20px;
+    border-radius: 10px; border: 0; cursor: pointer;
+    font: inherit; font-size: 17px; font-weight: 600;
+    text-decoration: none; -webkit-tap-highlight-color: transparent;
+  }
+  #device-gate .dg-primary {
+    background: var(--bb-accent, #f2b325); color: var(--bb-primary, #10214a);
+  }
+  #device-gate .dg-secondary {
+    background: rgba(255,255,255,0.09); color: #fff;
+    border: 1px solid rgba(255,255,255,0.18);
+  }
+  #device-gate .dg-tertiary {
+    background: none; color: rgba(255,255,255,0.62);
+    font-weight: 500; font-size: 15px; min-height: 44px; text-decoration: underline;
+  }
+  #device-gate .dg-foot {
+    margin: 18px 0 0; font-size: 13px; color: rgba(255,255,255,0.42);
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    #device-gate { animation: dg-in 180ms ease-out; }
+    @keyframes dg-in { from { opacity: 0 } to { opacity: 1 } }
+  }`;
+  return s;
+}
+
+/**
+ * Show the gate and resolve once the visitor has chosen. Resolves immediately
+ * when the device doesn't need one, so callers can always await it.
+ *
+ * Sets `bb_render_mode` BEFORE resolving, which is why main() awaits this ahead
+ * of its boot call: the store then builds in the chosen mode first time, with
+ * no reload and no 3D scene built just to tear it down.
+ */
+export function runDeviceGate(): Promise<void> {
+  const reason = detectGateReason();
+  if (!reason) return Promise.resolve();
+
+  const { head, body, canStay } = COPY[reason];
+  return new Promise<void>((resolve) => {
+    const root = document.createElement('div');
+    root.id = 'device-gate';
+    root.setAttribute('role', 'dialog');
+    root.setAttribute('aria-modal', 'true');
+    root.appendChild(styleTag());
+
+    const card = document.createElement('div');
+    card.className = 'dg-card';
+    // The emblem is the one in index.html's <defs> — the active brand's board,
+    // never a copy (CLAUDE.md signage rule 2).
+    card.innerHTML = `
+      <svg class="dg-logo" viewBox="0 0 640 400" aria-label="Halcyon Video">
+        <use href="#bb-ticket-logo"/>
+      </svg>
+      <h1></h1>
+      <p></p>`;
+    (card.querySelector('h1') as HTMLElement).textContent = head;
+    (card.querySelector('p') as HTMLElement).textContent = body;
+
+    const finish = (mode: 'flat' | '3d') => {
+      setSetting('bb_render_mode', mode);
+      try { localStorage.setItem(ANSWER_KEY, mode); } catch { /* private mode */ }
+      root.remove();
+      resolve();
+    };
+
+    const openFlat = document.createElement('button');
+    openFlat.className = 'dg-primary';
+    openFlat.textContent = 'Open the 2D store';
+    openFlat.addEventListener('click', () => finish('flat'));
+    card.appendChild(openFlat);
+
+    const tour = document.createElement('a');
+    tour.className = 'dg-btn dg-secondary';
+    tour.href = TOUR_URL;
+    tour.target = '_blank';
+    tour.rel = 'noopener noreferrer';
+    tour.textContent = 'Watch the 45-second tour ▶';
+    card.appendChild(tour);
+
+    if (canStay) {
+      const stay = document.createElement('button');
+      stay.className = 'dg-tertiary';
+      stay.textContent = 'Continue to the 3D store anyway';
+      stay.addEventListener('click', () => finish('3d'));
+      card.appendChild(stay);
+    }
+
+    const foot = document.createElement('p');
+    foot.className = 'dg-foot';
+    foot.textContent = 'You can switch modes any time from the store menu.';
+    card.appendChild(foot);
+
+    root.appendChild(card);
+    document.body.appendChild(root);
+  });
+}

--- a/src/fixture-registry.ts
+++ b/src/fixture-registry.ts
@@ -15,6 +15,7 @@ import { GoldClamshellDisplay } from './fixtures/gold-clamshell';
 import { PvDrapeTable } from './fixtures/pv-drape-table';
 import { ComingSoonLetterboard } from './fixtures/coming-soon-letterboard';
 import { TipJar } from './fixtures/tip-jar';
+import { MirrorColumn } from './fixtures/mirror-column';
 
 export interface PlacedFixture extends StoreFixture {
   placement: FixturePlacement;
@@ -60,3 +61,4 @@ registerFixtureKind('gold-clamshell', (placement, ctx) => new GoldClamshellDispl
 registerFixtureKind('pv-drape-table', (placement, ctx) => new PvDrapeTable(placement, ctx));
 registerFixtureKind('coming-soon-letterboard', (placement, ctx) => new ComingSoonLetterboard(placement, ctx));
 registerFixtureKind('tip-jar', (placement, ctx) => new TipJar(placement, ctx));
+registerFixtureKind('mirror-column', (placement, ctx) => new MirrorColumn(placement, ctx));

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -52,6 +52,13 @@ export interface FixtureContext {
   // theme-derived approximation the same way store-shell.ts's own knee
   // walls do.
   wallSurface: { material: THREE.Material; storeWidth: number; roomHeight: number } | null;
+  // Live planar reflections, for fixtures with mirrored surfaces (see
+  // fixtures/mirror-column.ts). Present ONLY when this machine gets live
+  // mirrors at all (store-mirrors.ts's liveMirrorsAllowed) and carrying the
+  // render-target size they should use; absent means "dress the surface in
+  // static env-mapped chrome instead", which is also what the standalone
+  // asset viewer wants — a Reflector in an empty void reflects nothing.
+  liveMirror?: { textureWidth: number; textureHeight: number };
 }
 
 import { Movie } from './jellyfin';

--- a/src/fixtures/mirror-column.ts
+++ b/src/fixtures/mirror-column.ts
@@ -1,0 +1,176 @@
+// Four-sided mirrored column — a clad structural pillar standing in the open
+// sales floor, every face a mirror.
+//
+// These were a fixture of the real chains: a building's structural column is
+// unavoidable and visually dead, so it gets clad floor-to-ceiling in mirror,
+// which makes it read as a slot of open room instead of a post, and doubles the
+// apparent depth of the aisles around it. Bigger stores carried two or three.
+//
+// The build is deliberately structural, not decorative: a plinth, four mirror
+// panels, a cap band, and nothing else. It is a column, and a column that
+// starts growing signage stops reading as part of the building.
+//
+// COLOURS come from the active theme (signage rule 2 — never hardcode a house
+// colour into a fixture): the plinth and cap band take themeTrimDarkHex, so
+// they follow the brand the day it moves instead of wearing the old house
+// forever.
+//
+// MIRRORS: four Reflectors when this machine gets live ones at all
+// (ctx.liveMirror, set from store-mirrors.ts's liveMirrorsAllowed), otherwise
+// the same env-mapped chrome the cornice band falls back to. They cost nothing
+// extra while off-camera: store-mirrors.ts skips any mirror that fails its
+// frustum AND facing test, so the two faces pointing away from you never spend
+// a refresh, and the store's whole reflection budget stays one re-render per
+// stride tick no matter how many mirrors are standing.
+import * as THREE from 'three';
+import { Reflector } from 'three/examples/jsm/objects/Reflector.js';
+import { FixtureContext, StoreFixture } from '../fixtures';
+import { FixturePlacement, FLOOR_FIXTURE_MAX_Z } from '../store-layout';
+import { Footprint, FLOOR_DISPLAY_CLEARANCE } from '../layout-validator';
+import { themeTrimDarkHex, scaleHex } from '../themes';
+
+/** Clad width/depth of the column, feet. */
+const SIDE = 2.0;
+/** Plinth height and cap-band height, feet. */
+const PLINTH_H = 0.55;
+const CAP_H = 0.45;
+/** How far the plinth and cap stand proud of the mirror face, feet. */
+const REVEAL = 0.06;
+/** Gap left at each end of a mirror panel so the panel edge is not pinched. */
+const PANEL_INSET = 0.02;
+
+export class MirrorColumn implements StoreFixture {
+  public placement: FixturePlacement;
+
+  private ctx: FixtureContext;
+  private group: THREE.Group | null = null;
+  private disposables: Array<{ dispose(): void }> = [];
+
+  constructor(placement: FixturePlacement, ctx: FixtureContext) {
+    this.placement = placement;
+    this.ctx = ctx;
+
+    // Back-wall-relative Z, same contract as the promo stands and the bargain
+    // bin: the corridor these stand in is a fixed distance from the BACK of the
+    // store, and the store's depth is derived from the library size, so a fixed
+    // world Z lands mid-shelf-field on a shallow store.
+    const options = this.placement.options || {};
+    if (options.relativeToBackWall) {
+      const zOffset = typeof options.zOffset === 'number' ? options.zOffset : this.placement.position.z;
+      this.placement.position.z = Math.min(this.ctx.backWallZ + zOffset, FLOOR_FIXTURE_MAX_Z - 0.5);
+    }
+  }
+
+  private side(): number {
+    const s = this.placement.options?.side;
+    return typeof s === 'number' && s > 0.5 ? s : SIDE;
+  }
+
+  build(): void {
+    const side = this.side();
+    const { x, z } = this.placement.position;
+    const ceilingY = this.ctx.ceilingY;
+    const panelH = ceilingY - PLINTH_H - CAP_H;
+    if (panelH < 1.0) return; // absurdly low ceiling — no column rather than a stub
+
+    const group = new THREE.Group();
+    group.position.set(x, 0, z);
+    group.rotation.y = this.placement.yaw || 0;
+
+    const trimHex = themeTrimDarkHex();
+    const trimMat = new THREE.MeshStandardMaterial({
+      color: new THREE.Color(trimHex), roughness: 0.42, metalness: 0.25,
+    });
+    // The core is what shows in the hairline seams between panels and at the
+    // corners; a shade off the trim so the corner arris catches a highlight
+    // rather than disappearing into the mirror.
+    const coreMat = new THREE.MeshStandardMaterial({
+      color: new THREE.Color(scaleHex(trimHex, 1.35)), roughness: 0.5, metalness: 0.2,
+    });
+    this.disposables.push(trimMat, coreMat);
+
+    const box = (w: number, h: number, d: number, y: number, mat: THREE.Material) => {
+      const geo = new THREE.BoxGeometry(w, h, d);
+      this.disposables.push(geo);
+      const mesh = new THREE.Mesh(geo, mat);
+      mesh.position.set(0, y + h / 2, 0);
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      group.add(mesh);
+      return mesh;
+    };
+
+    box(side + REVEAL * 2, PLINTH_H, side + REVEAL * 2, 0, trimMat);
+    box(side, panelH, side, PLINTH_H, coreMat);
+    box(side + REVEAL * 2, CAP_H, side + REVEAL * 2, ceilingY - CAP_H, trimMat);
+
+    // Four faces, each rotated to look out along its own axis. The panel sits a
+    // hair proud of the core so it never z-fights the box it is mounted on.
+    const panelW = side - PANEL_INSET * 2;
+    const half = side / 2 + 0.004;
+    const faces: Array<{ dx: number; dz: number; rotY: number }> = [
+      { dx: 0, dz: half, rotY: 0 },
+      { dx: half, dz: 0, rotY: Math.PI / 2 },
+      { dx: 0, dz: -half, rotY: Math.PI },
+      { dx: -half, dz: 0, rotY: -Math.PI / 2 },
+    ];
+    const live = this.ctx.liveMirror;
+    const chromeMat = live ? null : new THREE.MeshStandardMaterial({
+      color: 0xd6dbe2, metalness: 1.0, roughness: 0.12, envMapIntensity: 1.0,
+    });
+    if (chromeMat) this.disposables.push(chromeMat);
+
+    for (const f of faces) {
+      const geo = new THREE.PlaneGeometry(panelW, panelH - PANEL_INSET * 2);
+      this.disposables.push(geo);
+      const panel = live
+        ? new Reflector(geo, {
+            clipBias: 0.003,
+            textureWidth: live.textureWidth,
+            textureHeight: live.textureHeight,
+            color: 0xffffff,
+          })
+        : new THREE.Mesh(geo, chromeMat!);
+      panel.position.set(f.dx, PLINTH_H + panelH / 2, f.dz);
+      panel.rotation.y = f.rotY;
+      group.add(panel);
+      // A Reflector owns a render target of its own — that is the expensive
+      // part, and its geometry dispose() would not touch it.
+      if (panel instanceof Reflector) this.disposables.push(panel);
+    }
+
+    this.ctx.scene.add(group);
+    this.ctx.addCollider(group);
+    this.group = group;
+  }
+
+  getFootprint(): Footprint | null {
+    if (!this.group) return null;
+    const side = this.side() + REVEAL * 2;
+    return {
+      label: `fixture:${this.placement.id}`,
+      kind: 'fixture',
+      cx: this.placement.position.x,
+      cz: this.placement.position.z,
+      w: side,
+      d: side,
+      yaw: this.placement.yaw || 0,
+      // Customers walk all the way around a column, exactly as they circle a
+      // floor display, so it asks for the same berth.
+      clearance: FLOOR_DISPLAY_CLEARANCE,
+    };
+  }
+
+  update(_timeMs: number): void {
+    // Static structure — the mirrors are driven by store-mirrors.ts.
+  }
+
+  dispose(): void {
+    if (this.group) {
+      this.ctx.scene.remove(this.group);
+      this.group = null;
+    }
+    this.disposables.forEach((d) => d.dispose());
+    this.disposables = [];
+  }
+}

--- a/src/jellyfin.ts
+++ b/src/jellyfin.ts
@@ -1520,6 +1520,75 @@ export function buildStaticStreamUrl(jellyfinUrl: string, token: string, itemId:
   return `${url}/Videos/${itemId}/stream?static=true&api_key=${encodeURIComponent(token)}${sourceParam}`;
 }
 
+/**
+ * Subtitle codecs that are TEXT, and can therefore be fetched as a WebVTT
+ * sidecar and rendered by the browser over the video. Everything else — PGS,
+ * DVD, DVB, XSUB — is a bitmap the browser cannot draw, so it still has to be
+ * burned into the picture server-side (see pickSubtitleDelivery).
+ *
+ * Jellyfin reports the ffmpeg codec name, which is why both spellings of the
+ * common ones are here (`subrip`/`srt`, `ssa`/`ass`); `mov_text` is the MP4
+ * flavour and `webvtt`/`vtt` are already what we're asking for.
+ */
+const TEXT_SUBTITLE_CODECS = new Set([
+  'subrip', 'srt', 'ass', 'ssa', 'mov_text', 'webvtt', 'vtt', 'text', 'subviewer', 'microdvd',
+]);
+
+/** Is this subtitle stream text (client-renderable) rather than a bitmap? */
+export function isTextSubtitleCodec(codec: string | undefined): boolean {
+  return !!codec && TEXT_SUBTITLE_CODECS.has(codec.toLowerCase());
+}
+
+/**
+ * How a chosen subtitle track should be delivered.
+ *
+ * This is the whole point of the client-side subtitle work: asking the server
+ * to burn subtitles in (`SubtitleMethod=Encode`) forces a full video re-encode,
+ * so on the browser/Remote Play path merely defaulting captions ON turned every
+ * direct-playable file into a transcode. A text track costs the server nothing
+ * — it's a sidecar fetch — and switching or disabling it needs no new stream
+ * at all. Bitmap subtitles have no client renderer, so they keep the old path
+ * and pay the old price.
+ */
+export type SubtitleDelivery =
+  | { kind: 'none' }
+  | { kind: 'text'; streamIndex: number }
+  | { kind: 'burn-in'; streamIndex: number };
+
+export function pickSubtitleDelivery(
+  streams: MediaStreamInfo[] | undefined,
+  streamIndex: number | undefined,
+): SubtitleDelivery {
+  if (streamIndex === undefined) return { kind: 'none' };
+  const stream = streams?.find((s) => s.type === 'Subtitle' && s.index === streamIndex);
+  // Unknown stream, or a server that didn't report a codec: assume text and
+  // try the cheap path. The two failure modes are not symmetric — a sidecar
+  // that 404s costs one failed request and leaves the film playing, while a
+  // needless burn-in costs a re-encode of the entire runtime.
+  if (!stream || stream.codec === undefined) return { kind: 'text', streamIndex };
+  return isTextSubtitleCodec(stream.codec)
+    ? { kind: 'text', streamIndex }
+    : { kind: 'burn-in', streamIndex };
+}
+
+/**
+ * WebVTT sidecar for one subtitle stream, for a <track> on the <video>.
+ * Jellyfin converts SRT/ASS/SSA to VTT on the fly here — styling and
+ * positioning are flattened, which is the trade for not re-encoding the film.
+ */
+export function buildSubtitleTrackUrl(
+  jellyfinUrl: string,
+  token: string,
+  itemId: string,
+  streamIndex: number,
+  mediaSourceId?: string,
+): string {
+  const url = jellyfinUrl.replace(/\/$/, '');
+  const source = mediaSourceId ?? itemId;
+  return `${url}/Videos/${itemId}/${encodeURIComponent(source)}/Subtitles/${streamIndex}/0/Stream.vtt`
+       + `?api_key=${encodeURIComponent(token)}`;
+}
+
 /** Track/quality overrides for buildHlsStreamUrl (the player's track picker). */
 export interface HlsStreamOptions {
   /** Jellyfin MediaStream index of the audio track to transcode. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,7 @@ import {
 import { setupTerminalInput } from './store-setup-flow';
 import { registerLibraryToggles } from './library-settings';
 import { getActiveTheme, applyThemeCssVars, THEMES, resolveThemeId } from './themes';
+import { runDeviceGate } from './device-gate';
 import {
   activeMediaCutoff,
   filterLibrariesByCutoff,
@@ -4075,6 +4076,13 @@ async function main() {
     candyCheckoutIndex = candyCheckoutRows.length + 1;
     renderCandyCheckout();
   });
+
+  // A phone or a WebGL2-less browser can't drive the 3D store; offer 2.5D
+  // instead of letting the boot dead-end (see device-gate.ts). Awaited here,
+  // before the boot call below, so the chosen mode is already settled and the
+  // store builds it first time — no 3D scene raised only to be torn down.
+  // Resolves immediately on hardware that's fine, which is every kiosk.
+  await runDeviceGate();
 
   // Check saved credentials and try connection in background (demo mode
   // skips the credential gate entirely and never shows the login overlay).

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,8 @@ import {
   buildHlsStreamUrl,
   isHevcPassThroughEnabled,
   buildStaticStreamUrl,
+  buildSubtitleTrackUrl,
+  pickSubtitleDelivery,
   isDirectPlaySafe,
   fetchItemPlaybackInfo,
   MediaPlaybackInfo,
@@ -3184,15 +3186,26 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
     );
   }
 
-  // Direct play can't switch audio tracks, and default-on subtitles are
-  // burned in server-side (SubtitleMethod=Encode) — either preference
-  // forces the HLS transcode path.
-  const directPlayable = isDirectPlaySafe(mediaInfo) && initialAudioIndex === undefined && initialSubtitleIndex === undefined;
+  // How the chosen subtitle reaches the screen decides whether the server has
+  // to re-encode the film at all. A TEXT track is a WebVTT sidecar the browser
+  // draws itself — free, instantly switchable, and it leaves direct play
+  // intact. Only bitmap subtitles (PGS/DVD/DVB) still have to be burned into
+  // the picture, because there is no client renderer for them.
+  const subtitleDelivery = pickSubtitleDelivery(streams, initialSubtitleIndex);
+  const subtitleTrackUrl = subtitleDelivery.kind === 'text'
+    ? buildSubtitleTrackUrl(jellyfinUrl, token, playbackId, subtitleDelivery.streamIndex, mediaSourceId)
+    : undefined;
+  const burnInSubtitleIndex = subtitleDelivery.kind === 'burn-in' ? subtitleDelivery.streamIndex : undefined;
+
+  // Direct play can't switch audio tracks, and burned-in subtitles are encoded
+  // server-side — either forces the HLS transcode path. Text subtitles no
+  // longer do.
+  const directPlayable = isDirectPlaySafe(mediaInfo) && initialAudioIndex === undefined && burnInSubtitleIndex === undefined;
   const hlsSrc = buildHlsStreamUrl(jellyfinUrl, token, playbackId, {
     sourceVideoCodec,
     mediaSourceId,
     audioStreamIndex: initialAudioIndex,
-    subtitleStreamIndex: initialSubtitleIndex,
+    subtitleStreamIndex: burnInSubtitleIndex,
     startPositionTicks: resumeTicks || undefined,
   });
   const hevcCopy = isHevcPassThroughEnabled() && (sourceVideoCodec === 'hevc' || sourceVideoCodec === 'h265');
@@ -3228,6 +3241,17 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
     defaultAudioIndex: initialAudioIndex,
     defaultSubtitleIndex: initialSubtitleIndex,
     subtitlesDefaultOn: wantSubtitles,
+    subtitleTrackUrl,
+    // Picking a subtitle in the player asks here how to deliver it: a URL
+    // means "text — hang this sidecar on the <video>, keep playing"; null
+    // means "bitmap — only a burned-in re-encode can show this", and the
+    // player falls back to rebuilding the stream.
+    buildSubtitleTrack: (streamIndex) => {
+      const d = pickSubtitleDelivery(streams, streamIndex);
+      return d.kind === 'text'
+        ? buildSubtitleTrackUrl(jellyfinUrl, token, playbackId, d.streamIndex, mediaSourceId)
+        : null;
+    },
     startPositionTicks: resumeTicks || undefined,
     hideVideoSurface: diegetic,
     // Non-diegetic playback exits through returnToEntrance() (onClose below)

--- a/src/remote-play.ts
+++ b/src/remote-play.ts
@@ -120,6 +120,17 @@ export function isRemotelyDriven(): boolean {
 
 /** Live-apply entry for the settings toggle. Safe to call redundantly. */
 export function setRemotePlayEnabled(on: boolean): void {
+  // A spawned private instance exists ONLY to host — its viewer is already
+  // waiting on the stream — so nothing may switch that off. This is a guard,
+  // not a nicety: the instance boots with the owner's donated settings, and
+  // applyLiveSettings() replays every explicitly-set live one onto the newly
+  // built scene. bb_remote_play was among them, so the instance would start
+  // hosting, finish building its store, and then immediately tear the stream
+  // down — leaving every private viewer on "Store is still booting…" forever.
+  if (instanceId && !on) {
+    console.log('[RemotePlay] ignoring disable on a private instance — hosting is its whole job');
+    return;
+  }
   if (on === running) return;
   running = on;
   stats.running = on;

--- a/src/remote-touch.ts
+++ b/src/remote-touch.ts
@@ -1,0 +1,200 @@
+// Touch controls for the Remote Play viewer.
+//
+// The README sells Remote Play as "the store in your pocket" and tells you to
+// open /remote.html on a phone or tablet — but the viewer only ever listened
+// for keydown/keyup, mousemove under pointer lock, and click. On a phone that
+// means: no keyboard, no pointer lock (iOS Safari has none), and a tap that
+// can pick a case but cannot MOVE the browse cursor. You got a live video of a
+// store you could not walk. This is the input layer that was missing.
+//
+// It sends the same `{t:'key'}` messages the keyboard path already sends, so
+// the host needs no changes at all — the data channel, the synthetic-event
+// dispatch in remote-play.ts, and the store's InputManager are all untouched.
+// Key names mirror src/input.ts exactly (verified against its dispatch block):
+// arrows browse, Enter selects, q backs out, f toggles walk.
+//
+// Two behaviours worth keeping in mind:
+//   - Press-and-hold repeats with `repeat: true`, like a held key. That is
+//     load-bearing on ▼, where InputManager routes repeats into the
+//     hold-to-dismiss gesture ("not interested"); a naive repeat that omitted
+//     the flag would fire N separate taps and flip the case N times instead.
+//   - Dragging on the video sends `look` deltas, which is what makes walk mode
+//     usable without pointer lock. A drag suppresses the tap-to-pick click that
+//     would otherwise fire at the end of the gesture.
+
+export interface TouchControlOpts {
+  stage: HTMLElement;
+  sendKey(key: string, code: string, down: boolean, repeat: boolean): void;
+  sendLook(dx: number, dy: number): void;
+  unmute(): void;
+  /** Set true while a drag is in flight so the click handler can skip it. */
+  setDragging(v: boolean): void;
+}
+
+/**
+ * A finger is the only pointer here — the same test the boot-time device gate
+ * uses. A touchscreen laptop keeps its keyboard, and a 10-foot TV browser is
+ * large and remote-driven, so neither wants a thumb D-pad painted over the
+ * stream.
+ */
+export function isTouchPrimary(): boolean {
+  if (typeof window.matchMedia !== 'function') return false;
+  return window.matchMedia('(pointer: coarse)').matches
+      && window.matchMedia('(hover: none)').matches
+      && Math.min(window.innerWidth, window.innerHeight) < 900;
+}
+
+const CSS = `
+#rt-pad, #rt-actions { position: absolute; bottom: max(18px, env(safe-area-inset-bottom));
+  z-index: 40; touch-action: none; user-select: none; -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent; }
+#rt-pad { left: max(16px, env(safe-area-inset-left)); display: grid;
+  grid-template-columns: repeat(3, 58px); grid-template-rows: repeat(3, 58px); }
+#rt-actions { right: max(16px, env(safe-area-inset-right)); display: flex;
+  flex-direction: column; gap: 10px; align-items: flex-end; }
+.rt-btn {
+  display: flex; align-items: center; justify-content: center;
+  background: rgba(10, 25, 68, 0.62); color: #ffd23f;
+  border: 1px solid rgba(120, 150, 230, 0.45); border-radius: 12px;
+  font: 700 17px/1 system-ui, sans-serif; letter-spacing: 0.04em;
+  backdrop-filter: blur(3px); -webkit-backdrop-filter: blur(3px);
+  transition: background 90ms, transform 90ms;
+}
+.rt-btn.rt-held { background: rgba(255, 210, 63, 0.85); color: #0a1944; transform: scale(0.94); }
+#rt-pad .rt-btn { font-size: 21px; margin: 3px; }
+#rt-actions .rt-btn { min-width: 76px; height: 50px; padding: 0 16px; }
+#rt-actions .rt-ok { background: rgba(255, 210, 63, 0.9); color: #0a1944; border-color: #ffd23f; }
+/* Landscape phones are short: shrink so the pad never eats the picture. */
+@media (max-height: 460px) {
+  #rt-pad { grid-template-columns: repeat(3, 46px); grid-template-rows: repeat(3, 46px); }
+  #rt-actions .rt-btn { height: 42px; min-width: 66px; }
+}`;
+
+/** Grid placement for the D-pad's cross, by [column, row]. */
+const PAD: Array<{ label: string; key: string; code: string; col: number; row: number }> = [
+  { label: '▲', key: 'ArrowUp',    code: 'ArrowUp',    col: 2, row: 1 },
+  { label: '◀', key: 'ArrowLeft',  code: 'ArrowLeft',  col: 1, row: 2 },
+  { label: '▶', key: 'ArrowRight', code: 'ArrowRight', col: 3, row: 2 },
+  { label: '▼', key: 'ArrowDown',  code: 'ArrowDown',  col: 2, row: 3 },
+];
+
+const ACTIONS: Array<{ label: string; key: string; code: string; cls?: string }> = [
+  { label: 'OK',   key: 'Enter', code: 'Enter', cls: 'rt-ok' },
+  { label: 'BACK', key: 'q',     code: 'KeyQ' },
+  { label: 'WALK', key: 'f',     code: 'KeyF' },
+];
+
+const REPEAT_DELAY_MS = 380;   // matches a typical keyboard's first repeat
+const REPEAT_EVERY_MS = 120;
+
+export function installTouchControls(opts: TouchControlOpts): void {
+  const { stage, sendKey, sendLook, unmute, setDragging } = opts;
+
+  const style = document.createElement('style');
+  style.textContent = CSS;
+  document.head.appendChild(style);
+
+  /** Wire one button: down on press, `repeat: true` ticks while held, up on release. */
+  const bind = (el: HTMLElement, key: string, code: string) => {
+    let timer = 0;
+    let interval = 0;
+    let held = false;
+
+    const press = (e: Event) => {
+      e.preventDefault();      // no scroll, no double-tap zoom, no synthetic click
+      e.stopPropagation();     // never reaches the stage's tap-to-pick handler
+      if (held) return;
+      held = true;
+      el.classList.add('rt-held');
+      unmute();
+      sendKey(key, code, true, false);
+      timer = window.setTimeout(() => {
+        interval = window.setInterval(() => sendKey(key, code, true, true), REPEAT_EVERY_MS);
+      }, REPEAT_DELAY_MS);
+    };
+    const release = (e: Event) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (!held) return;
+      held = false;
+      el.classList.remove('rt-held');
+      clearTimeout(timer); clearInterval(interval);
+      timer = 0; interval = 0;
+      sendKey(key, code, false, false);
+    };
+
+    el.addEventListener('touchstart', press, { passive: false });
+    el.addEventListener('touchend', release, { passive: false });
+    // A finger sliding off the button, or the OS stealing the gesture, must
+    // still release the key — otherwise the host is left with it stuck down.
+    el.addEventListener('touchcancel', release, { passive: false });
+    el.addEventListener('contextmenu', (e) => e.preventDefault());
+  };
+
+  const pad = document.createElement('div');
+  pad.id = 'rt-pad';
+  for (const b of PAD) {
+    const el = document.createElement('div');
+    el.className = 'rt-btn';
+    el.textContent = b.label;
+    el.style.gridColumn = String(b.col);
+    el.style.gridRow = String(b.row);
+    el.setAttribute('aria-label', b.key);
+    bind(el, b.key, b.code);
+    pad.appendChild(el);
+  }
+
+  const actions = document.createElement('div');
+  actions.id = 'rt-actions';
+  for (const b of ACTIONS) {
+    const el = document.createElement('div');
+    el.className = `rt-btn ${b.cls ?? ''}`.trim();
+    el.textContent = b.label;
+    el.setAttribute('aria-label', b.label);
+    bind(el, b.key, b.code);
+    actions.appendChild(el);
+  }
+
+  document.body.appendChild(pad);
+  document.body.appendChild(actions);
+
+  // ── Drag to look ──────────────────────────────────────────────────────────
+  // Walk mode is driven by mouse-look, which needs pointer lock — unavailable
+  // on iOS Safari and meaningless without a mouse. A one-finger drag on the
+  // picture sends the same `look` deltas instead. Below the slop threshold the
+  // gesture stays a tap, so tap-to-pick still works.
+  const SLOP_PX = 8;
+  let lastX = 0, lastY = 0, dragging = false, moved = 0;
+
+  stage.addEventListener('touchstart', (e) => {
+    if (e.touches.length !== 1) return;
+    lastX = e.touches[0].clientX;
+    lastY = e.touches[0].clientY;
+    moved = 0;
+    dragging = false;
+  }, { passive: true });
+
+  stage.addEventListener('touchmove', (e) => {
+    if (e.touches.length !== 1) return;
+    const t = e.touches[0];
+    const dx = t.clientX - lastX;
+    const dy = t.clientY - lastY;
+    lastX = t.clientX;
+    lastY = t.clientY;
+    moved += Math.abs(dx) + Math.abs(dy);
+    if (moved < SLOP_PX) return;
+    if (!dragging) { dragging = true; setDragging(true); unmute(); }
+    e.preventDefault();               // stop the page rubber-banding under the drag
+    sendLook(dx, dy);
+  }, { passive: false });
+
+  const endDrag = () => {
+    if (!dragging) return;
+    dragging = false;
+    // Cleared a frame later: the synthesized click lands after touchend, and
+    // this flag is what tells the viewer's click handler to ignore it.
+    setTimeout(() => setDragging(false), 0);
+  };
+  stage.addEventListener('touchend', endDrag, { passive: true });
+  stage.addEventListener('touchcancel', endDrag, { passive: true });
+}

--- a/src/remote-touch.ts
+++ b/src/remote-touch.ts
@@ -64,10 +64,15 @@ const CSS = `
 #rt-pad .rt-btn { font-size: 21px; margin: 3px; }
 #rt-actions .rt-btn { min-width: 76px; height: 50px; padding: 0 16px; }
 #rt-actions .rt-ok { background: rgba(255, 210, 63, 0.9); color: #0a1944; border-color: #ffd23f; }
+/* The page's own hint line sits bottom-centre, which is exactly where the pad
+   now is: lift it clear and let it wrap, since its phone wording is longer
+   than the nowrap desktop one and a 390px screen cuts it off at both ends. */
+#hint { bottom: 200px; max-width: 84vw; white-space: normal; text-align: center; }
 /* Landscape phones are short: shrink so the pad never eats the picture. */
 @media (max-height: 460px) {
   #rt-pad { grid-template-columns: repeat(3, 46px); grid-template-rows: repeat(3, 46px); }
   #rt-actions .rt-btn { height: 42px; min-width: 66px; }
+  #hint { bottom: 158px; }
 }`;
 
 /** Grid placement for the D-pad's cross, by [column, row]. */

--- a/src/remote-viewer.ts
+++ b/src/remote-viewer.ts
@@ -8,6 +8,8 @@
 // of three.js and app imports: this page must load instantly on a phone or an
 // old laptop — the whole point of server-side rendering the store.
 
+import { installTouchControls, isTouchPrimary } from './remote-touch';
+
 const video = document.getElementById('screen') as HTMLVideoElement;
 const stage = document.getElementById('stage') as HTMLDivElement;
 const statusEl = document.getElementById('status') as HTMLDivElement;
@@ -393,7 +395,12 @@ function toggleMouseLook() {
 // Clicks: while mouse-looking the host activates whatever its walk-mode gaze
 // has focused (coordinates are irrelevant); otherwise map the click through
 // the object-fit letterbox onto normalized video coordinates.
+// Set while a touch drag is looking around; the click a touchend synthesizes
+// afterwards would otherwise pick whatever the finger happened to stop on.
+let touchDragging = false;
+
 stage.addEventListener('click', (e) => {
+  if (touchDragging) return;
   unmute();
   if (document.pointerLockElement === stage) {
     sendInput({ t: 'click', x: 0.5, y: 0.5 });
@@ -411,6 +418,22 @@ stage.addEventListener('click', (e) => {
   if (x < 0 || x > 1 || y < 0 || y > 1) return; // letterbox bar
   sendInput({ t: 'click', x, y });
 });
+
+// Touch devices get a thumb D-pad + drag-to-look instead of a keyboard they
+// don't have and a pointer lock iOS Safari won't grant (src/remote-touch.ts).
+// Everything it sends is an ordinary key/look message, so the host is unaware
+// there's a phone on the other end.
+if (isTouchPrimary()) {
+  installTouchControls({
+    stage,
+    sendKey: (key, code, down, repeat) =>
+      sendInput({ t: 'key', et: down ? 'down' : 'up', key, code, repeat }),
+    sendLook: (dx, dy) => sendInput({ t: 'look', dx, dy }),
+    unmute,
+    setDragging: (v) => { touchDragging = v; },
+  });
+  hintEl.textContent = 'D-pad browses · OK selects · drag to look around · tap a case to pick it';
+}
 
 // Verification hook (tools/verify_remote_play.mjs).
 (window as any).__remoteViewer = {

--- a/src/scene-shared.ts
+++ b/src/scene-shared.ts
@@ -78,6 +78,11 @@ export const CAMERA_GLIDE_LERP = 0.3;
 export const TOP_WRAP_GLIDE_LERP = 0.2;
 
 // Hitch-tracer slots for the hero-case rebind (see perf-trace.ts).
+export const SP_MIRROR = perfSlot('mirrorMs');   // Reflector re-render inside the composite
+export const CT_MIRROR = perfSlot('mirrorDraw');
+// Live planar reflection refresh target, Hz — deliberately well under any
+// display rate; store-mirrors.ts explains what that buys.
+export const MIRROR_REFRESH_HZ = 20;
 export const SP_HERO = perfSlot('heroMs');   // hero-case rebind (real artwork materials)
 export const CT_HERO = perfSlot('heroBind'); // selection moved onto a new title
 

--- a/src/store-fixtures-config.ts
+++ b/src/store-fixtures-config.ts
@@ -1,4 +1,4 @@
-import { FixturePlacement, BOX_SPACING } from './store-layout';
+import { FixturePlacement, BOX_SPACING, STORE_CENTER_X } from './store-layout';
 import { registerFixtureKind } from './fixture-registry';
 import { StructureFootprint } from './fixtures/period-fixtures';
 import { PV_DRAPE_TABLE_POP_KIT } from './fixtures/pv-drape-table';
@@ -44,6 +44,39 @@ export const DEFAULT_FIXTURE_PLACEMENTS: FixturePlacement[] = [
   // the game department took that corner, was removed at user direction —
   // the front corners stay open floor. binIndex 1 kept so the pool slice is
   // unchanged.)
+  // ── Mirrored structural column ────────────────────────────────────────────
+  // A clad four-sided mirror pillar in the open back floor — see
+  // fixtures/mirror-column.ts for what it is and why the chains built them.
+  //
+  // It stands in the BACK CROSS-AISLE — the open floor behind the aisle runs,
+  // between their back ends and the New Releases wall — at the left edge of the
+  // central walkway. That is where a real column lands: in circulation space, on
+  // the building's grid, touching no fixture's working face.
+  //
+  // Why not the store centreline, which is the obvious first guess: it has no
+  // room at any depth. Going back from the front, the corridor chain above
+  // (bargain bin at zOffset 11.5, promo stands at 18 and 24.5) leaves gaps of
+  // 6.5 ft, and two 3 ft clearances plus the column itself need 8.1; and the
+  // one remaining slot, zOffset ~5, is New Releases' own ground. That section
+  // anchors at (STORE_CENTER_X, backWallZ + 4) — store-camera.ts parks the
+  // browse camera and the overview marker there — so a column on the centreline
+  // 5 ft off the back wall does not merely crowd the NR wall, it stands in the
+  // spot the camera flies to.
+  //
+  // (5, backWallZ + 8) clears all of it: 5.9 ft to the bargain bin, 6.9 ft to
+  // the back wall, and it sits 4 ft off the NR camera lane and 6 ft off its
+  // axis, so the wall it could have blocked is browsed past it, not through it.
+  // CENTER_WALKWAY is 16 ft centred on x=11, i.e. x 3..19, so this hugs its
+  // left edge and the corridor stays walkable. The mirrored position (x=17) is
+  // free if the owner wants the flanking pair the bigger stores had — the two
+  // would read as one structural bay.
+  {
+    id: 'mirror-column-back',
+    kind: 'mirror-column',
+    position: { x: STORE_CENTER_X - 6, z: 8 },
+    yaw: 0,
+    options: { relativeToBackWall: true, zOffset: 8 }
+  },
   {
     id: 'bargain-bin-1',
     kind: 'bargain-bin',

--- a/src/store-mirrors.ts
+++ b/src/store-mirrors.ts
@@ -43,6 +43,20 @@ export type MirrorEntry = {
   rendered: boolean;
 };
 
+// Stand-in for the OTHER mirrors while one is rendering — see draw(). Chrome
+// with metalness 1 samples the room environment, so a mirror seen inside
+// another mirror reads as polished metal.
+let proxyMat: THREE.MeshStandardMaterial | null = null;
+function mirrorProxyMaterial(): THREE.MeshStandardMaterial {
+  if (!proxyMat) {
+    proxyMat = new THREE.MeshStandardMaterial({
+      color: 0xd6dbe2, metalness: 1.0, roughness: 0.12, envMapIntensity: 1.0,
+    });
+  }
+  return proxyMat;
+}
+const savedMats: Array<{ o: any; m: any }> = [];
+
 // Scratch, module-scoped so the per-frame pass allocates nothing.
 const frustumScratch = new THREE.Frustum();
 const projScreenScratch = new THREE.Matrix4();
@@ -173,10 +187,30 @@ export function renderMirrorsAhead(scene: StoreScene) {
       m.dirty = false;
       m.rendered = true;
       budget--;
+      // MIRROR INSIDE A MIRROR. The recursion guard above stops the nested
+      // RENDER, but it does not stop the other Reflectors from being DRAWN
+      // into this one's reflection — and they sample their texture with
+      // screen-space projective coords solved for the MAIN camera. From this
+      // mirror's virtual camera those coords are meaningless, so the panel
+      // comes out a black hole with stretched slivers down its edge. It only
+      // shows when two mirrors can see each other, which is rare between the
+      // cornice bands and constant once a mirrored column stands in the room.
+      // Swap the others to static chrome for the duration.
+      const proxy = mirrorProxyMaterial();
+      savedMats.length = 0;
+      for (const o of scene.mirrors) {
+        if (o === m) continue;
+        savedMats.push({ o: o.r, m: o.r.material });
+        o.r.material = proxy;
+      }
       perfTrace.count(CT_MIRROR);
       perfTrace.begin(SP_MIRROR);
       try { m.original(scene.renderer, scene.scene, scene.camera); }
-      finally { perfTrace.end(SP_MIRROR); }
+      finally {
+        perfTrace.end(SP_MIRROR);
+        for (const s of savedMats) s.o.material = s.m;
+        savedMats.length = 0;
+      }
     };
 
     // Round-robin over the mirrors in frame, so several sharing the view share

--- a/src/store-mirrors.ts
+++ b/src/store-mirrors.ts
@@ -1,0 +1,128 @@
+// Live planar-mirror throttling — extracted from StoreScene (three-scene.ts
+// keeps one-line delegating stubs). The cornice band and the front soffit ring
+// are three.js Reflectors: each one re-renders the whole scene from its own
+// viewpoint, which is the single most expensive thing in the frame at catalog
+// scale. Everything here exists to make them cost almost nothing when nothing
+// about the reflection has actually changed.
+//
+// Both functions take the StoreScene as their first parameter and read/write
+// scene state exactly as the original methods did.
+import { Reflector } from 'three/examples/jsm/objects/Reflector.js';
+import { perfTrace } from './perf-trace';
+import { SP_MIRROR, CT_MIRROR, MIRROR_REFRESH_HZ } from './scene-shared';
+import type { StoreScene } from './three-scene';
+
+// Recursion guard, module-scoped: the pillars face each other and the cornice
+// faces the room, so an unguarded reflector renders inside another reflector's
+// render, cascading into hundreds of nested scene draws.
+let reflectorRendering = false;
+
+/**
+ * A naive setup re-renders every mirror's reflection every frame. Each
+ * Reflector renders the whole scene from its viewpoint, and because the
+ * pillars face each other + the cornice faces the room, those renders
+ * cascade into each other — hundreds of nested renders that crash the GPU,
+ * and even guarded against recursion they cost ~12 full scene renders/frame
+ * (~26 fps).
+ *
+ * But a planar reflection of a static scene only changes when the *viewer*
+ * moves. So we wrap each mirror's onBeforeRender to render only when:
+ *   - no other mirror is mid-render (kills the recursion cascade), AND
+ *   - this mirror is "dirty" (the camera moved since it last rendered), AND
+ *   - we're under the per-frame budget (≤1 mirror render/frame).
+ * When you're parked at a shelf the mirrors are free (they reuse their last
+ * reflection texture, which is still correct), so browsing runs at full
+ * frame-rate. Reflections are frozen while the camera moves and refreshed once
+ * it settles (see updateMirrorThrottle) — the reflection is a real render, so
+ * shelves are the right size and perspective from wherever you come to rest.
+ */
+export function installMirrorThrottle(scene: StoreScene) {
+  scene.scene.traverse((obj) => {
+    if (obj instanceof Reflector) {
+      const entry = { r: obj, dirty: true };
+      scene.mirrors.push(entry);
+      const original = obj.onBeforeRender.bind(obj);
+      obj.onBeforeRender = (...args: any[]) => {
+        if (reflectorRendering) return;                 // no mirror-in-mirror nesting
+        if (!entry.dirty || scene.mirrorRenderBudget <= 0) return;  // static view → reuse last reflection
+        entry.dirty = false;
+        scene.mirrorRenderBudget--;
+        reflectorRendering = true;
+
+        // Temporarily hide the selection arrow during mirror renders so it doesn't reflect
+        const arrowWasVisible = scene.selectionArrow ? scene.selectionArrow.visible : false;
+        if (scene.selectionArrow) {
+          scene.selectionArrow.visible = false;
+        }
+
+        perfTrace.count(CT_MIRROR);
+        perfTrace.begin(SP_MIRROR);
+        try { (original as any)(...args); }
+        finally {
+          perfTrace.end(SP_MIRROR);
+          if (scene.selectionArrow) {
+            scene.selectionArrow.visible = arrowWasVisible;
+          }
+          reflectorRendering = false;
+        }
+      };
+    }
+  });
+}
+
+/**
+ * Called once per frame before rendering. Decides whether any mirror needs
+ * a fresh reflection this frame and, if so, admits at most one into the
+ * render budget that installMirrorThrottle's onBeforeRender wrapper consumes.
+ *
+ * - Camera fully still and nothing structural changed: budget = 0, every
+ *   mirror reuses its last reflection texture (0 reflector renders/frame).
+ * - Camera moving: one mirror is round-robined into the dirty queue per
+ *   frame (mirrorRefreshIdx), budget = 1, so reflections track the camera
+ *   at ~1 render/frame instead of 4.
+ * - Structural change (forceAll — scene rebuild, shelf pop, end-cap/clerk
+ *   motion): every mirror is marked dirty, but the budget is still capped
+ *   at 1/frame; mirrors that don't get the budget this frame stay dirty
+ *   and drain over the next few frames.
+ */
+export function updateMirrorThrottle(scene: StoreScene, forceAll: boolean) {
+  const moved =
+    scene.camera.position.distanceToSquared(scene.lastMirrorCamPos) > 1e-6 ||
+    Math.abs(1 - Math.abs(scene.camera.quaternion.dot(scene.lastMirrorCamQuat))) > 1e-7;
+
+  if (moved || forceAll) {
+    scene.lastMirrorCamPos.copy(scene.camera.position);
+    scene.lastMirrorCamQuat.copy(scene.camera.quaternion);
+  }
+
+  if (forceAll) {
+    for (const m of scene.mirrors) m.dirty = true;
+  } else if (moved && scene.mirrors.length > 0) {
+    scene.mirrors[scene.mirrorRefreshIdx % scene.mirrors.length].dirty = true;
+    scene.mirrorRefreshIdx = (scene.mirrorRefreshIdx + 1) % scene.mirrors.length;
+  }
+
+  // A fresh reflection is a full extra scene render. "One per frame fits a
+  // 60Hz budget" held on the small store; at catalog scale on the 4K kiosk
+  // it does not — a --full perf session there attributes 7.2ms/frame to the
+  // Reflectors, half of all render time, and they dominate ~80% of every
+  // hitch (p90 26.0ms -> 20.2ms with them frozen). So refresh on a STRIDE:
+  // these are tilted chrome bands high on the cornice and soffit, grazing
+  // and foreshortened, and nobody resolves a case spine in one, so ~20Hz
+  // under a 60Hz camera is invisible while the skipped draw-call replay is
+  // not. Dirty flags stay sticky, so nothing is lost — a refresh just lands
+  // a frame or two later, forceAll (clerk/end-cap motion) included. Deriving
+  // the stride from targetFps keeps that cadence put as the display changes;
+  // the old >90fps alternate-frame gate was this with a hardcoded 2.
+  const stride = Math.max(1, Math.round(scene.targetFps / MIRROR_REFRESH_HZ));
+  scene.mirrorMotionParity = (scene.mirrorMotionParity + 1) % stride;
+  const admit = !scene.mirrorsFrozen && scene.mirrorMotionParity === 0;
+
+  scene.mirrorRenderBudget = 0;
+  if (admit) {
+    for (const m of scene.mirrors) {
+      if (m.dirty) { scene.mirrorRenderBudget = 1; break; }
+    }
+  }
+}
+

--- a/src/store-mirrors.ts
+++ b/src/store-mirrors.ts
@@ -7,6 +7,21 @@
 //
 // Every function takes the StoreScene as its first parameter and reads/writes
 // scene state exactly as the original methods did.
+//
+// BOX-PROJECTED CUBEMAPS DO NOT WORK HERE — tried 2026-08-11, measured, and
+// reverted, so nobody spends another day on it. The pitch is seductive: bake
+// the room into one cubemap, box-project the reflected ray against the room's
+// bounds, and every mirror becomes one texture fetch with nothing to refresh.
+// Box projection is exact when the reflected geometry lies ON the box, and
+// this store is a rectangular room, so the room IS the box... except it isn't.
+// The room is a box PACKED with 7 ft shelving runs, endcaps, floor displays
+// and a checkout counter, and that furniture — not the walls — is what these
+// mirrors actually reflect. Everything between the capture point and the shell
+// gets projected out onto the shell, so the counter smears across the band at
+// several times its true size and the aisles vanish entirely. It reads as a
+// rendering fault, not a mirror. Per-mirror cubes would fix only the face they
+// were captured for, and an env-mapped cube with no box projection at all is
+// just the chrome fallback below, which already exists.
 import * as THREE from 'three';
 import { Reflector } from 'three/examples/jsm/objects/Reflector.js';
 import { perfTrace } from './perf-trace';

--- a/src/store-mirrors.ts
+++ b/src/store-mirrors.ts
@@ -1,12 +1,13 @@
-// Live planar-mirror throttling — extracted from StoreScene (three-scene.ts
-// keeps one-line delegating stubs). The cornice band and the front soffit ring
-// are three.js Reflectors: each one re-renders the whole scene from its own
+// Live planar mirrors — extracted from StoreScene (three-scene.ts keeps
+// one-line delegating stubs). The cornice band and the front soffit ring are
+// three.js Reflectors: each renders the whole scene again from its own
 // viewpoint, which is the single most expensive thing in the frame at catalog
-// scale. Everything here exists to make them cost almost nothing when nothing
-// about the reflection has actually changed.
+// scale. This module decides which machines get them at all, how often a stale
+// reflection is allowed to redraw, and which mirror that redraw is spent on.
 //
-// Both functions take the StoreScene as their first parameter and read/write
+// Every function takes the StoreScene as its first parameter and reads/writes
 // scene state exactly as the original methods did.
+import * as THREE from 'three';
 import { Reflector } from 'three/examples/jsm/objects/Reflector.js';
 import { perfTrace } from './perf-trace';
 import { SP_MIRROR, CT_MIRROR, MIRROR_REFRESH_HZ } from './scene-shared';
@@ -17,73 +18,176 @@ import type { StoreScene } from './three-scene';
 // render, cascading into hundreds of nested scene draws.
 let reflectorRendering = false;
 
+// Reflections redrawn per admitted frame. A second one does not amortise — it
+// costs ~5ms of its own and drops p50 below 60fps.
+const MIRRORS_PER_FRAME = 1;
+
+export type MirrorEntry = {
+  r: any; dirty: boolean; original: (...a: any[]) => void;
+  /** False until this reflector has rendered once — its target is still blank. */
+  rendered: boolean;
+};
+
+// Scratch, module-scoped so the per-frame pass allocates nothing.
+const frustumScratch = new THREE.Frustum();
+const projScreenScratch = new THREE.Matrix4();
+const sphereScratch = new THREE.Sphere();
+
+/** Is this mirror's plane inside the main camera's frustum? */
+function onScreen(m: MirrorEntry): boolean {
+  const geo = m.r.geometry;
+  if (!geo) return false;
+  if (!geo.boundingSphere) geo.computeBoundingSphere();
+  sphereScratch.copy(geo.boundingSphere).applyMatrix4(m.r.matrixWorld);
+  return frustumScratch.intersectsSphere(sphereScratch);
+}
+
 /**
- * A naive setup re-renders every mirror's reflection every frame. Each
- * Reflector renders the whole scene from its viewpoint, and because the
- * pillars face each other + the cornice faces the room, those renders
- * cascade into each other — hundreds of nested renders that crash the GPU,
- * and even guarded against recursion they cost ~12 full scene renders/frame
- * (~26 fps).
+ * Does this machine get live planar reflections at all? (Owner product call,
+ * 2026-08-11: "underpowered machines can't have the mirror.")
  *
- * But a planar reflection of a static scene only changes when the *viewer*
- * moves. So we wrap each mirror's onBeforeRender to render only when:
- *   - no other mirror is mid-render (kills the recursion cascade), AND
- *   - this mirror is "dirty" (the camera moved since it last rendered), AND
- *   - we're under the per-frame budget (≤1 mirror render/frame).
- * When you're parked at a shelf the mirrors are free (they reuse their last
- * reflection texture, which is still correct), so browsing runs at full
- * frame-rate. Reflections are frozen while the camera moves and refreshed once
- * it settles (see updateMirrorThrottle) — the reflection is a real render, so
- * shelves are the right size and perspective from wherever you come to rest.
+ * Machines that don't get them fall back to the env-mapped chrome the
+ * softwareGL and WebKitGTK paths already used — free, and it can never go
+ * stale, because an environment map is evaluated per fragment every frame.
+ *
+ * The tier is the calibrated one (src/quality-calibrate.ts measures the GPU),
+ * so 'low' and 'medium' are exactly what "underpowered" already means
+ * everywhere else in the app.
+ */
+export function liveMirrorsAllowed(scene: StoreScene): boolean {
+  return !scene.softwareGL && !scene.webkitGL && scene.effectiveQuality === 'high';
+}
+
+/**
+ * Render stale reflections as their own phase at the top of the frame: at most
+ * one per admitted frame, admitted at MIRROR_REFRESH_HZ rather than frame rate,
+ * and always spent on a mirror the player can actually see.
+ *
+ * WHAT DOES NOT MAKE A REFRESH CHEAPER, all measured on the 4K --full profile,
+ * so nobody repeats them: a refresh costs ~5-8ms and that number will not move.
+ * Dropping the reflector target from 1024px to 256px changes it by nothing.
+ * Hiding every movie box AND every shelf carcass in the store changes it by
+ * nothing either (7.08 -> 7.02ms). It is neither fill nor the scene's draw
+ * calls, which rules out proxy geometry and baked shelf textures — there is
+ * nothing cheaper to reflect.
+ *
+ * Beware one seductive measurement: hoisting these renders out of
+ * onBeforeRender appears to take a refresh to 0.25ms. It does not. That average
+ * is collected while the round-robin is mostly refreshing OFF-SCREEN mirrors,
+ * whose virtual camera faces a wall and renders almost nothing. A mirror you
+ * can see costs the full ~8ms wherever the render is issued from — so the
+ * refresh RATE is the only real lever, which is why the stride below stays.
+ *
+ * Since the cost is fixed, the game is spending the budget well, and that is
+ * what driving the renders from here buys over the stock onBeforeRender hook:
+ * inside the hook a mirror can only refresh itself in scene draw order, so the
+ * budget lands on whichever mirror happens to be drawn first — usually one
+ * behind the camera. Here we can pick. Off-screen mirrors are skipped entirely
+ * and stay sticky-dirty until seen, so every admitted refresh lands on a
+ * reflection someone is looking at. Same cost as the old round-robin, ~8x the
+ * useful freshness in the common one-mirror-in-frame view.
+ *
+ * (Hoisting also keeps the mirror's full scene pass out of the middle of the
+ * composite, where it used to pile onto the shadow rebake and the AO recompute
+ * in one ~37ms frame.)
+ */
+export function renderMirrorsAhead(scene: StoreScene) {
+  if (scene.mirrorsFrozen || reflectorRendering) return;
+  let any = false;
+  for (const m of scene.mirrors) if (m.dirty) { any = true; break; }
+  if (!any) return;
+
+  // Refresh on a STRIDE. These are tilted chrome bands high on the cornice and
+  // soffit, grazing and foreshortened, and nobody resolves a case spine in one,
+  // so ~20Hz under a 60Hz camera is invisible while the skipped full scene
+  // render is very much not: refreshing every frame instead triples total
+  // mirror time (1414ms -> 4254ms over one --full perf session), adds 43% to
+  // the session's draw calls and pushes p99 from 23.8ms to 27.9ms. Dirty flags
+  // are sticky, so nothing is ever lost — a refresh just lands a frame or two
+  // later. Deriving the stride from targetFps keeps that cadence put as the
+  // display changes.
+  const stride = Math.max(1, Math.round(scene.targetFps / MIRROR_REFRESH_HZ));
+  scene.mirrorMotionParity = (scene.mirrorMotionParity + 1) % stride;
+  if (scene.mirrorMotionParity !== 0) return;
+
+  let budget = MIRRORS_PER_FRAME;
+  reflectorRendering = true;
+  // The selection arrow must not appear in a reflection.
+  const arrowWasVisible = scene.selectionArrow ? scene.selectionArrow.visible : false;
+  if (scene.selectionArrow) scene.selectionArrow.visible = false;
+  try {
+    projScreenScratch.multiplyMatrices(
+      scene.camera.projectionMatrix, scene.camera.matrixWorldInverse);
+    frustumScratch.setFromProjectionMatrix(projScreenScratch);
+
+    const draw = (m: MirrorEntry) => {
+      m.dirty = false;
+      m.rendered = true;
+      budget--;
+      perfTrace.count(CT_MIRROR);
+      perfTrace.begin(SP_MIRROR);
+      try { m.original(scene.renderer, scene.scene, scene.camera); }
+      finally { perfTrace.end(SP_MIRROR); }
+    };
+
+    // Round-robin over the mirrors in frame, so several sharing the view share
+    // the budget fairly, but let one that has NEVER rendered jump the queue:
+    // its target is still blank, and a black band in the ceiling is not a
+    // cosmetic problem the way a slightly stale reflection is.
+    const n = scene.mirrors.length;
+    let fallback = -1;
+    for (let k = 0; k < n && budget > 0; k++) {
+      const idx = (scene.mirrorCursor + k) % n;
+      const m = scene.mirrors[idx];
+      if (!m.dirty || !onScreen(m)) continue;
+      if (!m.rendered) { scene.mirrorCursor = (idx + 1) % n; draw(m); break; }
+      if (fallback < 0) fallback = idx;
+    }
+    if (budget > 0 && fallback >= 0) {
+      scene.mirrorCursor = (fallback + 1) % n;
+      draw(scene.mirrors[fallback]);
+    }
+  } finally {
+    if (scene.selectionArrow) scene.selectionArrow.visible = arrowWasVisible;
+    reflectorRendering = false;
+  }
+}
+
+/**
+ * Collect the scene's Reflectors and neuter their built-in render hook.
+ *
+ * A stock Reflector re-renders itself from onBeforeRender every time it is
+ * drawn, and because the pillars face each other and the cornice faces the
+ * room, those renders nest into each other — hundreds of nested scene draws
+ * that overrun the GPU. We keep a reference to that original render function
+ * and call it ourselves, at most once per admitted frame, from
+ * renderMirrorsAhead(); the hook itself becomes a no-op.
+ *
+ * Called once per build, so it resets the list first — a rebuild otherwise
+ * leaves entries pointing at the previous store's destroyed Reflectors, and
+ * the refresh budget gets spent redrawing them.
  */
 export function installMirrorThrottle(scene: StoreScene) {
+  scene.mirrors.length = 0;
+  scene.mirrorCursor = 0;
   scene.scene.traverse((obj) => {
     if (obj instanceof Reflector) {
-      const entry = { r: obj, dirty: true };
-      scene.mirrors.push(entry);
-      const original = obj.onBeforeRender.bind(obj);
-      obj.onBeforeRender = (...args: any[]) => {
-        if (reflectorRendering) return;                 // no mirror-in-mirror nesting
-        if (!entry.dirty || scene.mirrorRenderBudget <= 0) return;  // static view → reuse last reflection
-        entry.dirty = false;
-        scene.mirrorRenderBudget--;
-        reflectorRendering = true;
-
-        // Temporarily hide the selection arrow during mirror renders so it doesn't reflect
-        const arrowWasVisible = scene.selectionArrow ? scene.selectionArrow.visible : false;
-        if (scene.selectionArrow) {
-          scene.selectionArrow.visible = false;
-        }
-
-        perfTrace.count(CT_MIRROR);
-        perfTrace.begin(SP_MIRROR);
-        try { (original as any)(...args); }
-        finally {
-          perfTrace.end(SP_MIRROR);
-          if (scene.selectionArrow) {
-            scene.selectionArrow.visible = arrowWasVisible;
-          }
-          reflectorRendering = false;
-        }
-      };
+      scene.mirrors.push({
+        r: obj, dirty: true, rendered: false, original: obj.onBeforeRender.bind(obj),
+      });
+      obj.onBeforeRender = () => {};  // see renderMirrorsAhead()
     }
   });
 }
 
 /**
- * Called once per frame before rendering. Decides whether any mirror needs
- * a fresh reflection this frame and, if so, admits at most one into the
- * render budget that installMirrorThrottle's onBeforeRender wrapper consumes.
+ * Called once per frame, before renderMirrorsAhead(). Marks reflections stale.
  *
- * - Camera fully still and nothing structural changed: budget = 0, every
- *   mirror reuses its last reflection texture (0 reflector renders/frame).
- * - Camera moving: one mirror is round-robined into the dirty queue per
- *   frame (mirrorRefreshIdx), budget = 1, so reflections track the camera
- *   at ~1 render/frame instead of 4.
- * - Structural change (forceAll — scene rebuild, shelf pop, end-cap/clerk
- *   motion): every mirror is marked dirty, but the budget is still capped
- *   at 1/frame; mirrors that don't get the budget this frame stay dirty
- *   and drain over the next few frames.
+ * A planar reflection of a static scene only changes when the VIEWER moves, so
+ * a parked camera marks nothing and every mirror reuses its last texture — a
+ * still store still costs zero. `forceAll` covers the cases where the scene
+ * changed under a stationary camera instead: rebuilds, shelf pops, end-cap
+ * motion, and the clerk coming to rest.
  */
 export function updateMirrorThrottle(scene: StoreScene, forceAll: boolean) {
   const moved =
@@ -93,36 +197,6 @@ export function updateMirrorThrottle(scene: StoreScene, forceAll: boolean) {
   if (moved || forceAll) {
     scene.lastMirrorCamPos.copy(scene.camera.position);
     scene.lastMirrorCamQuat.copy(scene.camera.quaternion);
-  }
-
-  if (forceAll) {
     for (const m of scene.mirrors) m.dirty = true;
-  } else if (moved && scene.mirrors.length > 0) {
-    scene.mirrors[scene.mirrorRefreshIdx % scene.mirrors.length].dirty = true;
-    scene.mirrorRefreshIdx = (scene.mirrorRefreshIdx + 1) % scene.mirrors.length;
-  }
-
-  // A fresh reflection is a full extra scene render. "One per frame fits a
-  // 60Hz budget" held on the small store; at catalog scale on the 4K kiosk
-  // it does not — a --full perf session there attributes 7.2ms/frame to the
-  // Reflectors, half of all render time, and they dominate ~80% of every
-  // hitch (p90 26.0ms -> 20.2ms with them frozen). So refresh on a STRIDE:
-  // these are tilted chrome bands high on the cornice and soffit, grazing
-  // and foreshortened, and nobody resolves a case spine in one, so ~20Hz
-  // under a 60Hz camera is invisible while the skipped draw-call replay is
-  // not. Dirty flags stay sticky, so nothing is lost — a refresh just lands
-  // a frame or two later, forceAll (clerk/end-cap motion) included. Deriving
-  // the stride from targetFps keeps that cadence put as the display changes;
-  // the old >90fps alternate-frame gate was this with a hardcoded 2.
-  const stride = Math.max(1, Math.round(scene.targetFps / MIRROR_REFRESH_HZ));
-  scene.mirrorMotionParity = (scene.mirrorMotionParity + 1) % stride;
-  const admit = !scene.mirrorsFrozen && scene.mirrorMotionParity === 0;
-
-  scene.mirrorRenderBudget = 0;
-  if (admit) {
-    for (const m of scene.mirrors) {
-      if (m.dirty) { scene.mirrorRenderBudget = 1; break; }
-    }
   }
 }
-

--- a/src/store-mirrors.ts
+++ b/src/store-mirrors.ts
@@ -32,14 +32,29 @@ export type MirrorEntry = {
 const frustumScratch = new THREE.Frustum();
 const projScreenScratch = new THREE.Matrix4();
 const sphereScratch = new THREE.Sphere();
+const normalScratch = new THREE.Vector3();
+const centreScratch = new THREE.Vector3();
 
-/** Is this mirror's plane inside the main camera's frustum? */
-function onScreen(m: MirrorEntry): boolean {
+/**
+ * Can the main camera see this mirror's reflective side?
+ *
+ * Frustum test, then a facing test. The facing half matters because mirrors
+ * come in sets that point away from each other — the four faces of a mirrored
+ * column, the cornice bands on opposite walls — and a Reflector's back is
+ * blank. Without it the two faces of a column behind you sit in the frustum's
+ * bounding-sphere test and take turns eating the refresh budget that the face
+ * you are looking at should have had.
+ */
+function onScreen(m: MirrorEntry, cameraPos: THREE.Vector3): boolean {
   const geo = m.r.geometry;
   if (!geo) return false;
   if (!geo.boundingSphere) geo.computeBoundingSphere();
   sphereScratch.copy(geo.boundingSphere).applyMatrix4(m.r.matrixWorld);
-  return frustumScratch.intersectsSphere(sphereScratch);
+  if (!frustumScratch.intersectsSphere(sphereScratch)) return false;
+  // PlaneGeometry faces +Z locally; a Reflector only reflects on that side.
+  normalScratch.set(0, 0, 1).transformDirection(m.r.matrixWorld);
+  centreScratch.setFromMatrixPosition(m.r.matrixWorld);
+  return normalScratch.dot(centreScratch.sub(cameraPos)) < 0;
 }
 
 /**
@@ -56,6 +71,25 @@ function onScreen(m: MirrorEntry): boolean {
  */
 export function liveMirrorsAllowed(scene: StoreScene): boolean {
   return !scene.softwareGL && !scene.webkitGL && scene.effectiveQuality === 'high';
+}
+
+/**
+ * Render-target size for a Reflector, derived from the REAL drawing buffer and
+ * capped by quality tier.
+ *
+ * A Reflector samples its texture with SCREEN-space projective coords, so the
+ * target has to track the drawing buffer's shape and size, not a magic square.
+ * A fixed 512x512 (what shipped once) is a ~7x upscale of a non-mipmapped
+ * target squashed to 1:1 and stretched back over a 20:1 band — the blocky smear
+ * in the feedback pin. Fill cost is the only thing that grows with this; the
+ * reflected scene's draw calls, which are what a refresh actually costs, do not.
+ */
+export function reflectorTargetSize(renderer: THREE.WebGLRenderer): { w: number; h: number } {
+  const buf = renderer.getDrawingBufferSize(new THREE.Vector2());
+  const quality = localStorage.getItem('bb_quality') || 'high';
+  const cap = quality === 'low' ? 256 : quality === 'medium' ? 512 : 1024;
+  const w = Math.max(64, Math.min(cap, Math.round(buf.x)));
+  return { w, h: Math.max(64, Math.round(w * (buf.y / Math.max(1, buf.x)))) };
 }
 
 /**
@@ -135,11 +169,12 @@ export function renderMirrorsAhead(scene: StoreScene) {
     // its target is still blank, and a black band in the ceiling is not a
     // cosmetic problem the way a slightly stale reflection is.
     const n = scene.mirrors.length;
+    const camPos = scene.camera.position;
     let fallback = -1;
     for (let k = 0; k < n && budget > 0; k++) {
       const idx = (scene.mirrorCursor + k) % n;
       const m = scene.mirrors[idx];
-      if (!m.dirty || !onScreen(m)) continue;
+      if (!m.dirty || !onScreen(m, camPos)) continue;
       if (!m.rendered) { scene.mirrorCursor = (idx + 1) % n; draw(m); break; }
       if (fallback < 0) fallback = idx;
     }

--- a/src/store-shell.ts
+++ b/src/store-shell.ts
@@ -13,6 +13,7 @@ import { assetUrl } from './asset-url';
 import { posterQueue, loadDecorPosterTexture } from './video-case';
 import { bakeFloorAO, makeWallContactAO } from './lightmap-bake';
 import { Reflector } from 'three/examples/jsm/objects/Reflector.js';
+import { liveMirrorsAllowed } from './store-mirrors';
 import { SlottedFixture } from './fixtures';
 import { AmbientTvs } from './ambient-tvs';
 import { EntranceCheckout } from './entrance';
@@ -1194,7 +1195,7 @@ export function buildStore(scene: StoreScene) {
       trofferFrameMaterial: trofferFrameMat,
       tileX: TILE_X,
       tileZ: TILE_Z,
-      softwareGL: scene.softwareGL || scene.webkitGL,
+      softwareGL: !liveMirrorsAllowed(scene),
       reflectorSize: soffitReflectorSize,
       // bb-2000: all-white soffit body + inset circular can lights, no mirror
       // ring (the perimeter cornice is dropped for that store — user).
@@ -2753,7 +2754,7 @@ export function buildCeilingFrame(scene: StoreScene, storeWidth: number, backWal
     // CPU. A static chrome plane keeps the band's look at zero render cost.
     // WebKitGTK pays the replay too (~14ms blocking per refresh), so it
     // takes the same static plane.
-    if (scene.softwareGL || scene.webkitGL) {
+    if (!liveMirrorsAllowed(scene)) {
       const still = new THREE.Mesh(new THREE.PlaneGeometry(mirrorW, mirrorH), chromeMat);
       const stillPos = mirrorPos.clone();
       stillPos.x += localZOffset * Math.sin(mirrorRotY);

--- a/src/store-shell.ts
+++ b/src/store-shell.ts
@@ -13,7 +13,7 @@ import { assetUrl } from './asset-url';
 import { posterQueue, loadDecorPosterTexture } from './video-case';
 import { bakeFloorAO, makeWallContactAO } from './lightmap-bake';
 import { Reflector } from 'three/examples/jsm/objects/Reflector.js';
-import { liveMirrorsAllowed } from './store-mirrors';
+import { liveMirrorsAllowed, reflectorTargetSize } from './store-mirrors';
 import { SlottedFixture } from './fixtures';
 import { AmbientTvs } from './ambient-tvs';
 import { EntranceCheckout } from './entrance';
@@ -1173,14 +1173,7 @@ export function buildStore(scene: StoreScene) {
     // what --quality asked for, and no screenshot could gate the look. The
     // harness's own fast default is quality LOW, which still lands on the cheap
     // tier, so this costs nothing on ordinary shots.
-    const soffitBuf = scene.renderer.getDrawingBufferSize(new THREE.Vector2());
-    const q = localStorage.getItem('bb_quality') || 'high';
-    const soffitCap = q === 'low' ? 256 : q === 'medium' ? 512 : 1024;
-    const soffitW = Math.max(64, Math.min(soffitCap, Math.round(soffitBuf.x)));
-    const soffitReflectorSize = {
-      w: soffitW,
-      h: Math.max(64, Math.round(soffitW * (soffitBuf.y / Math.max(1, soffitBuf.x)))),
-    };
+    const soffitReflectorSize = reflectorTargetSize(scene.renderer);
 
     const soffit = buildFrontSoffit({
       scene: scene.scene,
@@ -2770,29 +2763,17 @@ export function buildCeilingFrame(scene: StoreScene, storeWidth: number, backWal
     }
 
     // Reflection resolution (F8 pin 028 — "this is ugly and messed up", filed
-    // on the smeared, stair-stepped strip this band showed above the cornice).
-    // A Reflector renders the whole reflected VIEW into its target and samples
-    // it with SCREEN-space projective coords, so the target has to track the
-    // drawing buffer's shape and size, not a magic square. What shipped was a
-    // fixed 512x512 — on the owner's 3627x2039 kiosk that is a ~7x upscale of
-    // a non-mipmapped target squashed to 1:1 and stretched back out over a
-    // 20:1 band, i.e. exactly the blocky smear in the pin. And headless was
-    // pinned at 64 regardless of quality, so `npm run shot` could never see
-    // what the app shows and no screenshot could gate a fix.
-    //
-    // So: derive it from the real drawing buffer, keep its aspect, and cap by
-    // quality tier. Fill cost is the only thing that grows (the reflected
-    // scene's draw calls are unchanged), which is what a quality tier is for.
-    const bufSize = scene.renderer.getDrawingBufferSize(new THREE.Vector2());
-    const quality = localStorage.getItem('bb_quality') || 'high';
-    const cap = quality === 'low' ? 256 : quality === 'medium' ? 512 : 1024;
-    const texW = Math.max(64, Math.min(cap, Math.round(bufSize.x)));
-    const texH = Math.max(64, Math.round(texW * (bufSize.y / Math.max(1, bufSize.x))));
+    // on the smeared, stair-stepped strip this band showed above the cornice):
+    // a fixed 512x512 target stretched over a 20:1 band is the blocky smear in
+    // that pin, and headless was pinned at 64 regardless of quality, so no
+    // screenshot could gate a fix. reflectorTargetSize derives it from the real
+    // drawing buffer instead — see store-mirrors.ts.
+    const tex = reflectorTargetSize(scene.renderer);
 
     const mirror = new Reflector(new THREE.PlaneGeometry(mirrorW, mirrorH), {
       clipBias: 0.003,
-      textureWidth: texW,
-      textureHeight: texH,
+      textureWidth: tex.w,
+      textureHeight: tex.h,
       color: 0xffffff
     });
     

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -1607,6 +1607,12 @@ export class StoreScene {
       activeTheme: this.activeTheme,
       gondolaMaterials: this.gondolaMaterials,
       wallSurface: this.wallSurface,
+      liveMirror: mirrors.liveMirrorsAllowed(this)
+        ? (() => {
+            const s = mirrors.reflectorTargetSize(this.renderer);
+            return { textureWidth: s.w, textureHeight: s.h };
+          })()
+        : undefined,
     };
   }
 

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -914,6 +914,20 @@ export class StoreScene {
   // fades out and her roaming sim pauses entirely — nobody's there, nothing
   // needs to move, so the store can go fully idle.
   private static readonly IDLE_TIER_INPUT_MS = 30_000;
+  // How long the selection arrow keeps BOBBING after the last real input.
+  // Deliberately far shorter than IDLE_TIER_INPUT_MS, because the bob is the
+  // only thing holding the VIDEO tier on the entrance/jump-index view — the
+  // app's root since 2026-08-09 — and the VIDEO tier is excluded from the
+  // settle supersample (see settleRefine). At 30s that meant the FIRST view
+  // you see, and the one you return to constantly, spent half a minute
+  // re-compositing a room in which nothing moves but this arrow, then went
+  // straight to IDLE, parking forever on a frame rendered at the base budget:
+  // 2180x1226 stretched over a 3840x2160 panel. Both halves measured on the
+  // 4K harness: 4009 renderer.render() calls per 10 idle seconds before,
+  // 27 after (~148x), and the parked frame goes 2.67MP -> 16.6MP.
+  // The arrow stays visible, frozen mid-pose; any input resumes it, since
+  // every input path stamps user activity.
+  private static readonly ARROW_BOB_INPUT_MS = 2_500;
   // How long after the camera stops moving qualityScale stays at native res, so
   // the frame you settle on is sharp before render-on-demand parks it. Sized to
   // outlast the ~250ms AO fade-in that keeps rendering after a stop, so the
@@ -2803,6 +2817,9 @@ export class StoreScene {
   private mirrorRefreshIdx = 0;
   // Alternate-frame gate for mirror refreshes while chasing a >90fps target.
   private mirrorMotionParity = 0;
+  // bb_mirrors=0 — measurement/opt-out knob: mirrors keep their last (boot)
+  // reflection forever instead of re-rendering the scene as the camera moves.
+  private mirrorsFrozen = localStorage.getItem('bb_mirrors') === '0';
   // Sticky one-shot, consumed by the updateMirrorThrottle() call in animate():
   // set when the clerk comes to rest so mirrors catch her final pose. Her
   // update() runs in the pre-tier bookkeeping section (issue #96), so the rAF
@@ -2901,7 +2918,7 @@ export class StoreScene {
     // under a 120Hz camera is indistinguishable. Gating the budget (not the
     // dirty marking) keeps it effective when clerk motion force-dirties all.
     this.mirrorMotionParity ^= 1;
-    const admit = this.targetFps <= 90 || this.mirrorMotionParity === 0;
+    const admit = !this.mirrorsFrozen && (this.targetFps <= 90 || this.mirrorMotionParity === 0);
 
     this.mirrorRenderBudget = 0;
     if (admit) {
@@ -4625,7 +4642,7 @@ export class StoreScene {
     // STAYS visible on the parked frame — and stops claiming the VIDEO tier,
     // so the tier drops to IDLE. Every input path funnels through
     // requestRender()/markUserActivity, which resumes the bob next frame.
-    const arrowBobAwake = time - getLastUserActivity() < StoreScene.IDLE_TIER_INPUT_MS;
+    const arrowBobAwake = time - getLastUserActivity() < StoreScene.ARROW_BOB_INPUT_MS;
     if (this.selectionArrow && this.selectionArrow.visible && arrowBobAwake) {
       const t = performance.now() * 0.002;
       this.selectionArrow.position.y = this.selectionArrowBaseY + Math.sin(t) * 0.15;

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -14,6 +14,7 @@ import {
   textureArrayManager,
 } from './video-case';
 import { setSurfaceKtx2Renderer } from './surface-textures';
+import { pendingTextureUploads } from './poster-textures';
 // @ts-ignore
 import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
@@ -2568,8 +2569,18 @@ export class StoreScene {
     } else {
       this.motionScale = this.sharpScale;
     }
+    // settleScale is an absolute pixel target expressed as a multiplier over
+    // resScale (see its division above), so it is only correct for the resScale
+    // it was computed under. qualityScale, however, is latched by animate() and
+    // outlives that: let resScale rise afterwards — which it does constantly,
+    // since the scaler walks back up after boot — and the latched value
+    // over-delivers by exactly the ratio. Measured: a 29.5MP buffer against a
+    // 17MP SETTLE_PX_CAP, i.e. a ~500MB target allocation for one frame. Clamp
+    // it to the freshly-solved ceiling; motionScale is always <= settleScale, so
+    // this can only ever catch the stale case.
     // The parked frame must never be softer than the motion it followed.
     this.settleScale = Math.max(this.settleScale, this.motionScale);
+    this.qualityScale = Math.min(this.qualityScale, this.settleScale);
 
     const width = Math.max(1, Math.floor(clientWidth * this.resScale * this.qualityScale));
     const height = Math.max(1, Math.floor(clientHeight * this.resScale * this.qualityScale));
@@ -4217,6 +4228,20 @@ export class StoreScene {
       // VIDEO tier: don't let its throttled pacing feed the window; just keep
       // the clock from accumulating stale elapsed time across the gap.
       this.resScaleFrames = 0;
+      this.resScaleWindowStart = time;
+      return;
+    }
+    // Texture uploads are not a GPU verdict. The boot wave (and any streaming
+    // burst) hands this window frames pinned at 0.2-30fps by decode + upload
+    // work whose cost has nothing to do with how many pixels we are shading —
+    // the scaler read that as "slow GPU" and walked resolution down to the 0.70
+    // floor on a machine that then held a locked 60. It only climbs back at
+    // 0.05 per two good seconds, and cannot climb at all in the VIDEO tier
+    // (the early return above), so one boot could soften the store for the rest
+    // of the session. Skip the window entirely while the queue is draining.
+    if (pendingTextureUploads() > 0) {
+      this.resScaleFrames = 0;
+      this.resScaleGoodStreak = 0;
       this.resScaleWindowStart = time;
       return;
     }

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -2466,6 +2466,17 @@ export class StoreScene {
     (window as any).getArrangement = () => this.getArrangement();
     (window as any).ARRANGEMENTS = StoreScene.ARRANGEMENTS;
     (window as any).debugResScale = () => this.resScale;
+    // Force the stocked-shelves environment re-bake now instead of waiting for
+    // stockedRebakeDue()'s frame count + input-silence window. Verification
+    // hook: a screenshot never reaches those conditions, so without this the
+    // only reflections a shot can photograph are the EMPTY-SHELL bake taken
+    // before the cases are placed (see pendingStockedRebake).
+    (window as any).debugForceStockedRebake = () => {
+      this.pendingStockedRebake = false;
+      this.outdoor.rebakeEnvironment();
+      this.requestRender();
+      return true;
+    };
     // Partial-composite A/B (see PartialComposite.debugAB): renders the same
     // changed TV picture through the patch path and the full chain in one tick.
     (window as any).debugPartialAB = () => this.partial?.debugAB(
@@ -2812,21 +2823,16 @@ export class StoreScene {
   public updateColsCount() { return stock.updateColsCount(this); }
 
   // Live mirrors, throttled. See installMirrorThrottle().
-  public mirrors: { r: any; dirty: boolean }[] = [];
-  public mirrorRenderBudget = 0;
+  public mirrors: mirrors.MirrorEntry[] = [];
+  // Round-robin cursor for the reflection budget (store-mirrors.ts).
+  public mirrorCursor = 0;
   private static reflectorRendering = false;
   // Camera state as of the last updateMirrorThrottle() call, used to detect
   // whether the view actually changed (see updateMirrorThrottle).
   public lastMirrorCamPos = new THREE.Vector3(Infinity, Infinity, Infinity);
   public lastMirrorCamQuat = new THREE.Quaternion();
-  // Round-robins which mirror gets queued for refresh while the camera is
-  // moving, so all 4 stay reasonably fresh without ever exceeding the
-  // per-frame render budget.
-  public mirrorRefreshIdx = 0;
-  // Frame counter modulo the mirror refresh stride (see updateMirrorThrottle).
+  // Frame counter modulo the mirror refresh stride (see renderMirrorsAhead).
   public mirrorMotionParity = 0;
-  // Live planar reflection refresh target, Hz — deliberately well under any
-  // display rate; updateMirrorThrottle explains what that buys.
   // bb_mirrors=0 — opt-out/measurement knob: freeze reflections at their last
   // render instead of re-rendering the scene as the camera moves.
   public mirrorsFrozen = localStorage.getItem('bb_mirrors') === '0';
@@ -5463,6 +5469,7 @@ export class StoreScene {
       this.clerkMirrorRefresh || updatedMeshes.size > 0 ||
       (forceShadowRefresh && this.shadowRefreshFrames === 0));
     this.clerkMirrorRefresh = false;
+    mirrors.renderMirrorsAhead(this);
 
     // Fixture upkeep: desk terminal cursor blink; TV audio listener sync +
     // VideoTexture upload.

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -27,6 +27,7 @@ import { GTAOPass } from 'three/examples/jsm/postprocessing/GTAOPass.js';
 import { N8AOPass } from 'n8ao';
 import { BokehPass } from 'three/examples/jsm/postprocessing/BokehPass.js';
 import { Reflector } from 'three/examples/jsm/objects/Reflector.js';
+import * as mirrors from './store-mirrors';
 import { BeautyPass, PartialComposite } from './partial-composite';
 import { FixtureContext, SlottedFixture } from './fixtures';
 import { OverviewCursors, OverviewCursorTarget } from './overview-cursors';
@@ -139,10 +140,8 @@ const SP_SIM = perfSlot('simMs');          // animate() bookkeeping+simulation u
 const SP_SLOTS = perfSlot('slotsMs');      // dirty-slot lerp/matrix pass (includes hero bind)
 const SP_RENDER = perfSlot('renderMs');    // composer/renderer composite
 const SP_AO = perfSlot('aoComputeMs');     // GTAO recompute inside the composite
-const SP_MIRROR = perfSlot('mirrorMs');    // Reflector re-render inside the composite
 const CT_SHADOW = perfSlot('shadowBake');  // full shadow-map rebake requested
 const CT_AO = perfSlot('aoCompute');
-const CT_MIRROR = perfSlot('mirrorDraw');
 const CT_RES = perfSlot('resScaleApply');  // drawing-buffer resize (render targets realloc)
 const CT_PARTIAL = perfSlot('partialComposite'); // VIDEO frame served by the TV-screen patch path
 
@@ -316,7 +315,7 @@ export class StoreScene {
   // A live getter, not cached: displayHz() keeps returning the 60Hz default
   // until measureDisplayHz()'s async boot sample resolves, and this must pick
   // up the real rate the moment it does.
-  private get targetFps(): number {
+  public get targetFps(): number {
     return this.webkitGL ? 60 : computeFpsCap(displayHz(), this.fpsCapOverride);
   }
   // ACTIVE-tier composite spacing (see the frameInterval gate in animate()).
@@ -919,14 +918,12 @@ export class StoreScene {
   // only thing holding the VIDEO tier on the entrance/jump-index view — the
   // app's root since 2026-08-09 — and the VIDEO tier is excluded from the
   // settle supersample (see settleRefine). At 30s that meant the FIRST view
-  // you see, and the one you return to constantly, spent half a minute
-  // re-compositing a room in which nothing moves but this arrow, then went
-  // straight to IDLE, parking forever on a frame rendered at the base budget:
-  // 2180x1226 stretched over a 3840x2160 panel. Both halves measured on the
-  // 4K harness: 4009 renderer.render() calls per 10 idle seconds before,
-  // 27 after (~148x), and the parked frame goes 2.67MP -> 16.6MP.
-  // The arrow stays visible, frozen mid-pose; any input resumes it, since
-  // every input path stamps user activity.
+  // you see spent half a minute re-compositing a room where nothing moves but
+  // this arrow, then dropped straight to IDLE, parking forever on a base-budget
+  // frame: 2180x1226 stretched over a 3840x2160 panel. Measured on the 4K
+  // harness: 4009 renderer.render() calls per 10 idle seconds before, 27 after,
+  // and the parked frame goes 2.67MP -> 16.6MP. The arrow stays visible, frozen
+  // mid-pose; any input resumes it, since every input path stamps activity.
   private static readonly ARROW_BOB_INPUT_MS = 2_500;
   // How long after the camera stops moving qualityScale stays at native res, so
   // the frame you settle on is sharp before render-on-demand parks it. Sized to
@@ -2804,129 +2801,34 @@ export class StoreScene {
   public updateColsCount() { return stock.updateColsCount(this); }
 
   // Live mirrors, throttled. See installMirrorThrottle().
-  private mirrors: { r: any; dirty: boolean }[] = [];
-  private mirrorRenderBudget = 0;
+  public mirrors: { r: any; dirty: boolean }[] = [];
+  public mirrorRenderBudget = 0;
   private static reflectorRendering = false;
   // Camera state as of the last updateMirrorThrottle() call, used to detect
   // whether the view actually changed (see updateMirrorThrottle).
-  private lastMirrorCamPos = new THREE.Vector3(Infinity, Infinity, Infinity);
-  private lastMirrorCamQuat = new THREE.Quaternion();
+  public lastMirrorCamPos = new THREE.Vector3(Infinity, Infinity, Infinity);
+  public lastMirrorCamQuat = new THREE.Quaternion();
   // Round-robins which mirror gets queued for refresh while the camera is
   // moving, so all 4 stay reasonably fresh without ever exceeding the
   // per-frame render budget.
-  private mirrorRefreshIdx = 0;
-  // Alternate-frame gate for mirror refreshes while chasing a >90fps target.
-  private mirrorMotionParity = 0;
-  // bb_mirrors=0 — measurement/opt-out knob: mirrors keep their last (boot)
-  // reflection forever instead of re-rendering the scene as the camera moves.
-  private mirrorsFrozen = localStorage.getItem('bb_mirrors') === '0';
+  public mirrorRefreshIdx = 0;
+  // Frame counter modulo the mirror refresh stride (see updateMirrorThrottle).
+  public mirrorMotionParity = 0;
+  // Live planar reflection refresh target, Hz — deliberately well under any
+  // display rate; updateMirrorThrottle explains what that buys.
+  // bb_mirrors=0 — opt-out/measurement knob: freeze reflections at their last
+  // render instead of re-rendering the scene as the camera moves.
+  public mirrorsFrozen = localStorage.getItem('bb_mirrors') === '0';
   // Sticky one-shot, consumed by the updateMirrorThrottle() call in animate():
   // set when the clerk comes to rest so mirrors catch her final pose. Her
   // update() runs in the pre-tier bookkeeping section (issue #96), so the rAF
   // she stops on can be one the IDLE/VIDEO throttles never composite.
-  private clerkMirrorRefresh = false;
+  public clerkMirrorRefresh = false;
 
-  /**
-   * A naive setup re-renders every mirror's reflection every frame. Each
-   * Reflector renders the whole scene from its viewpoint, and because the
-   * pillars face each other + the cornice faces the room, those renders
-   * cascade into each other — hundreds of nested renders that crash the GPU,
-   * and even guarded against recursion they cost ~12 full scene renders/frame
-   * (~26 fps).
-   *
-   * But a planar reflection of a static scene only changes when the *viewer*
-   * moves. So we wrap each mirror's onBeforeRender to render only when:
-   *   - no other mirror is mid-render (kills the recursion cascade), AND
-   *   - this mirror is "dirty" (the camera moved since it last rendered), AND
-   *   - we're under the per-frame budget (≤1 mirror render/frame).
-   * When you're parked at a shelf the mirrors are free (they reuse their last
-   * reflection texture, which is still correct), so browsing runs at full
-   * frame-rate. Reflections are frozen while the camera moves and refreshed once
-   * it settles (see updateMirrorThrottle) — the reflection is a real render, so
-   * shelves are the right size and perspective from wherever you come to rest.
-   */
-  private installMirrorThrottle() {
-    this.scene.traverse((obj) => {
-      if (obj instanceof Reflector) {
-        const entry = { r: obj, dirty: true };
-        this.mirrors.push(entry);
-        const original = obj.onBeforeRender.bind(obj);
-        obj.onBeforeRender = (...args: any[]) => {
-          if (StoreScene.reflectorRendering) return;                 // no mirror-in-mirror nesting
-          if (!entry.dirty || this.mirrorRenderBudget <= 0) return;  // static view → reuse last reflection
-          entry.dirty = false;
-          this.mirrorRenderBudget--;
-          StoreScene.reflectorRendering = true;
-
-          // Temporarily hide the selection arrow during mirror renders so it doesn't reflect
-          const arrowWasVisible = this.selectionArrow ? this.selectionArrow.visible : false;
-          if (this.selectionArrow) {
-            this.selectionArrow.visible = false;
-          }
-
-          perfTrace.count(CT_MIRROR);
-          perfTrace.begin(SP_MIRROR);
-          try { (original as any)(...args); }
-          finally {
-            perfTrace.end(SP_MIRROR);
-            if (this.selectionArrow) {
-              this.selectionArrow.visible = arrowWasVisible;
-            }
-            StoreScene.reflectorRendering = false;
-          }
-        };
-      }
-    });
-  }
-
-  /**
-   * Called once per frame before rendering. Decides whether any mirror needs
-   * a fresh reflection this frame and, if so, admits at most one into the
-   * render budget that installMirrorThrottle's onBeforeRender wrapper consumes.
-   *
-   * - Camera fully still and nothing structural changed: budget = 0, every
-   *   mirror reuses its last reflection texture (0 reflector renders/frame).
-   * - Camera moving: one mirror is round-robined into the dirty queue per
-   *   frame (mirrorRefreshIdx), budget = 1, so reflections track the camera
-   *   at ~1 render/frame instead of 4.
-   * - Structural change (forceAll — scene rebuild, shelf pop, end-cap/clerk
-   *   motion): every mirror is marked dirty, but the budget is still capped
-   *   at 1/frame; mirrors that don't get the budget this frame stay dirty
-   *   and drain over the next few frames.
-   */
-  private updateMirrorThrottle(forceAll: boolean) {
-    const moved =
-      this.camera.position.distanceToSquared(this.lastMirrorCamPos) > 1e-6 ||
-      Math.abs(1 - Math.abs(this.camera.quaternion.dot(this.lastMirrorCamQuat))) > 1e-7;
-
-    if (moved || forceAll) {
-      this.lastMirrorCamPos.copy(this.camera.position);
-      this.lastMirrorCamQuat.copy(this.camera.quaternion);
-    }
-
-    if (forceAll) {
-      for (const m of this.mirrors) m.dirty = true;
-    } else if (moved && this.mirrors.length > 0) {
-      this.mirrors[this.mirrorRefreshIdx % this.mirrors.length].dirty = true;
-      this.mirrorRefreshIdx = (this.mirrorRefreshIdx + 1) % this.mirrors.length;
-    }
-
-    // A fresh reflection is a full extra scene render (~7ms / ~700 draw calls
-    // at high budget). At a 60Hz target one per frame fits; chasing 120fps
-    // it's most of the frame budget, so admit renders on alternate frames
-    // only — dirty flags are sticky, so nothing is lost, and a 60Hz mirror
-    // under a 120Hz camera is indistinguishable. Gating the budget (not the
-    // dirty marking) keeps it effective when clerk motion force-dirties all.
-    this.mirrorMotionParity ^= 1;
-    const admit = !this.mirrorsFrozen && (this.targetFps <= 90 || this.mirrorMotionParity === 0);
-
-    this.mirrorRenderBudget = 0;
-    if (admit) {
-      for (const m of this.mirrors) {
-        if (m.dirty) { this.mirrorRenderBudget = 1; break; }
-      }
-    }
-  }
+  // Live mirrors: install the per-Reflector render throttle, and decide each
+  // frame whether any reflection may re-render. See store-mirrors.ts.
+  private installMirrorThrottle() { return mirrors.installMirrorThrottle(this); }
+  private updateMirrorThrottle(forceAll: boolean) { return mirrors.updateMirrorThrottle(this, forceAll); }
 
   // Cube render targets behind the current reflection probes, kept so a re-bake
   // (outside-mode change) can dispose them instead of leaking GPU memory.

--- a/src/video-player.ts
+++ b/src/video-player.ts
@@ -100,8 +100,16 @@ export interface VideoPlayerOptions {
   startPositionTicks?: number;
   /** Audio tracks selectable in the picker (from the item's MediaStreams). */
   audioTracks?: TrackChoice[];
-  /** Subtitle tracks selectable in the picker (burned in server-side). */
+  /** Subtitle tracks selectable in the picker. */
   subtitleTracks?: TrackChoice[];
+  /** WebVTT sidecar for the initially-selected subtitle, when it's a text
+   *  track. Hung on the <video> as a <track>, so the server never re-encodes
+   *  the film just to show captions. */
+  subtitleTrackUrl?: string;
+  /** Ask how a newly-picked subtitle should be delivered: a URL means text
+   *  (swap the sidecar, keep playing), null means bitmap (only a burned-in
+   *  re-encode can render it, so rebuild the stream the old way). */
+  buildSubtitleTrack?: (streamIndex: number) => string | null;
   /** Initial audio MediaStream index (Settings ▸ Playback language pref).
    *  Pre-selects the picker row and rides along on every stream rebuild.
    *  The caller bakes it into the initial hlsSrc itself. */
@@ -200,6 +208,13 @@ export class VideoPlayer {
    *  finished" apart from "the user backed out" — see onClose. */
   private endedNaturally = false;
   private activeSubtitleTrack: TextTrack | null = null;
+  // The <track> carrying the WebVTT sidecar, when subtitles are delivered as
+  // text rather than burned into the video (see setSubtitleSidecar).
+  private subtitleTrackEl: HTMLTrackElement | null = null;
+  // Subtitle stream index the CURRENT stream has burned into the picture
+  // (bitmap tracks only). Non-null means captions are pixels: changing or
+  // removing them costs a new stream, which is what the sidecar path avoids.
+  private burnedInSubtitleIndex: number | null = null;
   private nativeLoadedMetadataListener: (() => void) | null = null;
   private isHidden = false;
   private preHiddenVolume = 1.0;
@@ -379,6 +394,12 @@ export class VideoPlayer {
     this.activeSubtitleTrack = null;
     this.subtitlesBtn.setAttribute('hidden', '');
     this.subtitlesBtn.classList.remove('is-active');
+    // A new title must never inherit the previous one's captions. A sidecar
+    // URL means the caller chose text delivery, so nothing is baked into the
+    // picture; a default index with no sidecar means it is.
+    this.burnedInSubtitleIndex =
+      !opts.subtitleTrackUrl && opts.defaultSubtitleIndex !== undefined ? opts.defaultSubtitleIndex : null;
+    this.setSubtitleSidecar(opts.subtitleTrackUrl ?? null);
     // Default focus for a fresh player: the timeline, ready to seek.
     this.focusTimeline();
 
@@ -1306,6 +1327,44 @@ export class VideoPlayer {
     this.fullscreenBtn.setAttribute('aria-label', isFullscreen ? 'Exit fullscreen' : 'Fullscreen');
   }
 
+  /**
+   * Hang a WebVTT sidecar on the <video> (or clear it). This is what replaced
+   * asking the server to burn subtitles into the picture: a <track> costs the
+   * server a text fetch instead of a full re-encode of the film, and swapping
+   * or clearing it needs no new stream, so switching subtitles is instant and
+   * never interrupts playback.
+   *
+   * The element is recreated rather than re-`src`'d because a <track> that has
+   * already loaded keeps its cues when only the src changes in some engines —
+   * leaving the old language's captions on screen under the new one's name.
+   */
+  private setSubtitleSidecar(url: string | null): void {
+    this.subtitleTrackEl?.remove();
+    this.subtitleTrackEl = null;
+    if (!url) {
+      this.activeSubtitleTrack = null;
+      this.subtitlesBtn.setAttribute('hidden', '');
+      this.subtitlesBtn.classList.remove('is-active');
+      return;
+    }
+    const el = document.createElement('track');
+    el.kind = 'subtitles';
+    el.label = 'Subtitles';
+    el.default = true;
+    el.src = url;
+    // A sidecar that 404s (wrong index, server without the converter) must not
+    // take the film down with it — log and leave the picture playing.
+    el.addEventListener('error', () => {
+      this.opts?.log?.('[Video] Subtitle track failed to load; playing without captions.');
+      this.subtitlesBtn.setAttribute('hidden', '');
+    });
+    this.video.appendChild(el);
+    this.subtitleTrackEl = el;
+    // The TextTrack behind a freshly-appended <track> only becomes usable once
+    // the browser has registered it, hence the deferred hookup.
+    setTimeout(() => this.setupSubtitlesIfAvailable(), 0);
+  }
+
   /** Subtitles are only ever surfaced if the loaded media actually carries a text track. */
   private setupSubtitlesIfAvailable(): void {
     const tracks = this.video.textTracks;
@@ -1412,10 +1471,40 @@ export class VideoPlayer {
     if (!row || row.kind !== 'item') return;
     if (row.group === 'quality') this.qualityPresetIdx = row.value as number;
     else if (row.group === 'audio') this.audioIndex = row.value as number;
-    else if (row.group === 'subs') this.subtitleIndex = row.value as number | null;
+    else if (row.group === 'subs') {
+      this.subtitleIndex = row.value as number | null;
+      // A text subtitle (or turning them off) needs no new stream at all —
+      // swap the sidecar and keep playing. Only a bitmap track, or dropping a
+      // burn-in already baked into the picture, has to go back to the server.
+      if (this.applySubtitleWithoutReload(this.subtitleIndex)) {
+        this.renderTracksMenu();
+        this.nudgeControls();
+        return;
+      }
+    }
     this.renderTracksMenu(); // reflect the new checkmark immediately
     this.applyStreamSelection();
     this.nudgeControls();
+  }
+
+  /**
+   * Try to honour a subtitle pick without rebuilding the stream.
+   * Returns false when only a server-side re-encode can do it, in which case
+   * the caller falls through to applyStreamSelection().
+   */
+  private applySubtitleWithoutReload(streamIndex: number | null): boolean {
+    // Pixels already baked into the video can only be removed or changed by
+    // encoding a new stream.
+    if (this.burnedInSubtitleIndex !== null) return false;
+    if (streamIndex === null) {
+      this.setSubtitleSidecar(null);
+      return true;
+    }
+    const url = this.opts?.buildSubtitleTrack?.(streamIndex);
+    if (!url) return false; // bitmap subtitle — burn-in is the only renderer
+    this.setSubtitleSidecar(url);
+    this.subtitlesBtn.classList.add('is-active');
+    return true;
   }
 
   // Rebuild the HLS stream for the current quality/audio/subtitle picks, then
@@ -1436,11 +1525,26 @@ export class VideoPlayer {
     // orphaned job per track change, all reading the same file concurrently).
     this.stopCurrentEncode();
     const preset = QUALITY_PRESETS[this.qualityPresetIdx] ?? QUALITY_PRESETS[0];
+    // Only ask the server to burn a subtitle in when the client genuinely
+    // cannot draw it. Passing a TEXT track's index here would force a full
+    // re-encode for captions the <track> sidecar renders for free — the exact
+    // cost this path exists to avoid.
+    const burnIn = this.subtitleIndex !== null && this.opts?.buildSubtitleTrack?.(this.subtitleIndex) == null
+      ? this.subtitleIndex
+      : undefined;
+    this.burnedInSubtitleIndex = burnIn ?? null;
+    // The new stream carries its own captions (or none); drop any sidecar so
+    // the two can't both be on screen.
+    if (burnIn !== undefined) this.setSubtitleSidecar(null);
+    else if (this.subtitleIndex !== null) {
+      const url = this.opts?.buildSubtitleTrack?.(this.subtitleIndex);
+      if (url) this.setSubtitleSidecar(url);
+    }
     const sel: StreamSelection = {
       maxBitrate: preset.maxBitrate,
       maxWidth: preset.maxWidth,
       audioStreamIndex: this.audioIndex,
-      subtitleStreamIndex: this.subtitleIndex ?? undefined,
+      subtitleStreamIndex: burnIn,
     };
     const src = build(sel);
     // Adopt the new session id immediately: a second change before this stream

--- a/tests/subtitle-delivery.test.ts
+++ b/tests/subtitle-delivery.test.ts
@@ -1,0 +1,102 @@
+// How a chosen subtitle reaches the screen — the decision that determines
+// whether the server re-encodes the whole film or serves a text file.
+//
+// Asking Jellyfin to burn subtitles in (SubtitleMethod=Encode) forces a full
+// video re-encode, so on the browser/Remote Play path merely defaulting
+// captions ON used to turn every direct-playable file into a transcode. Text
+// subtitles are now fetched as a WebVTT sidecar and drawn by the browser
+// instead; only bitmap formats, which have no client renderer, still pay the
+// old price. Getting the classification wrong is expensive in one direction
+// (a needless re-encode of the entire runtime) and invisible in the other
+// (captions that silently never appear), so it's pinned here.
+//
+//   npm run test:subs (or: node --experimental-strip-types --test tests/subtitle-delivery.test.ts)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { MediaStreamInfo } from '../src/jellyfin.ts';
+import {
+  isTextSubtitleCodec,
+  pickSubtitleDelivery,
+  buildSubtitleTrackUrl,
+} from '../src/jellyfin.ts';
+
+const sub = (index: number, codec: string): MediaStreamInfo =>
+  ({ index, type: 'Subtitle', codec });
+
+const STREAMS: MediaStreamInfo[] = [
+  { index: 1, type: 'Audio', codec: 'eac3' },
+  sub(2, 'subrip'),
+  sub(3, 'ass'),
+  sub(4, 'pgssub'),
+  sub(5, 'dvd_subtitle'),
+  sub(6, 'mov_text'),
+];
+
+test('text subtitle codecs are recognised in every spelling Jellyfin reports', () => {
+  for (const c of ['subrip', 'srt', 'ass', 'ssa', 'mov_text', 'webvtt', 'vtt', 'text']) {
+    assert.equal(isTextSubtitleCodec(c), true, `${c} should be text`);
+  }
+  // ffmpeg's casing is not guaranteed.
+  assert.equal(isTextSubtitleCodec('SubRip'), true);
+  assert.equal(isTextSubtitleCodec('ASS'), true);
+});
+
+test('bitmap subtitle codecs are not text — they have no client renderer', () => {
+  for (const c of ['pgssub', 'dvd_subtitle', 'dvbsub', 'xsub', 'hdmv_pgs_subtitle']) {
+    assert.equal(isTextSubtitleCodec(c), false, `${c} should be bitmap`);
+  }
+  assert.equal(isTextSubtitleCodec(undefined), false);
+  assert.equal(isTextSubtitleCodec(''), false);
+});
+
+test('no subtitle selected asks for no delivery at all', () => {
+  assert.deepEqual(pickSubtitleDelivery(STREAMS, undefined), { kind: 'none' });
+});
+
+test('a text track is delivered as a sidecar, never burned in', () => {
+  assert.deepEqual(pickSubtitleDelivery(STREAMS, 2), { kind: 'text', streamIndex: 2 });
+  assert.deepEqual(pickSubtitleDelivery(STREAMS, 3), { kind: 'text', streamIndex: 3 });
+  assert.deepEqual(pickSubtitleDelivery(STREAMS, 6), { kind: 'text', streamIndex: 6 });
+});
+
+test('a bitmap track still has to be burned in', () => {
+  assert.deepEqual(pickSubtitleDelivery(STREAMS, 4), { kind: 'burn-in', streamIndex: 4 });
+  assert.deepEqual(pickSubtitleDelivery(STREAMS, 5), { kind: 'burn-in', streamIndex: 5 });
+});
+
+test('an unknown stream falls back to the CHEAP path, not the expensive one', () => {
+  // A server that reports no codec, or an index we never saw, must not cost
+  // the viewer a full re-encode on a guess: a sidecar that 404s loses only
+  // the captions, and the film keeps playing.
+  assert.deepEqual(pickSubtitleDelivery(STREAMS, 99), { kind: 'text', streamIndex: 99 });
+  assert.deepEqual(pickSubtitleDelivery(undefined, 2), { kind: 'text', streamIndex: 2 });
+  assert.deepEqual(
+    pickSubtitleDelivery([{ index: 7, type: 'Subtitle' }], 7),
+    { kind: 'text', streamIndex: 7 },
+  );
+});
+
+test('an audio stream sharing a subtitle index is not mistaken for one', () => {
+  // Jellyfin indices are per-file, not per-type: index 1 here is AUDIO. Asking
+  // for subtitle index 1 must not classify off the audio codec.
+  assert.deepEqual(pickSubtitleDelivery(STREAMS, 1), { kind: 'text', streamIndex: 1 });
+});
+
+test('the sidecar URL points at the VTT converter for the right source', () => {
+  const url = buildSubtitleTrackUrl('http://jf:8096', 'tok en', 'item-1', 3, 'src-9');
+  assert.equal(
+    url,
+    'http://jf:8096/Videos/item-1/src-9/Subtitles/3/0/Stream.vtt?api_key=tok%20en',
+  );
+});
+
+test('the sidecar URL falls back to the item as its own media source', () => {
+  const url = buildSubtitleTrackUrl('http://jf:8096', 't', 'item-1', 2);
+  assert.equal(url, 'http://jf:8096/Videos/item-1/item-1/Subtitles/2/0/Stream.vtt?api_key=t');
+});
+
+test('a trailing slash on the server address does not double up', () => {
+  const url = buildSubtitleTrackUrl('http://jf:8096/', 't', 'i', 0);
+  assert.equal(url.startsWith('http://jf:8096/Videos/'), true, url);
+});

--- a/tools/remote-play-server.mjs
+++ b/tools/remote-play-server.mjs
@@ -298,7 +298,16 @@ export function remotePlayPlugin() {
         await page.evaluateOnNewDocument((kv) => {
           try {
             for (const [k, v] of Object.entries(kv)) localStorage.setItem(k, String(v));
-            localStorage.setItem("bb_remote_play", "0");
+            // bb_remote_play is deliberately NOT written here, in either
+            // direction. It is already stripped from the seed (SEED_SKIP) so
+            // the owner's kiosk setting can't make this instance register as
+            // the shared mirror; ?remoteId= is what makes it host, as host-<id>.
+            // Writing an explicit "0" used to look harmless and was the bug:
+            // applyLiveSettings() replays every EXPLICITLY-SET live setting
+            // once the scene is built, so the instance hosted, finished
+            // booting, then switched its own stream off and left the viewer
+            // stuck on "Store is still booting…". Leaving the key absent is
+            // what keeps it out of that replay.
           } catch { /* storage unavailable */ }
         }, seed);
       }


### PR DESCRIPTION
Release **v0.4.0** — 15 commits since v0.3.1. Owner tested `dev` before this was opened.

## Reach
- **#47** Demo degrades gracefully on mobile instead of dead-ending — 2D store offered to phones and WebGL2-less browsers
- **#48** arm64 Docker image back, on native runners instead of QEMU
- Remote Play: touch controls, so the store works on a phone
- Subtitles render client-side instead of re-encoding the film
- Fix: private Remote Play instances switching their own stream off

## Image quality
- Entrance view reaches its settle frame — stops looking soft
- Boot texture uploads no longer walk resolution down (0.70 → 0.85 floor on 4K); settle cap held
- Wire shelving + walls get the anisotropy they were missing

## Mirrors
- Refresh budget now spent on reflections actually on screen (frustum + facing), not round-robined across mirrors behind you. Same cost: 281 refreshes vs 282, p99 24.0ms vs 23.8ms
- New four-sided mirrored column in the back cross-aisle. Four more mirrors, no extra refreshes — the budget is the store's, not each mirror's
- Fix: one mirror no longer punches a black hole in another's reflection
- Box-projected cubemap mirrors tried, measured, rejected — rationale recorded in `store-mirrors.ts` so nobody rebuilds it

## Verified
- `npm run build`, 185 unit tests, nav-state suite, clerk-path audit, zero layout-validator violations
- `--full` perf on 4K/GPU: p50/p90/p99 16.7/16.9/24.2ms
- Visual: entrance, cornice band, column from four angles, New Releases ribbon

## Not verified
- **#11** (ceiling band intermittently solid black) is the same failure mode as the mirror-in-mirror fix here and may be its cause, but it predates the column and describes the whole band going black. Not claimed closed — wants its own repro run
- Mobile/touch and arm64 paths carried over from earlier commits; not re-tested in this pass
- The 11 unwired signage-wave fixture modules are **not** in this release
