### PR TITLE
Supply the store from Plex as well as Jellyfin

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,10 +2,22 @@
 # Save all your server credentials here so you never have to type them in manually again.
 # Vite automatically loads variables from .env.local on application boot.
 
-# Jellyfin Media Server (Required for library sync)
+# Media server (required for library sync) — fill in ONE of the two blocks.
+# The store identifies whichever server answers the address, so the only thing
+# that picks Jellyfin vs Plex here is which credentials you supply.
+
+# --- Jellyfin ---
 VITE_JELLYFIN_URL=http://localhost:8096
 VITE_JELLYFIN_USERNAME=your_username
 VITE_JELLYFIN_PASSWORD=your_password
+
+# --- Plex ---
+# Plex has no name/password sign-in a headless boot can drive (its sign-in
+# lives on plex.tv behind the interactive link flow), so a token IS the
+# credential here. Get one by linking once in the setup terminal, or from the
+# X-Plex-Token on any request made by a signed-in Plex client.
+# VITE_PLEX_URL=http://localhost:32400
+# VITE_PLEX_TOKEN=your_plex_token
 
 # Jellyseerr / Overseerr (Optional - for requests & discovery)
 VITE_JELLYSEERR_URL=http://localhost:5055

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,10 @@ COPY . .
 ARG VITE_JELLYFIN_URL
 ARG VITE_JELLYFIN_USERNAME
 ARG VITE_JELLYFIN_PASSWORD
+# Plex is configured with a URL + token instead of a name/password — see
+# .env.local.example for where the token comes from.
+ARG VITE_PLEX_URL
+ARG VITE_PLEX_TOKEN
 
 RUN npm run build
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Halcyon Video — a 3D video store for your media server
 
-**Your Jellyfin library, rebuilt as a walkable 1990s video rental store.** Every
+**Your Jellyfin or Plex library, rebuilt as a walkable 1990s video rental store.** Every
 movie you own is a case on a shelf. Browse the aisles under warm fluorescents,
 pull *Back to the Future* off the wall, flip it over and read the back of the
 box, carry it to the counter, and watch the clerk drop it in a bag that
@@ -45,7 +45,7 @@ The short answers, so you don't have to go looking for them.
 |---|---|
 | **Run in Docker?** | Yes — one `docker run`, or `docker compose up -d` from a clone. [Quick start ↓](#quick-start) |
 | **Do video games?** | Yes — point it at [RomM](https://github.com/rommapp/romm) and a whole department appears: per-platform bays, period-correct boxes and jewel cases. [More ↓](#the-games-department) |
-| **Work with Plex or Emby?** | Not yet — Jellyfin today. The media layer is one module and adapters are the top roadmap item ([#32](https://github.com/halcyon-video/halcyon-video/issues/32)). |
+| **Work with Plex?** | Yes — Jellyfin and Plex both. Type the address and the store works out which one answered; Plex signs in with a code on `plex.tv/link`, and its Home users become the membership cards. Emby is not supported. [More ↓](#which-media-server) |
 | **Run on a Raspberry Pi?** | Yes — **2.5D mode** runs the same store as plain HTML/CSS. [More ↓](#25d-mode--the-same-store-for-a-raspberry-pi) |
 | **Work away from home?** | Yes — **Remote Play** streams the live store to any browser, with its own TURN relay for off-LAN viewers. [More ↓](#remote-play--the-store-in-your-pocket) |
 | **Look like *my* video store?** | Yes — brand, logo, colors, themes, fixtures and sign art are all data you drop in a folder, not code. [More ↓](#make-it-yours) |
@@ -64,7 +64,7 @@ The short answers, so you don't have to go looking for them.
 ## What it is
 
 A Vite + TypeScript + **three.js** app (optionally Tauri-wrapped) that connects
-to **[Jellyfin](https://jellyfin.org/)** and procedurally builds a period video
+to **[Jellyfin](https://jellyfin.org/)** or **[Plex](https://www.plex.tv/)** and procedurally builds a period video
 store from whatever you have: every library becomes an aisle, genres become
 signposted sections, duplicate quality versions stack behind the face copy, the
 worst-rated titles literally end up in the **Bargain Bin**. It runs 24/7 on an
@@ -73,7 +73,7 @@ renders *nothing at all* and idles at near-zero CPU/GPU for days.
 
 The screenshots in this README show the store running its built-in demo
 catalog — public-domain classics on every shelf, no media server attached
-(the same thing the live demo link runs). Point it at your Jellyfin and every
+(the same thing the live demo link runs). Point it at your own server and every
 case becomes something you own. This isn't a tech demo that gets old in five
 minutes; it's how our family has picked a movie every night for months.
 
@@ -267,7 +267,7 @@ printed for.
   libplacebo and the **original lossless audio** — no transcode, no tens of GB
   of HLS segments. The remote still works: OK pauses, Up cycles subs, Down
   cycles audio, Left/Right scrub.
-- Playback reports back to Jellyfin (start/progress/stop), so resume points and
+- Playback reports back to your server (start/progress/stop), so resume points and
   watch history — which feed the staff picks — stay honest.
 
 ---
@@ -304,7 +304,7 @@ HDR skies) / street-view outside the glass.
 
 ### Membership cards
 
-Jellyfin users appear as **laminated membership cards** — deterministic member
+Server users appear as **laminated membership cards** — deterministic member
 numbers, "MEMBER SINCE", the user's avatar, a glint sweep. Picking your card is
 how you log in; cards flip over for password entry.
 
@@ -392,7 +392,7 @@ default 2) and viewers past the cap are turned away until one frees up.
 
 - The **bargain bin** is genuinely your library's worst-audience-scored titles,
   leaning in a rummage jumble. Critic scores are pointedly ignored.
-- **Four-sided collection displays** rotate a different Jellyfin BoxSet per
+- **Four-sided collection displays** rotate a different collection per
   face, re-picked daily.
 - The candy rack, tape rewinder, "BE KIND — PLEASE REWIND" tents, EAS pedestals,
   the beige security camera aimed exactly along the overview vantage.
@@ -440,7 +440,7 @@ This app's steady state is *days on a shelf*, and it's engineered like it:
 
 | You have | You get |
 |---|---|
-| **Jellyfin** (required — or demo mode) | The store, browsing, walk mode, playback, rentals, living room, clerk, themes, brand editor |
+| **Jellyfin or Plex** (required — or demo mode) | The store, browsing, walk mode, playback, rentals, living room, clerk, themes, brand editor |
 | **Jellyseerr** (optional) | Recommendation clasps, REQUEST / COMING SOON cases, collection gaps, discovery shelving, staff picks, FOR YOU endcaps, "order it for me" |
 | **RomM** (optional) | The video-game department: per-platform bays, real carton proportions, your cover scans |
 | **The server on the same machine as the TV** | mpv playback — real HDR and original lossless audio, no transcode |
@@ -455,7 +455,7 @@ never built, and callers never branch.
 <br>
 
 The store is built to run on your own network. Fonts, textures and every other
-asset ship inside the bundle, and Jellyfin, Jellyseerr and RomM are your own
+asset ship inside the bundle, and your media server, Jellyseerr and RomM are your own
 servers at your own addresses — nothing is fetched from a CDN to draw the store.
 
 Two optional features are the exceptions, and only while you use them:
@@ -467,7 +467,7 @@ Two optional features are the exceptions, and only while you use them:
 
 Jellyseerr returns a TMDB *path* rather than the image itself — its own web UI
 fetches from that same CDN — so there is no copy on your server to serve
-instead. Art for titles you already own always comes from Jellyfin, which is why
+instead. Art for titles you already own always comes from your own server, which is why
 the store proper works with the internet unplugged.
 
 Remote Play sends no video through the STUN server: it is one question ("what
@@ -487,7 +487,7 @@ git clone https://github.com/halcyon-video/halcyon-video
 cd halcyon-video
 npm install
 npm run dev          # dev server on :1420 — first boot shows the login /
-                     # membership cards; enter your Jellyfin URL + credentials
+                     # membership cards; enter your server URL + credentials
 ```
 
 **Docker — the no-fuss way:**
@@ -500,7 +500,7 @@ docker run -d --name halcyon --network host --restart unless-stopped \
 …or, from a clone, `docker compose up -d` (builds the image locally; the
 prebuilt image is published from releases). Then:
 
-1. Open `http://<host>:1420` in a browser and log into your Jellyfin — or
+1. Open `http://<host>:1420` in a browser and log into your media server — or
    append `?demo=1` to try it with no server at all.
 2. Open `http://<host>:1420/remote.html` on a phone, tablet, or set-top box:
    the **container** renders the store and streams it over WebRTC, with your
@@ -549,11 +549,41 @@ No. Render-on-demand means it only draws when something changes, a dynamic
 resolution scaler fits it to your hardware, and the **2.5D mode** runs the
 whole store as HTML/CSS on a Raspberry Pi.
 
+<a id="which-media-server"></a>
 **Does it work with Plex or Emby?**
-Today it speaks Jellyfin (and a no-server demo mode). The media layer is one
-module, and Plex/Emby adapters are the most-asked-about item on the roadmap —
-[issue #32](https://github.com/halcyon-video/halcyon-video/issues/32) is the
-one to watch or chime in on.
+Jellyfin and Plex both; Emby is not supported. The media layer sits behind one
+interface (`src/media-backend.ts`) with a backend on either side of it, and the
+store picks between them by asking the address you typed which one it is — so
+there is no server type to declare, just an address.
+
+The two differ in exactly three places you'll notice:
+
+- **Signing in.** Jellyfin takes a name and password. Plex shows a four-letter
+  code on the counter terminal that you approve at `plex.tv/link` from your
+  phone — no keyboard needed on the HTPC, and the only route that works with
+  two-factor auth. You can also paste an `X-Plex-Token` into the sign-in screen
+  or `VITE_PLEX_TOKEN`, which is what a headless or scripted deploy wants.
+- **Membership cards.** Jellyfin fans out its public user list; Plex fans out
+  your **Plex Home** members, and picking one switches to that member's own
+  token so watch state and resume points land on their history, not yours.
+- **Speed.** A Plex sync is markedly faster — a section listing arrives whole
+  instead of paged, and full metadata comes back comma-batched. A 458-title
+  library syncs in about 3 seconds.
+
+One Plex quirk worth knowing about, because it is Plex's and not ours: a Plex
+Media Server only allows browser requests from `localhost`, and answers every
+other origin with a fixed `app.plex.tv` CORS header — with no setting to add
+your own, the way Jellyfin has. So a store served over the LAN
+(`http://<host>:1420`) would have every request to Plex blocked by the browser.
+Halcyon handles that itself: media-server traffic is routed through its own
+`/plex-proxy` endpoint, host-side, where CORS doesn't apply. Nothing to
+configure — but it is why Plex needs the app's server (`npm run dev` /
+`npm run serve` / Docker) rather than a bare static host. The desktop build
+doesn't go near this: its requests never touch a browser policy.
+
+Everything downstream — shelves, collections, the Bargain Bin, staff picks,
+4K stickers, quality-version pickers, resume, Jellyseerr requests — works the
+same on both.
 
 **Can I run it in Docker?**
 Yes — see [Quick start](#quick-start). One `docker run` with `--network host`,
@@ -610,7 +640,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 *Halcyon Video is a fictional brand created for this project. This repository
 contains no third-party trademarks or brand assets: no real chain's name,
 logo, trade dress, or typefaces are included or distributed. Movie artwork
-visible in screenshots is library metadata from the author's personal Jellyfin
+visible in screenshots is library metadata from the author's personal library
 server. This project is not affiliated with, endorsed by, or connected to any
 video-rental company, past or present — it is a love letter to Friday nights
 at all of them.*

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -332,6 +332,59 @@ fn romm_request(
     Ok(body_str)
 }
 
+// Proxy a Plex request through the host (same rationale as jellyseerr_request:
+// no CORS, and the host can reach a server the sandboxed webview can't).
+//
+// Unlike its siblings this takes an arbitrary header MAP rather than one named
+// credential. Plex needs several headers on every call — `Accept:
+// application/json` (without it the server answers XML) plus the X-Plex-*
+// client identity that its tokens are issued against — and enumerating them as
+// parameters here would mean editing Rust every time the JS side adjusts one.
+#[tauri::command]
+fn plex_request(
+    method: String,
+    url: String,
+    headers: std::collections::HashMap<String, String>,
+    body: Option<String>,
+) -> Result<String, String> {
+    if cfg!(debug_assertions) {
+        println!("[Plex Request] {} {}", method, redact_url(&url));
+    }
+
+    let client = reqwest::blocking::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .map_err(|e| format!("Failed to build reqwest client: {}", e))?;
+
+    let req_method = reqwest::Method::from_bytes(method.as_bytes())
+        .map_err(|e| format!("Invalid HTTP method: {}", e))?;
+
+    let mut req = client.request(req_method, &url)
+        .header("Content-Type", "application/json");
+
+    for (name, value) in headers {
+        req = req.header(name, value);
+    }
+
+    if let Some(b) = body {
+        req = req.body(b);
+    }
+
+    let response = req.send().map_err(|e| format!("Request failed: {}", e))?;
+    let http_code = response.status().as_u16();
+    let body_str = response.text().map_err(|e| format!("Failed to read response body: {}", e))?;
+
+    if http_code >= 400 {
+        return Err(format!("HTTP error {}: {}", http_code, body_str));
+    }
+
+    if cfg!(debug_assertions) {
+        println!("[Plex OK] {} {} -> {} bytes", method, redact_url(&url), body_str.len());
+    }
+    Ok(body_str)
+}
+
 // T18: launch an emulator for a rented game. The command `template` is
 // tokenized on whitespace into an argv array (program + args); the literal
 // token `{path}` is replaced by the rom `path` as a SINGLE argv element, and
@@ -475,6 +528,7 @@ pub fn run() {
             suspend_system,
             check_file_exists,
             jellyfin_request,
+            plex_request,
             jellyseerr_request,
             romm_request,
             launch_game,

--- a/src/boot-flow.ts
+++ b/src/boot-flow.ts
@@ -10,13 +10,19 @@
 // and loaders through initBootFlow(deps); nothing here reaches back into
 // main.ts directly, so the two can't tangle.
 import {
-  fetchJellyfinLibrariesAndMovies,
+  fetchLibrariesAndMovies,
   authenticateUser,
   validateToken,
   fetchPublicUsers,
   normalizeUrl,
-  JellyfinLibrary,
-} from './jellyfin';
+  activeBackend,
+  setActiveBackendKind,
+  persistSession,
+  USERNAME_KEY,
+  TOKEN_KEY,
+  LAST_USER_ID_KEY,
+} from './media-backend.ts';
+import type { JellyfinLibrary } from './media-types.ts';
 import {
   openMembershipCardPicker,
   closeMembershipCardPicker,
@@ -186,7 +192,7 @@ async function syncForSetup(
   try {
     [libs] = await Promise.all([
       Promise.race([
-        fetchJellyfinLibrariesAndMovies(url, session.accessToken, session.userId, onProgress, {
+        fetchLibrariesAndMovies(url, session.accessToken, session.userId, onProgress, {
           excludeLibraryIds: excludedLibraryIds(),
         }),
         stallPromise,
@@ -301,10 +307,7 @@ export function showBootOverlay() {
 async function finishLoginAndLaunch(urlInput: string, session: MembershipLoginSession) {
   if (!deps) return;
   deps.log(`[System] Authenticated successfully as ${session.userName}.`, 'system');
-  localStorage.setItem('jellyfin_url', urlInput);
-  localStorage.setItem('jellyfin_token', session.accessToken);
-  localStorage.setItem('jellyfin_userid', session.userId);
-  localStorage.setItem('jellyfin_last_userid', session.userId); // remembered for next boot's card highlight
+  persistSession(activeBackend().kind, urlInput, session);
 
   deps.log('[System] Downloading movie libraries and catalog metadata...', 'system');
   // Stall watchdog, not a deadline — see the auto-login path for why a fixed
@@ -324,7 +327,7 @@ async function finishLoginAndLaunch(urlInput: string, session: MembershipLoginSe
   try {
     [libs] = await Promise.all([
       Promise.race([
-        fetchJellyfinLibrariesAndMovies(urlInput, session.accessToken, session.userId, armLoginStall, {
+        fetchLibrariesAndMovies(urlInput, session.accessToken, session.userId, armLoginStall, {
           excludeLibraryIds: excludedLibraryIds(),
         }),
         loginTimeout
@@ -363,14 +366,15 @@ export async function showLoginOrCards(reason?: string) {
   const savedUrl = localStorage.getItem('jellyfin_url');
   if (savedUrl) {
     try {
-      const users = await fetchPublicUsers(savedUrl);
+      const users = await fetchPublicUsers(savedUrl, localStorage.getItem(TOKEN_KEY) ?? undefined);
       if (users.length > 0) {
         if (reason) deps.log(`[System] ${reason}`, 'system');
         deps.log(`[System] Found ${users.length} membership card(s) on ${savedUrl}.`, 'system');
         openMembershipCardPicker({
           serverUrl: savedUrl,
           users,
-          lastUserId: localStorage.getItem('jellyfin_last_userid'),
+          sessionToken: localStorage.getItem(TOKEN_KEY) ?? undefined,
+          lastUserId: localStorage.getItem(LAST_USER_ID_KEY),
           onLogin: (session) => finishLoginAndLaunch(savedUrl, session),
           onManualLogin: () => abortBootToLogin(reason),
           onDemoMode: () => {
@@ -450,20 +454,43 @@ export async function checkCredentialsAndLoad() {
   const envUser = (typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_USERNAME : undefined) || '';
   const envPass = (typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_JELLYFIN_PASSWORD : undefined) || '';
 
-  let jellyfinUrl = localStorage.getItem('jellyfin_url') || envUrl;
+  // A Plex deployment configures a URL + TOKEN rather than a name/password:
+  // Plex's sign-in lives on plex.tv behind an interactive link flow that a
+  // headless first boot can't drive, so the token is the credential. Get one
+  // from any signed-in Plex client (Account → the X-Plex-Token on a request)
+  // or from the setup terminal after linking once.
+  const envPlexUrl = (typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_PLEX_URL : undefined) || '';
+  const envPlexToken = (typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_PLEX_TOKEN : undefined) || '';
+
+  let jellyfinUrl = localStorage.getItem('jellyfin_url') || envUrl || envPlexUrl;
   let token = localStorage.getItem('jellyfin_token');
   let userId = localStorage.getItem('jellyfin_userid');
+
+  if ((!token || !userId) && envPlexUrl && envPlexToken) {
+    setActiveBackendKind('plex');
+    d.log('[System] File credentials (.env.local) name a Plex server. Adopting the token...', 'system');
+    try {
+      const session = await activeBackend().adoptToken!(envPlexUrl, envPlexToken);
+      // The env token, not the account's — it's what the server was given.
+      const envSession = { ...session, accessToken: envPlexToken };
+      persistSession('plex', envPlexUrl, envSession);
+      localStorage.setItem(USERNAME_KEY, envSession.userName);
+      jellyfinUrl = envPlexUrl;
+      token = envSession.accessToken;
+      userId = envSession.userId;
+      d.log(`[System] Auto-authenticated successfully as ${envSession.userName}.`, 'system');
+    } catch (e: any) {
+      d.log(`[System] The Plex token in .env.local was refused: ${e?.message ?? e}`, 'system');
+    }
+  }
 
   // If no saved token/userId, attempt auto-authentication using credentials stored in .env.local / env
   if ((!token || !userId || !jellyfinUrl) && envUrl && envUser && envPass) {
     d.log('[System] File credentials (.env.local) found. Authenticating automatically...', 'system');
     try {
       const session = await authenticateUser(envUrl, envUser, envPass);
-      localStorage.setItem('jellyfin_url', envUrl);
-      localStorage.setItem('jellyfin_username', envUser);
-      localStorage.setItem('jellyfin_token', session.accessToken);
-      localStorage.setItem('jellyfin_userid', session.userId);
-      localStorage.setItem('jellyfin_last_userid', session.userId);
+      persistSession('jellyfin', envUrl, session);
+      localStorage.setItem(USERNAME_KEY, envUser);
       jellyfinUrl = envUrl;
       token = session.accessToken;
       userId = session.userId;
@@ -543,7 +570,7 @@ export async function checkCredentialsAndLoad() {
         let libs: JellyfinLibrary[];
         [libs] = await Promise.all([
           Promise.race([
-            fetchJellyfinLibrariesAndMovies(jellyfinUrl, activeToken!, activeUserId!, armStall, {
+            fetchLibrariesAndMovies(jellyfinUrl, activeToken!, activeUserId!, armStall, {
               excludeLibraryIds: excludedLibraryIds(),
             }),
             stallPromise

--- a/src/flat/flat-detail.ts
+++ b/src/flat/flat-detail.ts
@@ -1,4 +1,5 @@
-import { Movie, Episode, fetchSeriesEpisodes, fetchFirstEpisodeOfSeries } from '../jellyfin';
+import type { Movie, Episode } from '../media-types.ts';
+import { fetchSeriesEpisodes, fetchFirstEpisodeOfSeries } from '../media-backend.ts';
 import { launchGame } from '../romm';
 import { retailAudio } from '../audio';
 import { requestMovie, isDiscoveryRequested } from '../jellyseerr';

--- a/src/jellyfin.ts
+++ b/src/jellyfin.ts
@@ -4,172 +4,70 @@ import { invoke } from '@tauri-apps/api/core';
 // sibling specifier (same note as media-date-screen.ts).
 import { activeMediaCutoff, titleReleasedBy } from './media-release-date.ts';
 
-export interface Movie {
-  id: string;
-  title: string;
-  year: number;
-  duration: string;
-  rating: string;
-  overview: string;
-  director: string;
-  actors: string[]; // top-billed cast, at most 5 names
-  genres: string[];
-  localPath: string;
-  posterUrl?: string;
-  backdropUrl?: string;
-  dateCreated?: string;
-  isSeries?: boolean;
-  is4k?: boolean;
-  communityRating?: number; // 0-10 (e.g. 9.0 = 4.5 stars out of 5)
-  criticRating?: number;    // 0-100 Rotten Tomatoes score
-  libraryName?: string;
-  studios?: string[];
-  // Synthesized (see jellyseerr.ts) for a title that's been requested on
-  // Jellyseerr but hasn't finished downloading yet: it gets a display case
-  // with poster art on the New Releases wall but no rental backstock, and
-  // selecting it should show "Coming Soon" rather than allow playback.
-  comingSoon?: boolean;
-  // TMDB id (see jellyseerr.ts's fetchDiscoverMovies) -- required to call
-  // requestMovie() for a discovery title.
-  tmdbId?: number;
-  // Synthesized (see jellyseerr.ts's fetchDiscoverMovies) for a Jellyseerr
-  // trending/popular suggestion that is NOT in the Jellyfin library: it gets
-  // an empty display case shelved inline with the regular stock (REQUEST
-  // corner sticker, no rental backstock), and selecting it lets the user
-  // REQUEST it through Jellyseerr instead of play it.
-  discovery?: boolean;
-  // True when a `discovery` or `collectionGap` title has already been
-  // requested (through this app this session, or because Jellyseerr's own
-  // records say so -- see StoreScene's merge of comingSoon into
-  // discoveryMovies, and fetchCollectionGaps keeping requested gaps). These
-  // cases stamp the gold COMING SOON corner label instead of the blue
-  // REQUEST one; endcap candidates wear the green REQUESTED tag.
-  discoveryRequested?: boolean;
-  // T18: synthesized (see romm.ts's fetchGames) for a video-game title from a
-  // Romm server. It gets a display case (cover art) in the VIDEO GAMES section,
-  // is grouped under `platform` (e.g. "SNES"), and selecting it "rents" -> the
-  // Tauri build launches the configured emulator on `launchPath`; the browser
-  // build shows a "take it to the counter" toast.
-  game?: boolean;
-  platform?: string;
-  launchPath?: string;
-  // Flat scan art for the case's OTHER faces (back panel / spine / disc
-  // label), resolved by romm.ts's gameArtUrls(). Absent for a title whose
-  // library never scraped that media — the faces then keep their generated
-  // fallbacks. Typed loosely here so jellyfin.ts stays free of a romm.ts
-  // import (romm.ts already imports this module).
-  gameArt?: { back?: string; spine?: string; label?: string };
-  // Discs in this title's retail case (romm.ts discCountFrom: distinct
-  // "(Disc N)" tags across the rom + its siblings). Only set when >= 2 —
-  // it thickens a jewel-case platform's box to the multi-disc fat case.
-  discCount?: number;
-  // Audio/subtitle streams of the primary media source (already fetched with
-  // the catalog via Fields=MediaSources) — drives the in-app player's track
-  // picker. Absent for series containers, games, and discovery titles.
-  mediaStreams?: MediaStreamInfo[];
-  // Container + video/audio codecs of the primary media source (same
-  // MediaSources fetch as mediaStreams above) — lets launchVideoPlayback
-  // decide direct-play vs. HLS transcode BEFORE opening the player (see
-  // isDirectPlaySafe). Absent for series containers, games, and discovery
-  // titles; series episodes are probed on demand instead (see
-  // fetchItemPlaybackInfo) since the episode list never fetches MediaSources.
-  mediaPlaybackInfo?: MediaPlaybackInfo;
-  // Width/height ratio of the poster image, straight from Jellyfin's
-  // PrimaryImageAspectRatio field. Lets flat mode size a case to the art
-  // before the lazy poster loads (issue #108) instead of reflowing the row
-  // on every image load. Absent for games, discovery titles, and servers
-  // that haven't probed the image yet.
-  primaryImageAspectRatio?: number;
-  // Alternate quality versions of the same film. Built two ways: a Jellyfin
-  // item whose versions were merged server-side carries several MediaSources
-  // (one version each), and duplicate items of the same film (a 4K rip and a
-  // 1080p rip ingested separately) are collapsed to ONE shelf box by
-  // collapseDuplicateVersions(). Present ONLY when there are 2+ choices,
-  // ordered best-quality-first; pressing Play on such a title opens the
-  // version picker (main.ts) instead of streaming blind.
-  versions?: MovieVersion[];
-  // Name of the Jellyfin collection (BoxSet) this movie belongs to, e.g.
-  // "Harry Potter Collection". Jellyfin list queries don't carry membership on
-  // the item itself, so this is tagged in a separate pass after library sync
-  // (see applyCollectionMembership). Members of one collection file together
-  // on the shelf in premiere order (see shelfTitleCompare in store-layout).
-  collectionName?: string;
-  // ISO premiere date — breaks the chronological tie between same-collection
-  // titles released the same year (ProductionYear alone can't order them).
-  premiereDate?: string;
-  // Synthesized (see jellyseerr.ts's fetchCollectionGaps) for an entry of a
-  // collection the user PARTLY owns — you have 5 of the 8 Harry Potters, so
-  // the other 3 stand in their correct chronological shelf position wearing a
-  // corner sticker, with no rental backstock behind them. Selecting one
-  // requests it through Jellyseerr rather than playing it.
-  //
-  // Jellyfin can't source these on its own: its BoxSet is built from the files
-  // you have, so it has no idea the collection is incomplete. The full member
-  // list comes from TMDB via Jellyseerr, keyed on collectionTmdbId below.
-  collectionGap?: boolean;
-  // Per-user watch state off Jellyfin's UserData (the catalog queries hit the
-  // per-user /Users/{id}/Items endpoint, so this is THIS user's history).
-  // Watched titles are the anchors the staff-picks engine aggregates TMDB
-  // "people who liked this also liked" results over (see staff-picks.ts).
-  played?: boolean;
-  playCount?: number;
-  lastPlayedDate?: string; // ISO — orders anchors by recency
-  // Ticks into the item Jellyfin says THIS user left off at. The server only
-  // ever returns a non-zero PlaybackPositionTicks while the item is still
-  // inside its own resume window (fully watched or never started both come
-  // back unset) — so "present -> resume there" is the same rule every other
-  // Jellyfin client follows, with no separate "start over" affordance needed.
-  resumePositionTicks?: number;
-  // Exact runtime in ticks (Jellyfin's RunTimeTicks), alongside the rounded
-  // `duration` display string above. Lets a natural end-of-file be told apart
-  // from a user quit without a per-path duration probe (see playback-flow.ts).
-  runTimeTicks?: number;
-  // Set by the staff-picks engine on an OWNED title that the aggregated
-  // watch-history recommendations surfaced: its case wears the STAFF PICK
-  // sticker (video-case.ts) and it's eligible for the genre endcaps.
-  staffPick?: boolean;
-  // Top-billed cast as Jellyfin Person references (id + portrait URL), captured
-  // alongside `actors` (name-only) so wall décor (wall-decor.ts) can tally the
-  // library's most-featured actors and pull real portraits without a second
-  // round-trip. Same top-5 cap as `actors`; `imageUrl` is only set when the
-  // person has a PrimaryImageTag in Jellyfin (many crew/cast entries don't).
-  // Undefined on synthesized titles (discovery/collectionGap/game) and the
-  // synthetic demo/harness catalog, which has no Person image data at all.
-  castPeople?: { id: string; name: string; imageUrl?: string }[];
-}
+// The store's domain model lives in media-types.ts now that a second backend
+// (plex.ts) fills the same shapes -- see the note at the top of that file.
+// Re-exported here so the modules that import `Movie` and friends from
+// './jellyfin' keep compiling unchanged.
+import type {
+  Movie,
+  MediaStreamInfo,
+  MovieVersion,
+  MediaPlaybackInfo,
+  HlsStreamOptions,
+  Episode,
+  MediaLibrary,
+  JellyfinLibrary,
+  LibrarySummary,
+  PublicUser,
+  MediaSession,
+} from './media-types.ts';
+export type {
+  Movie,
+  MediaStreamInfo,
+  MovieVersion,
+  MediaPlaybackInfo,
+  HlsStreamOptions,
+  Episode,
+  MediaLibrary,
+  JellyfinLibrary,
+  LibrarySummary,
+  PublicUser,
+  MediaSession,
+};
 
-export interface MediaStreamInfo {
-  /** Jellyfin stream index — pass as AudioStreamIndex/SubtitleStreamIndex. */
-  index: number;
-  type: 'Audio' | 'Subtitle';
-  language?: string;
-  displayTitle?: string;
-  codec?: string;
-  isDefault?: boolean;
-  /** Audio channel count (2 = stereo, 6 = 5.1, 8 = 7.1) — used to print the
-   *  channel layout in the back-cover tech-specs table. Audio streams only. */
-  channels?: number;
-}
-
-/** One playable quality/edition of a film — see Movie.versions. */
-export interface MovieVersion {
-  /** Jellyfin item to stream (and report playback against). */
-  itemId: string;
-  /** Set when this version is one MediaSource of a server-side-merged item;
-   *  passed as MediaSourceId so Jellyfin streams THAT file, not the default. */
-  mediaSourceId?: string;
-  /** Picker row text, e.g. "4K · HDR · HEVC · 54 GB". */
-  label: string;
-  is4k: boolean;
-  /** Video frame size, for best-first ordering. */
-  width?: number;
-  height?: number;
-  /** File path of this version, for the external-player fallback. */
-  localPath?: string;
-  mediaStreams?: MediaStreamInfo[];
-  mediaPlaybackInfo?: MediaPlaybackInfo;
-}
-
+// Backend-neutral media logic (version collapsing, direct-play safety, the
+// collection side-tables, transcode ceilings) lives in media-shared.ts so
+// plex.ts can use the same rules without importing this module. Re-exported
+// for the callers that have always imported them from here.
+import {
+  pickSubtitleDelivery,
+  isTextSubtitleCodec,
+  type SubtitleDelivery,
+  formatBytes,
+  qualityTag,
+  collapseDuplicateVersions,
+  collectionArt,
+  collectionTmdbIds,
+  collectionSyncStats,
+  isHevcPassThroughEnabled,
+  isHevcMain10Supported,
+  isDirectPlaySafe,
+  DEFAULT_VIDEO_BITRATE,
+  COPY_VIDEO_BITRATE,
+} from './media-shared.ts';
+import { knownServerLibraries, rememberKnownLibraries, type MediaBackend } from './media-backend.ts';
+export { knownServerLibraries };
+export {
+  pickSubtitleDelivery,
+  isTextSubtitleCodec,
+  type SubtitleDelivery,
+  collapseDuplicateVersions,
+  collectionArt,
+  collectionTmdbIds,
+  collectionSyncStats,
+  isHevcPassThroughEnabled,
+  isDirectPlaySafe,
+};
 /** Audio + subtitle streams of one media source, for the player's track picker. */
 function extractStreamsFromSource(source: any): MediaStreamInfo[] | undefined {
   const raw = source?.MediaStreams;
@@ -191,23 +89,6 @@ function extractStreamsFromSource(source: any): MediaStreamInfo[] | undefined {
 /** Audio + subtitle streams of an item's first media source. */
 function extractMediaStreams(item: any): MediaStreamInfo[] | undefined {
   return extractStreamsFromSource(item.MediaSources?.[0]);
-}
-
-/** Container + video/audio codecs needed by isDirectPlaySafe. All strings are
- *  lower-cased so callers can compare against fixed allowlists. */
-export interface MediaPlaybackInfo {
-  container?: string;
-  videoCodec?: string;
-  audioCodecs: string[];
-  /** Video frame dimensions of the default source — feed the tech-specs
-   *  table's resolution + aspect-ratio derivation. */
-  width?: number;
-  height?: number;
-  /** Display aspect ratio string straight from Jellyfin (e.g. "16:9",
-   *  "2.40:1"), when the server reports one. */
-  aspectRatio?: string;
-  /** HDR class ("SDR", "HDR10", "DOVI", …) — lets the table flag HDR. */
-  videoRange?: string;
 }
 
 /** Container/codec info of one media source — see MediaPlaybackInfo. */
@@ -233,39 +114,6 @@ function extractPlaybackInfoFromSource(source: any): MediaPlaybackInfo | undefin
 /** Container/codec info of an item's first media source. */
 function extractPlaybackInfo(item: any): MediaPlaybackInfo | undefined {
   return extractPlaybackInfoFromSource(item.MediaSources?.[0]);
-}
-
-export interface Episode {
-  id: string;
-  seriesId: string;
-  seriesName: string;
-  seasonNumber: number;
-  episodeNumber: number;
-  name: string;
-  overview: string;
-  path: string;
-  runTimeTicks?: number;
-  /** This user's UserData.PlaybackPositionTicks — see Movie.resumePositionTicks
-   *  for the same "present -> resume there" rule. */
-  resumePositionTicks?: number;
-  thumbUrl?: string;
-  seasonId?: string;
-  /** Primary (poster, 2:3) image of the Season item this episode belongs to. */
-  seasonPrimaryUrl?: string;
-}
-
-export interface JellyfinLibrary {
-  id: string;
-  name: string;
-  movies: Movie[];
-  genres: string[];
-  /**
-   * Synthesized by games-only.ts: this "library" is one Romm platform, not a
-   * Jellyfin one. Its titles carry no wall categories, so the shelf
-   * planner keeps it un-sectioned and every signboard reads the platform name
-   * (see StorePlan.buildLibraryLayouts).
-   */
-  games?: boolean;
 }
 
 /**
@@ -397,13 +245,6 @@ export async function authenticateUser(
   }
 }
 
-export interface PublicUser {
-  id: string;
-  name: string;
-  hasPassword: boolean;
-  primaryImageTag?: string;
-}
-
 /**
  * Hits Jellyfin's public user list (`/Users/Public`), the same endpoint
  * Jellyfin's own "select user" screen uses -- no auth required. Some
@@ -468,24 +309,6 @@ function checkIs4k(item: any): boolean {
 // ─── Quality versions (4K / 1080p) ───────────────────────────────────────────
 
 /** Human file size for version labels ("54.4 GB"). */
-function formatBytes(bytes: number): string {
-  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
-  if (bytes >= 1024 ** 2) return `${Math.round(bytes / 1024 ** 2)} MB`;
-  return `${Math.round(bytes / 1024)} KB`;
-}
-
-/** Resolution bucket name — width AND height checked so scope (1920x800) and
- *  4:3 (1440x1080) content both land in the right bucket. */
-function qualityTag(width?: number, height?: number): string | undefined {
-  const w = width ?? 0;
-  const h = height ?? 0;
-  if (w >= 3200 || h >= 2000) return "4K";
-  if (w >= 1800 || h >= 1030) return "1080p";
-  if (w >= 1150 || h >= 690) return "720p";
-  if (w > 0 || h > 0) return "SD";
-  return undefined;
-}
-
 /** One MovieVersion per MediaSource of a catalog item (best-first sorting and
  *  the 2+-only pruning happen later, in finalizeVersions). Exported for unit
  *  tests only. */
@@ -527,87 +350,6 @@ export function buildItemVersions(item: any): MovieVersion[] {
       mediaPlaybackInfo: extractPlaybackInfoFromSource(source),
     };
   });
-}
-
-// Trailing resolution/format markers stripped when matching duplicate items of
-// the same film ("Heat (4K)" and "Heat" are one movie). Only quality markers —
-// cut markers (Extended, Director's Cut) are left alone: those are genuinely
-// different films content-wise and keep their own shelf box.
-const RES_MARKER_RE =
-  /[\s\-–·]*[[({]?\s*\b(4k|uhd|2160p|1440p|1080[pi]|720p|480p|576p|hdr10\+?|hdr|dolby\s*vision|dv|remux|blu-?ray|web-?(dl|rip)|x26[45]|h\.?26[45]|hevc|av1)\b\s*[\])}]?\s*$/i;
-
-function versionGroupKey(m: Movie): string {
-  let t = m.title.toLowerCase().trim();
-  for (;;) {
-    const stripped = t.replace(RES_MARKER_RE, "").trim();
-    if (stripped === t || stripped.length === 0) break;
-    t = stripped;
-  }
-  return `${t}|${m.year}`;
-}
-
-/** Best-first version order: bigger frame wins; 16:9-normalized so a width-only
- *  entry still ranks against a height-only one. */
-function versionRank(v: MovieVersion): number {
-  return Math.max(v.width ?? 0, ((v.height ?? 0) * 16) / 9, v.is4k ? 3840 : 0);
-}
-
-/** Sort/dedupe a movie's accumulated versions; below 2 real choices the array
- *  is dropped entirely so single-file movies stay exactly as before. */
-function finalizeVersions(m: Movie): void {
-  if (!m.versions || m.versions.length < 2) {
-    m.versions = undefined;
-    return;
-  }
-  const seen = new Set<string>();
-  const versions = m.versions.filter((v) => {
-    const key = `${v.itemId}|${v.mediaSourceId ?? ""}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
-  if (versions.length < 2) {
-    m.versions = undefined;
-    return;
-  }
-  versions.sort((a, b) => versionRank(b) - versionRank(a));
-  m.versions = versions;
-  // The single remaining box advertises the best available quality.
-  if (versions.some((v) => v.is4k)) m.is4k = true;
-}
-
-/**
- * Collapse duplicate entries of the same film (same normalized title + year)
- * into ONE shelf box carrying every quality as a Movie.version — the fix for
- * a 4K and a 1080p rip of one movie standing side by side on the shelf. The
- * first-seen entry keeps the shelf spot and its metadata/poster; extra
- * entries contribute their versions and disappear from the catalog. Series,
- * games, and synthesized (discovery/coming-soon) entries never collapse.
- * Exported for unit tests only.
- */
-export function collapseDuplicateVersions(movies: Movie[], context: string): Movie[] {
-  const byKey = new Map<string, Movie>();
-  const out: Movie[] = [];
-  let collapsed = 0;
-  for (const m of movies) {
-    if (m.isSeries || m.game || m.discovery || m.comingSoon || m.collectionGap) {
-      out.push(m);
-      continue;
-    }
-    const prior = byKey.get(versionGroupKey(m));
-    if (!prior) {
-      byKey.set(versionGroupKey(m), m);
-      out.push(m);
-      continue;
-    }
-    prior.versions = [...(prior.versions ?? []), ...(m.versions ?? [])];
-    collapsed++;
-  }
-  for (const m of out) finalizeVersions(m);
-  if (collapsed > 0) {
-    console.info(`[Jellyfin] ${context}: collapsed ${collapsed} duplicate quality version(s) into their main title.`);
-  }
-  return out;
 }
 
 // Item types ingested as shelf titles. "Video" covers Jellyfin's
@@ -787,33 +529,6 @@ export async function fetchMediaCatalog(
  * membership in list queries, so each BoxSet's children are walked once here.
  * A movie in several collections keeps the first one seen — one shelf spot.
  */
-/**
- * Artwork for the collections that survived the version-pair filter, keyed by
- * collection name (the same key `Movie.collectionName` carries). Populated by
- * fetchCollectionMembership; read by the four-sided collection displays to
- * build their signage. Empty when running against the synthetic harness
- * library, in which case the signs fall back to a member title's backdrop.
- */
-export const collectionArt = new Map<string, { posterUrl?: string; backdropUrl?: string }>();
-
-/**
- * Collection name -> TMDB *collection* id, harvested from each BoxSet's
- * ProviderIds during the same membership sync. This is the only bridge from a
- * Jellyfin BoxSet (which knows only what's on disk) to the collection's full
- * member list, so it's what lets fetchCollectionGaps work out which entries
- * are missing. Empty for BoxSets the user assembled by hand (no TmdbCollection
- * id) and in the synthetic harness library — those collections simply show no
- * gaps.
- */
-export const collectionTmdbIds = new Map<string, number>();
-
-/**
- * Counts from the last membership sync, for the boot console's collection-gap
- * status line. jellyfin.ts can't call main.ts's logToConsole (circular), so it
- * records what it saw and main.ts does the talking.
- */
-export const collectionSyncStats = { boxSets: 0, scraped: 0, rejectedVersionPairs: 0 };
-
 async function fetchCollectionMembership(
   url: string,
   token: string,
@@ -995,42 +710,6 @@ async function fetchVideoViews(url: string, token: string, userId: string): Prom
     );
     return keep;
   });
-}
-
-export interface LibrarySummary {
-  id: string;
-  name: string;
-}
-
-const KNOWN_LIBS_KEY = 'bb_known_libraries';
-
-/**
- * Remember the server's FULL video-library list (id + name) whenever a fetch
- * sees it — the fetchers above/below are the only places that ever see the
- * complete list, exclusions and all. localStorage-persisted so the Store
- * Libraries settings page can offer EXCLUDED libraries for re-enabling on
- * every later boot (#41): an excluded library is absent from the synced
- * catalog by design, so the catalog alone can never list it again.
- */
-function rememberKnownLibraries(libs: ReadonlyArray<LibrarySummary>): void {
-  if (typeof localStorage === 'undefined') return;
-  try {
-    localStorage.setItem(KNOWN_LIBS_KEY, JSON.stringify(libs.map((l) => ({ id: l.id, name: l.name }))));
-  } catch { /* quota — the drawer just misses excluded rows until next boot */ }
-}
-
-/** The last-remembered full server library list ([] before any real fetch). */
-export function knownServerLibraries(): LibrarySummary[] {
-  if (typeof localStorage === 'undefined') return [];
-  try {
-    const raw = localStorage.getItem(KNOWN_LIBS_KEY);
-    const parsed = raw ? JSON.parse(raw) : [];
-    return Array.isArray(parsed)
-      ? parsed.filter((l) => l && typeof l.id === 'string' && typeof l.name === 'string')
-      : [];
-  } catch {
-    return [];
-  }
 }
 
 /**
@@ -1420,61 +1099,6 @@ export async function stopActiveEncoding(playSessionId: string, log?: (msg: stri
   }
 }
 
-// ─── Direct-play safety ───────────────────────────────────────────────────────
-
-/** MediaSource.isTypeSupported, guarded for non-browser contexts. */
-function mseSupports(mime: string): boolean {
-  try {
-    return typeof MediaSource !== 'undefined' && MediaSource.isTypeSupported(mime);
-  } catch {
-    return false;
-  }
-}
-
-// Whether this webview's MSE can decode HEVC, probed once at module load.
-// hvc1.1.6.* = Main (8-bit), hvc1.2.4.* = Main 10 — movie remuxes (and anime
-// especially) are typically 10-bit. When the webview can decode HEVC, HLS
-// requests list it as an allowed codec so Jellyfin STREAM-COPIES the video
-// instead of re-encoding it to H.264 — a cheap remux (audio-only transcode)
-// instead of a full ffmpeg video transcode.
-const HEVC_MAIN_SUPPORTED = mseSupports('video/mp4; codecs="hvc1.1.6.L153.B0"');
-const HEVC_MAIN10_SUPPORTED = mseSupports('video/mp4; codecs="hvc1.2.4.L153.B0"');
-
-const DIRECT_PLAY_SAFE_CONTAINERS = new Set(['mp4', 'm4v', 'mov', 'webm']);
-const DIRECT_PLAY_SAFE_VIDEO_CODECS = new Set(['h264', 'vp8', 'vp9', 'av1']);
-// HEVC direct play only when Main 10 decodes too: MediaPlaybackInfo doesn't
-// carry bit depth, so we can't tell an 8-bit file from a 10-bit one here.
-if (HEVC_MAIN10_SUPPORTED) {
-  DIRECT_PLAY_SAFE_VIDEO_CODECS.add('hevc');
-  DIRECT_PLAY_SAFE_VIDEO_CODECS.add('h265');
-}
-const DIRECT_PLAY_SAFE_AUDIO_CODECS = new Set(['aac', 'mp3', 'opus', 'vorbis', 'flac']);
-
-/** Whether HLS requests allow HEVC stream copy (webview MSE decodes HEVC). */
-export function isHevcPassThroughEnabled(): boolean {
-  return HEVC_MAIN_SUPPORTED;
-}
-
-/**
- * True only when the item's container, video codec, and every audio codec are
- * all in WebKitGTK's known-safe allowlist — i.e. safe to try the raw
- * `stream?static=true` URL. WebKitGTK silently DROPS audio tracks whose codec
- * isn't in its allowlist (AC3/EAC3/DTS are typical movie-rip audio) regardless
- * of installed GStreamer decoders, with no error firing to trigger the normal
- * direct→HLS fallback — so anything missing or unrecognized must default to
- * NOT safe rather than risk silent audio. MKV is deliberately excluded even
- * when its codecs are otherwise fine: WebKit's range-seeking on Matroska is
- * what makes scrubbing take ages; HLS transcode seeks in ~2s by comparison.
- */
-export function isDirectPlaySafe(info: MediaPlaybackInfo | undefined | null): boolean {
-  if (!info) return false;
-  const { container, videoCodec, audioCodecs } = info;
-  if (!container || !DIRECT_PLAY_SAFE_CONTAINERS.has(container)) return false;
-  if (!videoCodec || !DIRECT_PLAY_SAFE_VIDEO_CODECS.has(videoCodec)) return false;
-  if (!audioCodecs || audioCodecs.length === 0) return false;
-  return audioCodecs.every((c) => DIRECT_PLAY_SAFE_AUDIO_CODECS.has(c));
-}
-
 /**
  * On-demand MediaSources probe for an item whose playback info isn't already
  * held in memory. TV episodes are the case in practice: fetchSeriesEpisodes /
@@ -1521,57 +1145,6 @@ export function buildStaticStreamUrl(jellyfinUrl: string, token: string, itemId:
 }
 
 /**
- * Subtitle codecs that are TEXT, and can therefore be fetched as a WebVTT
- * sidecar and rendered by the browser over the video. Everything else — PGS,
- * DVD, DVB, XSUB — is a bitmap the browser cannot draw, so it still has to be
- * burned into the picture server-side (see pickSubtitleDelivery).
- *
- * Jellyfin reports the ffmpeg codec name, which is why both spellings of the
- * common ones are here (`subrip`/`srt`, `ssa`/`ass`); `mov_text` is the MP4
- * flavour and `webvtt`/`vtt` are already what we're asking for.
- */
-const TEXT_SUBTITLE_CODECS = new Set([
-  'subrip', 'srt', 'ass', 'ssa', 'mov_text', 'webvtt', 'vtt', 'text', 'subviewer', 'microdvd',
-]);
-
-/** Is this subtitle stream text (client-renderable) rather than a bitmap? */
-export function isTextSubtitleCodec(codec: string | undefined): boolean {
-  return !!codec && TEXT_SUBTITLE_CODECS.has(codec.toLowerCase());
-}
-
-/**
- * How a chosen subtitle track should be delivered.
- *
- * This is the whole point of the client-side subtitle work: asking the server
- * to burn subtitles in (`SubtitleMethod=Encode`) forces a full video re-encode,
- * so on the browser/Remote Play path merely defaulting captions ON turned every
- * direct-playable file into a transcode. A text track costs the server nothing
- * — it's a sidecar fetch — and switching or disabling it needs no new stream
- * at all. Bitmap subtitles have no client renderer, so they keep the old path
- * and pay the old price.
- */
-export type SubtitleDelivery =
-  | { kind: 'none' }
-  | { kind: 'text'; streamIndex: number }
-  | { kind: 'burn-in'; streamIndex: number };
-
-export function pickSubtitleDelivery(
-  streams: MediaStreamInfo[] | undefined,
-  streamIndex: number | undefined,
-): SubtitleDelivery {
-  if (streamIndex === undefined) return { kind: 'none' };
-  const stream = streams?.find((s) => s.type === 'Subtitle' && s.index === streamIndex);
-  // Unknown stream, or a server that didn't report a codec: assume text and
-  // try the cheap path. The two failure modes are not symmetric — a sidecar
-  // that 404s costs one failed request and leaves the film playing, while a
-  // needless burn-in costs a re-encode of the entire runtime.
-  if (!stream || stream.codec === undefined) return { kind: 'text', streamIndex };
-  return isTextSubtitleCodec(stream.codec)
-    ? { kind: 'text', streamIndex }
-    : { kind: 'burn-in', streamIndex };
-}
-
-/**
  * WebVTT sidecar for one subtitle stream, for a <track> on the <video>.
  * Jellyfin converts SRT/ASS/SSA to VTT on the fly here — styling and
  * positioning are flattened, which is the trade for not re-encoding the film.
@@ -1589,30 +1162,6 @@ export function buildSubtitleTrackUrl(
        + `?api_key=${encodeURIComponent(token)}`;
 }
 
-/** Track/quality overrides for buildHlsStreamUrl (the player's track picker). */
-export interface HlsStreamOptions {
-  /** Jellyfin MediaStream index of the audio track to transcode. */
-  audioStreamIndex?: number;
-  /** Jellyfin MediaStream index of the subtitle track to BURN IN (SubtitleMethod=Encode). */
-  subtitleStreamIndex?: number;
-  /** Video bitrate ceiling in bits/s (default 8 Mbps). */
-  maxBitrate?: number;
-  /** Optional resolution ceiling to pair with a lower bitrate. */
-  maxWidth?: number;
-  /** Absolute item position (ticks) to start the transcode at, so a seek
-   *  lands on an already-offset stream instead of encoding from 0:00 and
-   *  jumping client-side (which is what makes seeking a transcode slow). */
-  startPositionTicks?: number;
-  /** Lower-cased source video codec (MediaPlaybackInfo.videoCodec). HEVC
-   *  pass-through + fMP4 segments are only requested when the source is
-   *  actually HEVC — everything else stays on the battle-tested TS path. */
-  sourceVideoCodec?: string;
-  /** Specific MediaSource of a merged multi-version item to stream
-   *  (MovieVersion.mediaSourceId). Defaults to the item id, i.e. the
-   *  item's default source. */
-  mediaSourceId?: string;
-}
-
 // PlaySessionId baked into the most recently built HLS URL. Exposed via
 // getLastHlsPlaySessionId() so a caller that only has the URL (the player's
 // buildStream callback returns a plain string) can still learn which session
@@ -1622,39 +1171,6 @@ let lastHlsPlaySessionId: string | undefined;
 export function getLastHlsPlaySessionId(): string | undefined {
   return lastHlsPlaySessionId;
 }
-
-// Default video bitrate ceiling (bits/s) for the "Auto" HLS stream. This is
-// NOT a bandwidth limit (the server is on the LAN) — it's a MEMORY limit for
-// the client's MSE SourceBuffer. hls.js buffers ~60-80s ahead regardless of
-// its maxBufferLength/maxBufferSize knobs (verified — it ignores them on a
-// fast VOD source), and the Chromium/Brave webview caps a single video
-// SourceBuffer at ~250 MB. A 38.5 Mbps Blu-ray remux stream-copied verbatim
-// therefore overflows that cap ~35-40s in: hls.js flush-evicts the buffer,
-// punches a hole right in front of the playhead, and playback FREEZES (the
-// "freezes at ~39s" bug, reproduced in Brave). Capping at 20 Mbps keeps
-// ~80s of buffer near ~200 MB, which Brave evicts cleanly with zero stalls
-// (measured). Jellyfin stream-copies sources already under this ceiling and
-// re-encodes heavier remuxes down to it (cheap on the box's QSV/VAAPI); it
-// clamps the encode target to the source bitrate, so this never inflates
-// output. 1080p H.264 at 20 Mbps is visually near-transparent.
-const DEFAULT_VIDEO_BITRATE = 20_000_000;
-
-// Ceiling sent when the source video is being STREAM-COPIED (hevcCopy below).
-// Jellyfin only copies when source bitrate <= requested bitrate, so the 20 Mbps
-// re-encode ceiling above silently forced every 4K remux (94 Mbps for a typical
-// Movies4k title) into a full h264_qsv re-encode — which also drags in a 1440p
-// downscale AND, because Jellyfin's HDR tonemapping doesn't engage on this
-// box's VAAPI-decode pipeline, a `setparams=...bt709` relabel that ships PQ /
-// BT.2020 pixels tagged as Rec.709. That mislabel is what makes 4K HDR titles
-// look washed out. Copying sidesteps all three: the bitstream is untouched, so
-// resolution and HDR10 metadata arrive exactly as mastered.
-//
-// The copy path's real constraint is MEMORY, not bandwidth (LAN server): see
-// HLS_COPY_BUFFER in video-player.ts, which shrinks hls.js's buffer so a
-// 94 Mbps stream stays under Brave's ~250 MB SourceBuffer cap. Keep the two in
-// sync — raising this without shrinking that reintroduces the freeze-at-~39s
-// eviction bug.
-const COPY_VIDEO_BITRATE = 200_000_000;
 
 /**
  * HLS master playlist that asks Jellyfin to transcode (when needed) to
@@ -1675,7 +1191,7 @@ export function buildHlsStreamUrl(jellyfinUrl: string, token: string, itemId: st
   // StartTimeTicks and 500s (see the loader workaround in video-player.ts),
   // so its blast radius is kept to the files that need it.
   const hevcCopy =
-    HEVC_MAIN_SUPPORTED &&
+    isHevcPassThroughEnabled() &&
     (opts?.sourceVideoCodec === "hevc" || opts?.sourceVideoCodec === "h265");
   const segmentContainer = hevcCopy ? "mp4" : "ts";
   const params = new URLSearchParams({
@@ -1700,7 +1216,7 @@ export function buildHlsStreamUrl(jellyfinUrl: string, token: string, itemId: st
   });
   // 10-bit HEVC can't be copied to a webview that only decodes Main — force
   // those back to the h264 transcode rather than hand MSE undecodable video.
-  if (hevcCopy && !HEVC_MAIN10_SUPPORTED) params.set("MaxVideoBitDepth", "8");
+  if (hevcCopy && !isHevcMain10Supported()) params.set("MaxVideoBitDepth", "8");
   if (opts?.maxWidth) params.set("MaxWidth", String(opts.maxWidth));
   if (opts?.startPositionTicks) params.set("StartTimeTicks", String(opts.startPositionTicks));
   if (opts?.audioStreamIndex !== undefined) params.set("AudioStreamIndex", String(opts.audioStreamIndex));
@@ -1730,3 +1246,61 @@ export function isStreamCopyUrl(src: string): boolean {
   }
 }
 
+
+// ─── Backend registration ─────────────────────────────────────────────────────
+
+/**
+ * The Jellyfin implementation of MediaBackend. Everything above is the
+ * implementation; this object is only the wiring, so the free functions stay
+ * directly callable (and unit-testable) exactly as they were.
+ */
+export const jellyfinBackend: MediaBackend = {
+  kind: 'jellyfin',
+  label: 'Jellyfin',
+
+  normalizeUrl,
+  async identify(rawUrl: string): Promise<boolean> {
+    // /System/Info/Public is Jellyfin's unauthenticated "who am I" endpoint.
+    // Emby answers it too and reports its own ProductName; the store has never
+    // been tested against Emby, so only a self-declared Jellyfin counts here
+    // rather than quietly treating one server as the other.
+    try {
+      const url = normalizeUrl(rawUrl);
+      const body = await jellyfinRequest('GET', `${url}/System/Info/Public`);
+      const info = JSON.parse(body);
+      return /jellyfin/i.test(String(info?.ProductName ?? ''));
+    } catch {
+      return false;
+    }
+  },
+
+  validateToken,
+  authenticateUser,
+  fetchPublicUsers: (url: string) => fetchPublicUsers(url),
+  buildUserAvatarUrl: (url: string, user: PublicUser) =>
+    buildUserAvatarUrl(url, user.id, user.primaryImageTag),
+  // Jellyfin has no card-to-session switch: picking a card just pre-fills the
+  // name on the same AuthenticateByName call the manual form makes.
+  signInAsPublicUser: (url: string, user: PublicUser, secret?: string) =>
+    authenticateUser(url, user.name, secret),
+
+  fetchLibraryList,
+  fetchLibrariesAndMovies: fetchJellyfinLibrariesAndMovies,
+
+  fetchSeriesEpisodes,
+  fetchFirstEpisodeOfSeries,
+
+  subtitleDelivery: pickSubtitleDelivery,
+  buildSubtitleTrackUrl,
+
+  fetchItemPlaybackInfo,
+  buildStaticStreamUrl,
+  buildHlsStreamUrl,
+  lastHlsPlaySessionId: getLastHlsPlaySessionId,
+  stopActiveEncoding,
+  isStreamCopyUrl,
+
+  reportPlaybackStart,
+  reportPlaybackProgress,
+  reportPlaybackStopped,
+};

--- a/src/library-settings.ts
+++ b/src/library-settings.ts
@@ -25,8 +25,8 @@
 // main.ts never registers anything. Keys are stable per library id, so a
 // choice survives re-syncs and member switches.
 import { registerSetting } from './settings';
-import { knownServerLibraries } from './jellyfin';
-import type { LibrarySummary } from './jellyfin';
+import { knownServerLibraries } from './media-backend.ts';
+import type { LibrarySummary } from './media-types.ts';
 
 export const CARRY_LIB_PREFIX = 'bb_carrylib_';
 export const TV_LIB_PREFIX = 'bb_tvlib_';

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,11 @@ import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { measureDisplayHz } from './display-hz';
 import { installDebugLog, debugLogPath } from './debug-log';
+// Side-effect import: registers the Jellyfin and Plex backends before anything
+// resolves activeBackend(). It sits above the media-layer imports below
+// because module evaluation follows import order — moving it down would let a
+// facade call run against an empty registry.
+import './media-backends.ts';
 
 // Before anything else that might fail: a packaged build has no devtools and
 // no stdout, so without this every console line is written to nowhere.
@@ -17,26 +22,30 @@ function closeApp() { isTauri ? getCurrentWindow().close() : window.close(); }
 import {
   authenticateUser,
   validateToken,
-  Movie,
-  JellyfinLibrary,
   fetchFirstEpisodeOfSeries,
   fetchSeriesEpisodes,
   reportPlaybackStart,
   reportPlaybackStopped,
   reportPlaybackProgress,
   buildHlsStreamUrl,
-  isHevcPassThroughEnabled,
   buildStaticStreamUrl,
   buildSubtitleTrackUrl,
   pickSubtitleDelivery,
-  isDirectPlaySafe,
   fetchItemPlaybackInfo,
+} from './media-backend.ts';
+import {
+  isHevcPassThroughEnabled,
+  isDirectPlaySafe,
+  collectionTmdbIds,
+  collectionSyncStats,
+} from './media-shared.ts';
+import type {
+  Movie,
+  JellyfinLibrary,
   MediaPlaybackInfo,
   MovieVersion,
   Episode,
-  collectionTmdbIds,
-  collectionSyncStats
-} from './jellyfin';
+} from './media-types.ts';
 import {
   fetchComingSoonMovies,
   fetchDiscoverMovies,
@@ -3193,7 +3202,7 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
   // the picture, because there is no client renderer for them.
   const subtitleDelivery = pickSubtitleDelivery(streams, initialSubtitleIndex);
   const subtitleTrackUrl = subtitleDelivery.kind === 'text'
-    ? buildSubtitleTrackUrl(jellyfinUrl, token, playbackId, subtitleDelivery.streamIndex, mediaSourceId)
+    ? (buildSubtitleTrackUrl(jellyfinUrl, token, playbackId, subtitleDelivery.streamIndex, mediaSourceId) ?? undefined)
     : undefined;
   const burnInSubtitleIndex = subtitleDelivery.kind === 'burn-in' ? subtitleDelivery.streamIndex : undefined;
 

--- a/src/media-backend.ts
+++ b/src/media-backend.ts
@@ -1,0 +1,538 @@
+// THE MEDIA LAYER'S SEAM (issue #32). Everything the store needs from a media
+// server, expressed once, so Jellyfin and Plex are two implementations of one
+// contract rather than two code paths threaded through the app.
+//
+// Shape of the split:
+//   media-types.ts   the domain model (Movie, Episode, ...) — no server in it
+//   media-shared.ts  logic that belongs to the store or the webview, not the
+//                    server (version collapse, direct-play safety, ceilings)
+//   media-backend.ts THIS FILE — the contract, the active-backend registry,
+//                    and a facade whose functions carry the same names and
+//                    signatures the app has always called
+//   jellyfin.ts      backend #1
+//   plex.ts          backend #2
+//
+// Callers keep calling free functions (`fetchSeriesEpisodes(url, token, ...)`)
+// and the facade at the bottom routes each one to whichever backend the store
+// is currently pointed at. That is deliberate: it kept the migration to ~8
+// touched files instead of ~60, and it means a call site never has to know
+// which server it is talking to.
+//
+// Note the (url, token, userId) arguments threaded through nearly every
+// method. They are NOT redundant with the stored session: playback code paths
+// legitimately hold a url/token pair for a title while the store is being
+// re-pointed elsewhere, and the boot flow authenticates against an address
+// that isn't persisted yet. The backend is stateless about credentials on
+// purpose; only `activeBackendKind()` is remembered.
+import type {
+  Episode,
+  HlsStreamOptions,
+  MediaStreamInfo,
+  LibrarySummary,
+  MediaLibrary,
+  MediaPlaybackInfo,
+  MediaSession,
+  PublicUser,
+} from './media-types.ts';
+
+import type { SubtitleDelivery } from './media-shared.ts';
+
+export type MediaServerKind = 'jellyfin' | 'plex';
+
+/** Minimal handle on a playable episode — see fetchFirstEpisodeOfSeries. */
+export interface EpisodeRef {
+  id: string;
+  path: string;
+}
+
+/** A sign-in-by-code flow (Plex's plex.tv/link). See MediaBackend.beginLink. */
+export interface LinkFlow {
+  /** Short code the user types on the verification page — goes on the CRT. */
+  code: string;
+  /** Human-readable page the code is entered at, e.g. "plex.tv/link". */
+  verificationUrl: string;
+  /** Epoch ms after which `code` stops working and a new flow is needed. */
+  expiresAt: number;
+  /**
+   * Polls until the user approves the code. Resolves with the session, or null
+   * if the code expired or `cancel()` was called first. Never rejects on a
+   * transient network blip — a linking HTPC that loses the LAN for a moment
+   * should keep waiting, not drop the user back to a form.
+   */
+  wait(): Promise<MediaSession | null>;
+  /** Abandon the flow (user backed out of the screen). */
+  cancel(): void;
+}
+
+export interface CatalogSyncOptions {
+  /**
+   * Library ids this store does NOT carry (#41): their item sync is skipped
+   * entirely, not fetched-and-hidden. Sourced from the Store Libraries
+   * toggles (Settings → Connection / the setup terminal's checkbox rows).
+   */
+  excludeLibraryIds?: ReadonlySet<string>;
+}
+
+export interface MediaBackend {
+  readonly kind: MediaServerKind;
+  /** Server name as the user knows it, for UI copy: "Jellyfin" / "Plex". */
+  readonly label: string;
+
+  // ─── Address + identity ────────────────────────────────────────────────────
+
+  normalizeUrl(url: string): string;
+  /**
+   * Unauthenticated "is a server of MY kind here?" probe, used by the setup
+   * terminal to work out what the user just typed the address of instead of
+   * making them pick from a menu first. Resolves false (never throws) when the
+   * address answers as something else or doesn't answer at all.
+   */
+  identify(url: string): Promise<boolean>;
+
+  // ─── Sign-in ───────────────────────────────────────────────────────────────
+
+  /**
+   * Liveness/auth check for a stored token. Resolves true on a clean success;
+   * resolves false ONLY when the server definitively rejected the token
+   * (HTTP 401/403). Anything else — network blip, timeout, 5xx — throws, so
+   * callers can tell "token is stale" apart from "server unreachable" and
+   * never tear down a session over a transient failure (issue #125).
+   */
+  validateToken(url: string, token: string): Promise<boolean>;
+  /** Classic name+password sign-in. */
+  authenticateUser(url: string, username: string, password?: string): Promise<MediaSession>;
+  /**
+   * Users to fan out as membership cards. `token` is optional because Jellyfin
+   * serves its list unauthenticated (/Users/Public) while Plex's Home users
+   * come from the account — pass whatever session token is already in hand.
+   * Callers must treat a throw or an empty array as "fall back to signing in
+   * by name": plenty of servers legitimately have no list to give.
+   */
+  fetchPublicUsers(url: string, token?: string): Promise<PublicUser[]>;
+  /** Avatar for a listed user, or null when they have none set. */
+  buildUserAvatarUrl(url: string, user: PublicUser): string | null;
+  /**
+   * Complete a card sign-in for a user the list already named. `secret` is the
+   * user's password (Jellyfin) or Home PIN (Plex); omit for unprotected users.
+   * `token` is the session token the list was fetched with, which Plex needs
+   * to perform the switch and Jellyfin ignores.
+   */
+  signInAsPublicUser(
+    url: string,
+    user: PublicUser,
+    secret?: string,
+    token?: string
+  ): Promise<MediaSession>;
+  /**
+   * Begin a sign-in-by-code flow, on backends that have one. Undefined on
+   * backends that don't (Jellyfin) — callers must feature-detect and fall back
+   * to authenticateUser.
+   */
+  beginLink?(url: string): Promise<LinkFlow>;
+  /**
+   * Adopt a token the user pasted in by hand, resolving whatever identity the
+   * server attaches to it. The escape hatch for when the link flow can't run
+   * (no route to plex.tv, headless setup, a scripted deploy).
+   */
+  adoptToken?(url: string, token: string): Promise<MediaSession>;
+
+  // ─── Catalog ───────────────────────────────────────────────────────────────
+
+  /**
+   * Names-only library listing for the first-run setup terminal (#41): no item
+   * sync, so the checkbox screen can appear the moment a member signs in — the
+   * expensive per-library item fetch then runs only for the libraries the
+   * store actually carries.
+   */
+  fetchLibraryList(url: string, token: string, userId: string): Promise<LibrarySummary[]>;
+  /**
+   * Full catalog sync. `onProgress` is called at each milestone and callers
+   * use it as a LIVENESS signal: a big library legitimately takes minutes, so
+   * a caller must be able to tell "still working" from "server is gone"
+   * without a wall-clock deadline that a large enough catalog can never beat.
+   */
+  fetchLibrariesAndMovies(
+    url: string,
+    token: string,
+    userId: string,
+    onProgress?: (stage: string) => void,
+    opts?: CatalogSyncOptions
+  ): Promise<MediaLibrary[]>;
+
+  // ─── Series ────────────────────────────────────────────────────────────────
+
+  fetchSeriesEpisodes(url: string, token: string, userId: string, seriesId: string): Promise<Episode[]>;
+  /**
+   * Just enough of the earliest episode to start playing a series the user
+   * picked off the shelf without opening the episode list. Deliberately NOT a
+   * full Episode: callers only ever need the id to stream and the path for the
+   * external-player fallback, and resolving the rest would cost a second
+   * round-trip on a hot path.
+   */
+  fetchFirstEpisodeOfSeries(
+    url: string,
+    token: string,
+    userId: string,
+    seriesId: string
+  ): Promise<EpisodeRef | null>;
+
+  // ─── Playback ──────────────────────────────────────────────────────────────
+
+  /**
+   * On-demand probe for an item whose playback info isn't already in memory.
+   * TV episodes are the case in practice: the episode fetchers never request
+   * media sources (a series can have hundreds of episodes, and the picker
+   * never needs codec info), so launchVideoPlayback calls this for the one
+   * episode it's about to play. Returns undefined on any failure —
+   * isDirectPlaySafe treats that as not-safe, defaulting to HLS.
+   */
+  fetchItemPlaybackInfo(
+    url: string,
+    token: string,
+    userId: string,
+    itemId: string
+  ): Promise<MediaPlaybackInfo | undefined>;
+  /**
+   * How a chosen subtitle track should be delivered. Backend-aware because the
+   * cheap road isn't universally available: Jellyfin converts a text track to
+   * a WebVTT sidecar on demand, so only bitmap subtitles need burning in;
+   * plex.ts has no verified sidecar endpoint yet and so burns every track in,
+   * which is what it did before this interface existed.
+   */
+  subtitleDelivery(streams: MediaStreamInfo[] | undefined, streamIndex: number | undefined): SubtitleDelivery;
+  /**
+   * WebVTT sidecar URL for a text subtitle track, or null on a backend that
+   * can't serve one — callers must treat null as "burn it in instead".
+   */
+  buildSubtitleTrackUrl(
+    url: string,
+    token: string,
+    itemId: string,
+    streamIndex: number,
+    mediaSourceId?: string
+  ): string | null;
+  /** Direct stream of the original file — only safe per isDirectPlaySafe. */
+  buildStaticStreamUrl(url: string, token: string, itemId: string, mediaSourceId?: string): string;
+  /** HLS playlist the in-app player can always handle. */
+  buildHlsStreamUrl(url: string, token: string, itemId: string, opts?: HlsStreamOptions): string;
+  /**
+   * Session handle baked into the most recently built HLS URL, so a caller
+   * that only has the URL (the player's buildStream callback returns a plain
+   * string) can still learn which session to tear down before rebuilding it.
+   */
+  lastHlsPlaySessionId(): string | undefined;
+  /**
+   * Tell the server to stop transcoding immediately rather than waiting for
+   * its idle timeout — called right before abandoning an HLS stream for a
+   * rebuilt one (seek, quality/track change) so the old ffmpeg process isn't
+   * left encoding a stream nobody is reading.
+   */
+  stopActiveEncoding(playSessionId: string, log?: (msg: string) => void): Promise<void>;
+  /**
+   * Whether an HLS URL was built to let the server STREAM-COPY the video, i.e.
+   * it may carry a full-bitrate 4K remux rather than a capped stream. The
+   * player uses this to pick a buffer profile that keeps such a stream inside
+   * the webview's SourceBuffer budget.
+   */
+  isStreamCopyUrl(src: string): boolean;
+
+  // ─── Progress reporting ────────────────────────────────────────────────────
+
+  reportPlaybackStart(url: string, token: string, itemId: string): Promise<void>;
+  reportPlaybackProgress(
+    url: string,
+    token: string,
+    itemId: string,
+    positionTicks: number,
+    isPaused: boolean
+  ): Promise<void>;
+  reportPlaybackStopped(url: string, token: string, itemId: string, positionTicks: number): Promise<void>;
+}
+
+// ─── Stored connection ────────────────────────────────────────────────────────
+
+// The url/token/userid keys keep their historical `jellyfin_` spelling on
+// purpose: renaming them would sign every existing install out on upgrade for
+// no user-visible gain. Only the SERVER KIND is a new key, and its absence
+// means Jellyfin — which is exactly right for every store that existed before
+// Plex support landed.
+const KIND_KEY = 'media_server_kind';
+export const URL_KEY = 'jellyfin_url';
+export const TOKEN_KEY = 'jellyfin_token';
+export const USER_ID_KEY = 'jellyfin_userid';
+export const LAST_USER_ID_KEY = 'jellyfin_last_userid';
+export const USERNAME_KEY = 'jellyfin_username';
+
+function readLocal(key: string): string | null {
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeLocal(key: string, value: string): void {
+  try {
+    localStorage?.setItem(key, value);
+  } catch { /* private mode / quota — the session just doesn't survive a reload */ }
+}
+
+export function activeBackendKind(): MediaServerKind {
+  return readLocal(KIND_KEY) === 'plex' ? 'plex' : 'jellyfin';
+}
+
+export function setActiveBackendKind(kind: MediaServerKind): void {
+  writeLocal(KIND_KEY, kind);
+}
+
+/** Stored connection, or nulls before first run. */
+export function storedConnection(): { url: string | null; token: string | null; userId: string | null } {
+  return { url: readLocal(URL_KEY), token: readLocal(TOKEN_KEY), userId: readLocal(USER_ID_KEY) };
+}
+
+/** Persist an authenticated session (and the backend that produced it). */
+export function persistSession(kind: MediaServerKind, url: string, session: MediaSession): void {
+  setActiveBackendKind(kind);
+  writeLocal(URL_KEY, url);
+  writeLocal(TOKEN_KEY, session.accessToken);
+  writeLocal(USER_ID_KEY, session.userId);
+  writeLocal(LAST_USER_ID_KEY, session.userId); // remembered for next boot's card highlight
+}
+
+const KNOWN_LIBS_KEY = 'bb_known_libraries';
+
+/**
+ * Remember the server's FULL video-library list (id + name) whenever a fetch
+ * sees it — the catalog fetchers are the only places that ever see the
+ * complete list, exclusions and all. localStorage-persisted so the Store
+ * Libraries settings page can offer EXCLUDED libraries for re-enabling on
+ * every later boot (#41): an excluded library is absent from the synced
+ * catalog by design, so the catalog alone can never list it again.
+ */
+export function rememberKnownLibraries(libs: ReadonlyArray<LibrarySummary>): void {
+  writeLocal(KNOWN_LIBS_KEY, JSON.stringify(libs.map((l) => ({ id: l.id, name: l.name }))));
+}
+
+/** The last-remembered full server library list ([] before any real fetch). */
+export function knownServerLibraries(): LibrarySummary[] {
+  try {
+    const raw = readLocal(KNOWN_LIBS_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed)
+      ? parsed.filter((l) => l && typeof l.id === 'string' && typeof l.name === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+// ─── Registry ─────────────────────────────────────────────────────────────────
+
+// Backends register themselves at import time rather than being imported here
+// directly: this module is imported by the domain-facing call sites, and a
+// static import of both backends from here would drag the whole Plex client
+// into a Jellyfin-only store's bundle (and vice versa) for no reason.
+const registry = new Map<MediaServerKind, MediaBackend>();
+
+export function registerBackend(backend: MediaBackend): void {
+  registry.set(backend.kind, backend);
+}
+
+export function backendFor(kind: MediaServerKind): MediaBackend {
+  const backend = registry.get(kind);
+  if (!backend) {
+    throw new Error(
+      `No media backend registered for "${kind}". ` +
+      `Import ./media-backends.ts once at startup to register them.`
+    );
+  }
+  return backend;
+}
+
+/** Every registered backend, for screens that offer a choice of server. */
+export function allBackends(): MediaBackend[] {
+  return [...registry.values()];
+}
+
+export function activeBackend(): MediaBackend {
+  return backendFor(activeBackendKind());
+}
+
+/**
+ * Work out which kind of server is answering at an address by asking each
+ * backend in turn, so the setup terminal can accept a bare address instead of
+ * making the user declare the server type first. Resolves null when nothing
+ * recognizable answers.
+ */
+export async function identifyServer(url: string): Promise<MediaServerKind | null> {
+  // Sequential and short-circuiting, not a Promise.all race: a probe that
+  // misses is a CROSS-ORIGIN request the browser logs as a CORS failure, and
+  // firing every backend's probe at an address that only one of them owns fills
+  // the console with alarming errors for a connection that then works fine.
+  // Registration order puts the proxy-routed backend first for the same reason
+  // (see media-backends.ts).
+  for (const backend of allBackends()) {
+    try {
+      if (await backend.identify(url)) {
+        console.info(`[Media] ${url} identified as ${backend.label}.`);
+        return backend.kind;
+      }
+      console.info(`[Media] ${url} is not ${backend.label}.`);
+    } catch (e) {
+      console.info(`[Media] ${backend.label} probe of ${url} failed:`, e);
+    }
+  }
+  return null;
+}
+
+// ─── Facade ───────────────────────────────────────────────────────────────────
+// Same names and signatures the app has always called, now routed to whichever
+// backend is active. Import these instead of reaching into jellyfin.ts.
+
+export function normalizeUrl(url: string): string {
+  // Address normalization is pure string work and identical across backends,
+  // but it must stay callable BEFORE a backend is chosen (the setup terminal
+  // normalizes what the user typed in order to probe it), so it can't go
+  // through activeBackend().
+  let cleaned = (url || '').trim().replace(/\/$/, '');
+  if (!cleaned) return '';
+  if (!/^https?:\/\//i.test(cleaned)) cleaned = `http://${cleaned}`;
+  return cleaned;
+}
+
+export function validateToken(url: string, token: string): Promise<boolean> {
+  if (!url || !token) return Promise.resolve(false);
+  return activeBackend().validateToken(url, token);
+}
+
+export function authenticateUser(url: string, username: string, password?: string): Promise<MediaSession> {
+  return activeBackend().authenticateUser(url, username, password);
+}
+
+export function fetchPublicUsers(url: string, token?: string): Promise<PublicUser[]> {
+  return activeBackend().fetchPublicUsers(url, token);
+}
+
+export function buildUserAvatarUrl(url: string, user: PublicUser): string | null {
+  return activeBackend().buildUserAvatarUrl(url, user);
+}
+
+export function signInAsPublicUser(
+  url: string,
+  user: PublicUser,
+  secret?: string,
+  token?: string
+): Promise<MediaSession> {
+  return activeBackend().signInAsPublicUser(url, user, secret, token);
+}
+
+export function fetchLibraryList(url: string, token: string, userId: string): Promise<LibrarySummary[]> {
+  return activeBackend().fetchLibraryList(url, token, userId);
+}
+
+export function fetchLibrariesAndMovies(
+  url: string,
+  token: string,
+  userId: string,
+  onProgress?: (stage: string) => void,
+  opts?: CatalogSyncOptions
+): Promise<MediaLibrary[]> {
+  return activeBackend().fetchLibrariesAndMovies(url, token, userId, onProgress, opts);
+}
+
+export function fetchSeriesEpisodes(
+  url: string,
+  token: string,
+  userId: string,
+  seriesId: string
+): Promise<Episode[]> {
+  return activeBackend().fetchSeriesEpisodes(url, token, userId, seriesId);
+}
+
+export function fetchFirstEpisodeOfSeries(
+  url: string,
+  token: string,
+  userId: string,
+  seriesId: string
+): Promise<EpisodeRef | null> {
+  return activeBackend().fetchFirstEpisodeOfSeries(url, token, userId, seriesId);
+}
+
+export function fetchItemPlaybackInfo(
+  url: string,
+  token: string,
+  userId: string,
+  itemId: string
+): Promise<MediaPlaybackInfo | undefined> {
+  return activeBackend().fetchItemPlaybackInfo(url, token, userId, itemId);
+}
+
+export function pickSubtitleDelivery(
+  streams: MediaStreamInfo[] | undefined,
+  streamIndex: number | undefined
+): SubtitleDelivery {
+  return activeBackend().subtitleDelivery(streams, streamIndex);
+}
+
+export function buildSubtitleTrackUrl(
+  url: string,
+  token: string,
+  itemId: string,
+  streamIndex: number,
+  mediaSourceId?: string
+): string | null {
+  return activeBackend().buildSubtitleTrackUrl(url, token, itemId, streamIndex, mediaSourceId);
+}
+
+export function buildStaticStreamUrl(
+  url: string,
+  token: string,
+  itemId: string,
+  mediaSourceId?: string
+): string {
+  return activeBackend().buildStaticStreamUrl(url, token, itemId, mediaSourceId);
+}
+
+export function buildHlsStreamUrl(
+  url: string,
+  token: string,
+  itemId: string,
+  opts?: HlsStreamOptions
+): string {
+  return activeBackend().buildHlsStreamUrl(url, token, itemId, opts);
+}
+
+export function getLastHlsPlaySessionId(): string | undefined {
+  return activeBackend().lastHlsPlaySessionId();
+}
+
+export function stopActiveEncoding(playSessionId: string, log?: (msg: string) => void): Promise<void> {
+  return activeBackend().stopActiveEncoding(playSessionId, log);
+}
+
+export function isStreamCopyUrl(src: string): boolean {
+  return activeBackend().isStreamCopyUrl(src);
+}
+
+export function reportPlaybackStart(url: string, token: string, itemId: string): Promise<void> {
+  return activeBackend().reportPlaybackStart(url, token, itemId);
+}
+
+export function reportPlaybackProgress(
+  url: string,
+  token: string,
+  itemId: string,
+  positionTicks: number,
+  isPaused: boolean
+): Promise<void> {
+  return activeBackend().reportPlaybackProgress(url, token, itemId, positionTicks, isPaused);
+}
+
+export function reportPlaybackStopped(
+  url: string,
+  token: string,
+  itemId: string,
+  positionTicks: number
+): Promise<void> {
+  return activeBackend().reportPlaybackStopped(url, token, itemId, positionTicks);
+}

--- a/src/media-backends.ts
+++ b/src/media-backends.ts
@@ -1,0 +1,24 @@
+// Backend registration. Imported once for its side effect, early enough that
+// any later activeBackend() call finds a populated registry — main.ts and the
+// tools that boot without it (remote play, the demo harness) each pull this in
+// before touching the media layer.
+//
+// It exists as its own module so media-backend.ts can stay free of imports
+// from the backends it defines the contract for: the call sites import the
+// contract, the contract imports nothing, and only this file knows the full
+// list.
+import { registerBackend } from './media-backend.ts';
+import { jellyfinBackend } from './jellyfin.ts';
+import { plexBackend } from './plex.ts';
+
+// Order matters for identifyServer, which probes in registration order and
+// stops at the first match. Plex goes first because its probe is routed
+// through the app's own /plex-proxy (a Plex server refuses browser requests
+// from any non-loopback origin), so a miss costs a same-origin 404 and no
+// console noise — whereas a missed Jellyfin probe is a cross-origin request
+// the browser reports as a CORS error. This says nothing about which backend
+// is the DEFAULT: an install with no stored server kind is still Jellyfin.
+registerBackend(plexBackend);
+registerBackend(jellyfinBackend);
+
+export { jellyfinBackend, plexBackend };

--- a/src/media-shared.ts
+++ b/src/media-shared.ts
@@ -1,0 +1,316 @@
+// Media logic that is NOT a property of any one server: duplicate-version
+// collapsing, direct-play safety, and the collection side-tables. All of it
+// used to live in jellyfin.ts; it moved here when plex.ts arrived, because
+// every piece below reasons about the STORE's domain model (Movie,
+// MediaPlaybackInfo) or about THIS WEBVIEW's decoding ability — neither of
+// which changes with the server on the other end.
+//
+// jellyfin.ts re-exports the public names, so existing importers are
+// unaffected. New code should import from here.
+import type { Movie, MovieVersion, MediaPlaybackInfo, MediaStreamInfo } from './media-types.ts';
+
+// ─── Quality labelling ────────────────────────────────────────────────────────
+
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
+  if (bytes >= 1024 ** 2) return `${Math.round(bytes / 1024 ** 2)} MB`;
+  return `${Math.round(bytes / 1024)} KB`;
+}
+
+/** Resolution bucket name — width AND height checked so scope (1920x800) and
+ *  4:3 (1440x1080) content both land in the right bucket. */
+export function qualityTag(width?: number, height?: number): string | undefined {
+  const w = width ?? 0;
+  const h = height ?? 0;
+  if (w >= 3200 || h >= 2000) return "4K";
+  if (w >= 1800 || h >= 1030) return "1080p";
+  if (w >= 1150 || h >= 690) return "720p";
+  if (w > 0 || h > 0) return "SD";
+  return undefined;
+}
+
+/** Whether a frame size counts as 4K for the case's 4K sticker. Shared so both
+ *  backends agree on the threshold even though they learn the size differently
+ *  (Jellyfin: per-source Width/Height; Plex: Media.videoResolution === '4k',
+ *  which it cross-checks against this). */
+export function is4kFrame(width?: number, height?: number): boolean {
+  return (width ?? 0) >= 3200 || (height ?? 0) >= 2000;
+}
+
+// ─── Duplicate-version collapsing ─────────────────────────────────────────────
+
+// Trailing resolution/format markers stripped when matching duplicate items of
+// the same film ("Heat (4K)" and "Heat" are one movie). Only quality markers —
+// cut markers (Extended, Director's Cut) are left alone: those are genuinely
+// different films content-wise and keep their own shelf box.
+const RES_MARKER_RE =
+  /[\s\-–·]*[[({]?\s*\b(4k|uhd|2160p|1440p|1080[pi]|720p|480p|576p|hdr10\+?|hdr|dolby\s*vision|dv|remux|blu-?ray|web-?(dl|rip)|x26[45]|h\.?26[45]|hevc|av1)\b\s*[\])}]?\s*$/i;
+
+function versionGroupKey(m: Movie): string {
+  let t = m.title.toLowerCase().trim();
+  for (;;) {
+    const stripped = t.replace(RES_MARKER_RE, "").trim();
+    if (stripped === t || stripped.length === 0) break;
+    t = stripped;
+  }
+  return `${t}|${m.year}`;
+}
+
+/** Best-first version order: bigger frame wins; 16:9-normalized so a width-only
+ *  entry still ranks against a height-only one. */
+function versionRank(v: MovieVersion): number {
+  return Math.max(v.width ?? 0, ((v.height ?? 0) * 16) / 9, v.is4k ? 3840 : 0);
+}
+
+/** Sort/dedupe a movie's accumulated versions; below 2 real choices the array
+ *  is dropped entirely so single-file movies stay exactly as before. */
+function finalizeVersions(m: Movie): void {
+  if (!m.versions || m.versions.length < 2) {
+    m.versions = undefined;
+    return;
+  }
+  const seen = new Set<string>();
+  const versions = m.versions.filter((v) => {
+    const key = `${v.itemId}|${v.mediaSourceId ?? ""}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  if (versions.length < 2) {
+    m.versions = undefined;
+    return;
+  }
+  versions.sort((a, b) => versionRank(b) - versionRank(a));
+  m.versions = versions;
+  // The single remaining box advertises the best available quality.
+  if (versions.some((v) => v.is4k)) m.is4k = true;
+}
+
+/**
+ * Collapse duplicate entries of the same film (same normalized title + year)
+ * into ONE shelf box carrying every quality as a Movie.version — the fix for
+ * a 4K and a 1080p rip of one movie standing side by side on the shelf. The
+ * first-seen entry keeps the shelf spot and its metadata/poster; extra
+ * entries contribute their versions and disappear from the catalog. Series,
+ * games, and synthesized (discovery/coming-soon) entries never collapse.
+ *
+ * Both backends run this over their mapped catalog, and both need it for the
+ * same reason: a server that ingested a 4K rip and a 1080p rip as separate
+ * items has no idea they are one film. (An item whose versions were merged
+ * SERVER-side arrives as one item with several sources and is already handled
+ * by the backend's own version builder.)
+ */
+export function collapseDuplicateVersions(movies: Movie[], context: string): Movie[] {
+  const byKey = new Map<string, Movie>();
+  const out: Movie[] = [];
+  let collapsed = 0;
+  for (const m of movies) {
+    if (m.isSeries || m.game || m.discovery || m.comingSoon || m.collectionGap) {
+      out.push(m);
+      continue;
+    }
+    const prior = byKey.get(versionGroupKey(m));
+    if (!prior) {
+      byKey.set(versionGroupKey(m), m);
+      out.push(m);
+      continue;
+    }
+    prior.versions = [...(prior.versions ?? []), ...(m.versions ?? [])];
+    collapsed++;
+  }
+  for (const m of out) finalizeVersions(m);
+  if (collapsed > 0) {
+    console.info(`[Catalog] ${context}: collapsed ${collapsed} duplicate quality version(s) into their main title.`);
+  }
+  return out;
+}
+
+// ─── Collection side-tables ───────────────────────────────────────────────────
+
+/**
+ * Artwork for the collections that survived the version-pair filter, keyed by
+ * collection name (the same key `Movie.collectionName` carries). Read by the
+ * four-sided collection displays to build their signage. Empty when running
+ * against the synthetic harness library, in which case the signs fall back to
+ * a member title's backdrop.
+ *
+ * Filled by whichever backend synced last: jellyfin.ts walks each BoxSet's
+ * children (membership isn't on the item in a list query); plex.ts reads the
+ * section's own collection listing, since Plex tags membership on the item.
+ */
+export const collectionArt = new Map<string, { posterUrl?: string; backdropUrl?: string }>();
+
+/**
+ * Collection name -> TMDB *collection* id. This is the only bridge from a
+ * server-side collection (which knows only what's on disk) to the collection's
+ * full member list, so it's what lets fetchCollectionGaps work out which
+ * entries are missing. Empty for collections the user assembled by hand (no
+ * TMDB collection id) and in the synthetic harness library — those collections
+ * simply show no gaps.
+ */
+export const collectionTmdbIds = new Map<string, number>();
+
+/**
+ * Counts from the last membership sync, for the boot console's collection-gap
+ * status line. A backend can't call main.ts's logToConsole (circular), so it
+ * records what it saw and main.ts does the talking.
+ */
+export const collectionSyncStats = { boxSets: 0, scraped: 0, rejectedVersionPairs: 0 };
+
+/** Wipe the side-tables before a fresh sync, so a re-sync (or a switch to the
+ *  other backend) never leaves a previous server's collections standing. */
+export function resetCollectionState(): void {
+  collectionArt.clear();
+  collectionTmdbIds.clear();
+  collectionSyncStats.boxSets = 0;
+  collectionSyncStats.scraped = 0;
+  collectionSyncStats.rejectedVersionPairs = 0;
+}
+
+// ─── Subtitle delivery ────────────────────────────────────────────────────────
+
+/**
+ * Subtitle codecs that are TEXT, and can therefore be fetched as a WebVTT
+ * sidecar and rendered by the browser over the video. Everything else — PGS,
+ * DVD, DVB, XSUB — is a bitmap the browser cannot draw, so it still has to be
+ * burned into the picture server-side (see pickSubtitleDelivery).
+ *
+ * Both servers report the ffmpeg codec name, which is why both spellings of the
+ * common ones are here (`subrip`/`srt`, `ssa`/`ass`); `mov_text` is the MP4
+ * flavour and `webvtt`/`vtt` are already what we're asking for.
+ */
+const TEXT_SUBTITLE_CODECS = new Set([
+  'subrip', 'srt', 'ass', 'ssa', 'mov_text', 'webvtt', 'vtt', 'text', 'subviewer', 'microdvd',
+]);
+
+/** Is this subtitle stream text (client-renderable) rather than a bitmap? */
+export function isTextSubtitleCodec(codec: string | undefined): boolean {
+  return !!codec && TEXT_SUBTITLE_CODECS.has(codec.toLowerCase());
+}
+
+/**
+ * How a chosen subtitle track should be delivered.
+ *
+ * This is the whole point of the client-side subtitle work: asking the server
+ * to burn subtitles in (`SubtitleMethod=Encode`) forces a full video re-encode,
+ * so on the browser/Remote Play path merely defaulting captions ON turned every
+ * direct-playable file into a transcode. A text track costs the server nothing
+ * — it's a sidecar fetch — and switching or disabling it needs no new stream
+ * at all. Bitmap subtitles have no client renderer, so they keep the old path
+ * and pay the old price.
+ */
+export type SubtitleDelivery =
+  | { kind: 'none' }
+  | { kind: 'text'; streamIndex: number }
+  | { kind: 'burn-in'; streamIndex: number };
+
+export function pickSubtitleDelivery(
+  streams: MediaStreamInfo[] | undefined,
+  streamIndex: number | undefined,
+): SubtitleDelivery {
+  if (streamIndex === undefined) return { kind: 'none' };
+  const stream = streams?.find((s) => s.type === 'Subtitle' && s.index === streamIndex);
+  // Unknown stream, or a server that didn't report a codec: assume text and
+  // try the cheap path. The two failure modes are not symmetric — a sidecar
+  // that 404s costs one failed request and leaves the film playing, while a
+  // needless burn-in costs a re-encode of the entire runtime.
+  if (!stream || stream.codec === undefined) return { kind: 'text', streamIndex };
+  return isTextSubtitleCodec(stream.codec)
+    ? { kind: 'text', streamIndex }
+    : { kind: 'burn-in', streamIndex };
+}
+
+
+// ─── Direct-play safety ───────────────────────────────────────────────────────
+
+/** MediaSource.isTypeSupported, guarded for non-browser contexts. */
+function mseSupports(mime: string): boolean {
+  try {
+    return typeof MediaSource !== 'undefined' && MediaSource.isTypeSupported(mime);
+  } catch {
+    return false;
+  }
+}
+
+// Whether this webview's MSE can decode HEVC, probed once at module load.
+// hvc1.1.6.* = Main (8-bit), hvc1.2.4.* = Main 10 — movie remuxes (and anime
+// especially) are typically 10-bit. When the webview can decode HEVC, HLS
+// requests list it as an allowed codec so the server STREAM-COPIES the video
+// instead of re-encoding it to H.264 — a cheap remux (audio-only transcode)
+// instead of a full ffmpeg video transcode.
+const HEVC_MAIN_SUPPORTED = mseSupports('video/mp4; codecs="hvc1.1.6.L153.B0"');
+const HEVC_MAIN10_SUPPORTED = mseSupports('video/mp4; codecs="hvc1.2.4.L153.B0"');
+
+const DIRECT_PLAY_SAFE_CONTAINERS = new Set(['mp4', 'm4v', 'mov', 'webm']);
+const DIRECT_PLAY_SAFE_VIDEO_CODECS = new Set(['h264', 'vp8', 'vp9', 'av1']);
+// HEVC direct play only when Main 10 decodes too: MediaPlaybackInfo doesn't
+// carry bit depth, so we can't tell an 8-bit file from a 10-bit one here.
+if (HEVC_MAIN10_SUPPORTED) {
+  DIRECT_PLAY_SAFE_VIDEO_CODECS.add('hevc');
+  DIRECT_PLAY_SAFE_VIDEO_CODECS.add('h265');
+}
+const DIRECT_PLAY_SAFE_AUDIO_CODECS = new Set(['aac', 'mp3', 'opus', 'vorbis', 'flac']);
+
+/** Whether HLS requests allow HEVC stream copy (webview MSE decodes HEVC). */
+export function isHevcPassThroughEnabled(): boolean {
+  return HEVC_MAIN_SUPPORTED;
+}
+
+/** Whether the webview decodes 10-bit HEVC — backends cap bit depth when not. */
+export function isHevcMain10Supported(): boolean {
+  return HEVC_MAIN10_SUPPORTED;
+}
+
+/**
+ * True only when the item's container, video codec, and every audio codec are
+ * all in WebKitGTK's known-safe allowlist — i.e. safe to try the raw
+ * direct-file URL. WebKitGTK silently DROPS audio tracks whose codec isn't in
+ * its allowlist (AC3/EAC3/DTS are typical movie-rip audio) regardless of
+ * installed GStreamer decoders, with no error firing to trigger the normal
+ * direct→HLS fallback — so anything missing or unrecognized must default to
+ * NOT safe rather than risk silent audio. MKV is deliberately excluded even
+ * when its codecs are otherwise fine: WebKit's range-seeking on Matroska is
+ * what makes scrubbing take ages; HLS transcode seeks in ~2s by comparison.
+ */
+export function isDirectPlaySafe(info: MediaPlaybackInfo | undefined | null): boolean {
+  if (!info) return false;
+  const { container, videoCodec, audioCodecs } = info;
+  if (!container || !DIRECT_PLAY_SAFE_CONTAINERS.has(container)) return false;
+  if (!videoCodec || !DIRECT_PLAY_SAFE_VIDEO_CODECS.has(videoCodec)) return false;
+  if (!audioCodecs || audioCodecs.length === 0) return false;
+  return audioCodecs.every((c) => DIRECT_PLAY_SAFE_AUDIO_CODECS.has(c));
+}
+
+// ─── Transcode bitrate ceilings ───────────────────────────────────────────────
+
+// Default video bitrate ceiling (bits/s) for the "Auto" HLS stream. This is
+// NOT a bandwidth limit (the server is on the LAN) — it's a MEMORY limit for
+// the client's MSE SourceBuffer. hls.js buffers ~60-80s ahead regardless of
+// its maxBufferLength/maxBufferSize knobs (verified — it ignores them on a
+// fast VOD source), and the Chromium/Brave webview caps a single video
+// SourceBuffer at ~250 MB. A 38.5 Mbps Blu-ray remux stream-copied verbatim
+// therefore overflows that cap ~35-40s in: hls.js flush-evicts the buffer,
+// punches a hole right in front of the playhead, and playback FREEZES (the
+// "freezes at ~39s" bug, reproduced in Brave). Capping at 20 Mbps keeps
+// ~80s of buffer near ~200 MB, which Brave evicts cleanly with zero stalls
+// (measured). A server stream-copies sources already under this ceiling and
+// re-encodes heavier remuxes down to it (cheap on the box's QSV/VAAPI); it
+// clamps the encode target to the source bitrate, so this never inflates
+// output. 1080p H.264 at 20 Mbps is visually near-transparent.
+export const DEFAULT_VIDEO_BITRATE = 20_000_000;
+
+// Ceiling sent when the source video is being STREAM-COPIED. A server only
+// copies when source bitrate <= requested bitrate, so the 20 Mbps re-encode
+// ceiling above silently forced every 4K remux (94 Mbps for a typical 4K
+// title) into a full re-encode — which also drags in a downscale AND, because
+// HDR tonemapping doesn't engage on every box's decode pipeline, a bt709
+// relabel that ships PQ / BT.2020 pixels tagged as Rec.709. That mislabel is
+// what makes 4K HDR titles look washed out. Copying sidesteps all three: the
+// bitstream is untouched, so resolution and HDR metadata arrive as mastered.
+//
+// The copy path's real constraint is MEMORY, not bandwidth (LAN server): see
+// HLS_COPY_BUFFER in video-player.ts, which shrinks hls.js's buffer so a
+// 94 Mbps stream stays under Brave's ~250 MB SourceBuffer cap. Keep the two in
+// sync — raising this without shrinking that reintroduces the freeze-at-~39s
+// eviction bug.
+export const COPY_VIDEO_BITRATE = 200_000_000;

--- a/src/media-types.ts
+++ b/src/media-types.ts
@@ -1,0 +1,305 @@
+// The store's DOMAIN MODEL — what a rental case knows about itself, with no
+// media server in it.
+//
+// These types used to live in jellyfin.ts, which made every one of the ~60
+// modules that only wanted `Movie` import the Jellyfin client (and, through
+// it, @tauri-apps/api) to get it. They moved here when the media layer was
+// split behind MediaBackend (see media-backend.ts) so a second server —
+// plex.ts — could fill the same shapes without either backend importing the
+// other. jellyfin.ts re-exports every name below, so the old
+// `import { Movie } from './jellyfin'` spellings keep working.
+//
+// Two Jellyfin-isms deliberately survive the move, because they are the
+// store's internal units and rewriting 60 modules to change them would buy
+// nothing: durations/positions are in TICKS (1 tick = 100 ns, so ms * 10_000
+// — plex.ts converts on the way in), and per-title stream/version handles are
+// opaque STRINGS whose meaning belongs to whichever backend minted them.
+
+export interface Movie {
+  id: string;
+  title: string;
+  year: number;
+  duration: string;
+  rating: string;
+  overview: string;
+  director: string;
+  actors: string[]; // top-billed cast, at most 5 names
+  genres: string[];
+  localPath: string;
+  posterUrl?: string;
+  backdropUrl?: string;
+  dateCreated?: string;
+  isSeries?: boolean;
+  is4k?: boolean;
+  communityRating?: number; // 0-10 (e.g. 9.0 = 4.5 stars out of 5)
+  criticRating?: number;    // 0-100 Rotten Tomatoes score
+  libraryName?: string;
+  studios?: string[];
+  // Synthesized (see jellyseerr.ts) for a title that's been requested on
+  // Jellyseerr but hasn't finished downloading yet: it gets a display case
+  // with poster art on the New Releases wall but no rental backstock, and
+  // selecting it should show "Coming Soon" rather than allow playback.
+  comingSoon?: boolean;
+  // TMDB id (see jellyseerr.ts's fetchDiscoverMovies) -- required to call
+  // requestMovie() for a discovery title.
+  tmdbId?: number;
+  // Synthesized (see jellyseerr.ts's fetchDiscoverMovies) for a Jellyseerr
+  // trending/popular suggestion that is NOT in the library: it gets an empty
+  // display case shelved inline with the regular stock (REQUEST corner
+  // sticker, no rental backstock), and selecting it lets the user REQUEST it
+  // through Jellyseerr instead of play it.
+  discovery?: boolean;
+  // True when a `discovery` or `collectionGap` title has already been
+  // requested (through this app this session, or because Jellyseerr's own
+  // records say so -- see StoreScene's merge of comingSoon into
+  // discoveryMovies, and fetchCollectionGaps keeping requested gaps). These
+  // cases stamp the gold COMING SOON corner label instead of the blue
+  // REQUEST one; endcap candidates wear the green REQUESTED tag.
+  discoveryRequested?: boolean;
+  // T18: synthesized (see romm.ts's fetchGames) for a video-game title from a
+  // Romm server. It gets a display case (cover art) in the VIDEO GAMES section,
+  // is grouped under `platform` (e.g. "SNES"), and selecting it "rents" -> the
+  // Tauri build launches the configured emulator on `launchPath`; the browser
+  // build shows a "take it to the counter" toast.
+  game?: boolean;
+  platform?: string;
+  launchPath?: string;
+  // Flat scan art for the case's OTHER faces (back panel / spine / disc
+  // label), resolved by romm.ts's gameArtUrls(). Absent for a title whose
+  // library never scraped that media — the faces then keep their generated
+  // fallbacks. Typed loosely here so this module stays free of a romm.ts
+  // import.
+  gameArt?: { back?: string; spine?: string; label?: string };
+  // Discs in this title's retail case (romm.ts discCountFrom: distinct
+  // "(Disc N)" tags across the rom + its siblings). Only set when >= 2 —
+  // it thickens a jewel-case platform's box to the multi-disc fat case.
+  discCount?: number;
+  // Audio/subtitle streams of the primary media source — drives the in-app
+  // player's track picker. Absent for series containers, games, and discovery
+  // titles.
+  //
+  // Jellyfin ships these with the catalog (Fields=MediaSources); Plex does
+  // NOT return them from a section listing, so plex.ts fills them from a
+  // second, comma-batched /library/metadata pass over the same items.
+  mediaStreams?: MediaStreamInfo[];
+  // Container + video/audio codecs of the primary media source — lets
+  // launchVideoPlayback decide direct-play vs. HLS transcode BEFORE opening
+  // the player (see isDirectPlaySafe). Absent for series containers, games,
+  // and discovery titles; series episodes are probed on demand instead (see
+  // MediaBackend.fetchItemPlaybackInfo) since the episode list never fetches
+  // media sources.
+  mediaPlaybackInfo?: MediaPlaybackInfo;
+  // Width/height ratio of the poster image. Lets flat mode size a case to the
+  // art before the lazy poster loads (issue #108) instead of reflowing the row
+  // on every image load. Absent for games, discovery titles, and servers that
+  // haven't probed the image yet (Plex reports no such ratio — its posters are
+  // uniformly 2:3, which is flat mode's own default).
+  primaryImageAspectRatio?: number;
+  // Alternate quality versions of the same film. Built two ways: an item whose
+  // versions were merged server-side carries several sources (one version
+  // each — Jellyfin MediaSources, Plex Media[]), and duplicate items of the
+  // same film (a 4K rip and a 1080p rip ingested separately) are collapsed to
+  // ONE shelf box by collapseDuplicateVersions(). Present ONLY when there are
+  // 2+ choices, ordered best-quality-first; pressing Play on such a title
+  // opens the version picker (main.ts) instead of streaming blind.
+  versions?: MovieVersion[];
+  // Name of the collection this movie belongs to, e.g. "Harry Potter
+  // Collection". Members of one collection file together on the shelf in
+  // premiere order (see shelfTitleCompare in store-layout).
+  //
+  // Jellyfin list queries don't carry membership on the item, so jellyfin.ts
+  // tags this in a separate pass after library sync; Plex returns a
+  // `Collection` tag on the item itself and needs no such pass.
+  collectionName?: string;
+  // ISO premiere date — breaks the chronological tie between same-collection
+  // titles released the same year (a production year alone can't order them).
+  premiereDate?: string;
+  // Synthesized (see jellyseerr.ts's fetchCollectionGaps) for an entry of a
+  // collection the user PARTLY owns — you have 5 of the 8 Harry Potters, so
+  // the other 3 stand in their correct chronological shelf position wearing a
+  // corner sticker, with no rental backstock behind them. Selecting one
+  // requests it through Jellyseerr rather than playing it.
+  //
+  // No media server can source these on its own: its collection is built from
+  // the files you have, so it has no idea the collection is incomplete. The
+  // full member list comes from TMDB via Jellyseerr, keyed on the collection's
+  // TMDB id.
+  collectionGap?: boolean;
+  // Per-user watch state. Both backends query as a specific user (Jellyfin's
+  // /Users/{id}/Items; a Plex Home user's own token), so this is THIS user's
+  // history. Watched titles are the anchors the staff-picks engine aggregates
+  // TMDB "people who liked this also liked" results over (see staff-picks.ts).
+  played?: boolean;
+  playCount?: number;
+  lastPlayedDate?: string; // ISO — orders anchors by recency
+  // Ticks into the item the server says THIS user left off at. Servers only
+  // report a non-zero resume position while the item is still inside their own
+  // resume window (fully watched or never started both come back unset) — so
+  // "present -> resume there" is the same rule every other client of either
+  // server follows, with no separate "start over" affordance needed.
+  resumePositionTicks?: number;
+  // Exact runtime in ticks, alongside the rounded `duration` display string
+  // above. Lets a natural end-of-file be told apart from a user quit without a
+  // per-path duration probe (see playback-flow.ts).
+  runTimeTicks?: number;
+  // Set by the staff-picks engine on an OWNED title that the aggregated
+  // watch-history recommendations surfaced: its case wears the STAFF PICK
+  // sticker (video-case.ts) and it's eligible for the genre endcaps.
+  staffPick?: boolean;
+  // Top-billed cast as person references (id + portrait URL), captured
+  // alongside `actors` (name-only) so wall décor (wall-decor.ts) can tally the
+  // library's most-featured actors and pull real portraits without a second
+  // round-trip. Same top-5 cap as `actors`; `imageUrl` is only set when the
+  // server has a portrait (many crew/cast entries don't). Undefined on
+  // synthesized titles (discovery/collectionGap/game) and the synthetic
+  // demo/harness catalog, which has no person image data at all.
+  castPeople?: { id: string; name: string; imageUrl?: string }[];
+}
+
+export interface MediaStreamInfo {
+  /** Backend stream handle — pass back as the audio/subtitle selection.
+   *  Jellyfin: the MediaStream index. Plex: the Stream `id` (NOT its ffmpeg
+   *  `index`, which is what /library/parts wants selections keyed on). */
+  index: number;
+  type: 'Audio' | 'Subtitle';
+  language?: string;
+  displayTitle?: string;
+  codec?: string;
+  isDefault?: boolean;
+  /** Audio channel count (2 = stereo, 6 = 5.1, 8 = 7.1) — used to print the
+   *  channel layout in the back-cover tech-specs table. Audio streams only. */
+  channels?: number;
+}
+
+/** One playable quality/edition of a film — see Movie.versions. */
+export interface MovieVersion {
+  /** Item to stream (and report playback against). */
+  itemId: string;
+  /** Set when this version is one source of a server-side-merged item, so the
+   *  server streams THAT file and not the default. Jellyfin: MediaSourceId.
+   *  Plex: the index into Media[], passed as mediaIndex. */
+  mediaSourceId?: string;
+  /** Picker row text, e.g. "4K · HDR · HEVC · 54 GB". */
+  label: string;
+  is4k: boolean;
+  /** Video frame size, for best-first ordering. */
+  width?: number;
+  height?: number;
+  /** File path of this version, for the external-player fallback. */
+  localPath?: string;
+  mediaStreams?: MediaStreamInfo[];
+  mediaPlaybackInfo?: MediaPlaybackInfo;
+}
+
+/** Container + video/audio codecs needed by isDirectPlaySafe. All strings are
+ *  lower-cased so callers can compare against fixed allowlists. */
+export interface MediaPlaybackInfo {
+  container?: string;
+  videoCodec?: string;
+  audioCodecs: string[];
+  /** Video frame dimensions of the default source — feed the tech-specs
+   *  table's resolution + aspect-ratio derivation. */
+  width?: number;
+  height?: number;
+  /** Display aspect ratio string (e.g. "16:9", "2.40:1"), when the server
+   *  reports one. */
+  aspectRatio?: string;
+  /** HDR class ("SDR", "HDR10", "DOVI", …) — lets the table flag HDR. */
+  videoRange?: string;
+}
+
+export interface Episode {
+  id: string;
+  seriesId: string;
+  seriesName: string;
+  seasonNumber: number;
+  episodeNumber: number;
+  name: string;
+  overview: string;
+  path: string;
+  runTimeTicks?: number;
+  /** This user's server-side resume position — see Movie.resumePositionTicks
+   *  for the same "present -> resume there" rule. */
+  resumePositionTicks?: number;
+  thumbUrl?: string;
+  seasonId?: string;
+  /** Primary (poster, 2:3) image of the Season item this episode belongs to. */
+  seasonPrimaryUrl?: string;
+}
+
+/** One library ("view" / "section") of the server, with its stock. */
+export interface MediaLibrary {
+  id: string;
+  name: string;
+  movies: Movie[];
+  genres: string[];
+  /**
+   * Synthesized by games-only.ts: this "library" is one Romm platform, not a
+   * media-server one. Its titles carry no wall categories, so the shelf
+   * planner keeps it un-sectioned and every signboard reads the platform name
+   * (see StorePlan.buildLibraryLayouts).
+   */
+  games?: boolean;
+}
+
+/** Historical spelling of MediaLibrary, kept so the ~15 modules that import it
+ *  under the old name compile unchanged. Prefer MediaLibrary in new code. */
+export type JellyfinLibrary = MediaLibrary;
+
+/** Name-only library row for the setup terminal's carried-libraries screen. */
+export interface LibrarySummary {
+  id: string;
+  name: string;
+}
+
+/** A user the sign-in screen can fan out as a membership card. */
+export interface PublicUser {
+  id: string;
+  name: string;
+  hasPassword: boolean;
+  primaryImageTag?: string;
+  /** Ready-to-use avatar URL, when the backend hands one over directly rather
+   *  than making the caller build it from an image tag (Plex Home users carry
+   *  an absolute plex.tv avatar; Jellyfin leaves this unset and the caller
+   *  goes through MediaBackend.buildUserAvatarUrl). */
+  avatarUrl?: string;
+  /** Opaque per-user handle the backend needs to complete a card sign-in
+   *  (Plex: the Home user's uuid, for the token switch). Unused by Jellyfin. */
+  switchId?: string;
+}
+
+/** Track/quality overrides for MediaBackend.buildHlsStreamUrl (the player's
+ *  track picker). Backend-neutral: every field is expressed in the store's own
+ *  units, and each backend translates on the way out. */
+export interface HlsStreamOptions {
+  /** MediaStreamInfo.index of the audio track to transcode. */
+  audioStreamIndex?: number;
+  /** MediaStreamInfo.index of the subtitle track to BURN IN. Burn-in is the
+   *  one delivery method guaranteed to render on a transcode path (pixels are
+   *  baked in, container-agnostic) and it forces the server to re-encode video
+   *  even where it could otherwise stream-copy. */
+  subtitleStreamIndex?: number;
+  /** Video bitrate ceiling in bits/s. */
+  maxBitrate?: number;
+  /** Optional resolution ceiling to pair with a lower bitrate. */
+  maxWidth?: number;
+  /** Absolute item position (ticks) to start the transcode at, so a seek
+   *  lands on an already-offset stream instead of encoding from 0:00 and
+   *  jumping client-side (which is what makes seeking a transcode slow). */
+  startPositionTicks?: number;
+  /** Lower-cased source video codec (MediaPlaybackInfo.videoCodec). HEVC
+   *  pass-through + fMP4 segments are only requested when the source is
+   *  actually HEVC — everything else stays on the battle-tested TS path. */
+  sourceVideoCodec?: string;
+  /** Specific source of a merged multi-version item to stream
+   *  (MovieVersion.mediaSourceId). Defaults to the item's own default
+   *  source. */
+  mediaSourceId?: string;
+}
+
+/** An authenticated session against whichever server the store is pointed at. */
+export interface MediaSession {
+  accessToken: string;
+  userId: string;
+  userName: string;
+}

--- a/src/membership-cards.ts
+++ b/src/membership-cards.ts
@@ -16,7 +16,8 @@
 // reinterpreted here as its 2D equivalent: a canvas-drawn card face plus a
 // CSS glint sweep and heavy box-shadow to sell the laminated look.
 
-import { authenticateUser, buildUserAvatarUrl, type PublicUser } from './jellyfin';
+import { signInAsPublicUser, buildUserAvatarUrl } from './media-backend.ts';
+import type { PublicUser } from './media-types.ts';
 import { getActiveTheme } from './themes';
 import { BB_ANTON, BB_ARCHIVO_BLACK } from './bundled-fonts';
 import { HALCYON_CREAM } from './logo-spec';
@@ -32,6 +33,13 @@ export interface OpenCardPickerOptions {
   users: PublicUser[];
   /** Last-used user id, if any -- pre-highlighted (not auto-logged-in). */
   lastUserId?: string | null;
+  /**
+   * Session token the user list was fetched with. Jellyfin ignores it (each
+   * card signs in on its own name+password), but Plex needs it: its cards are
+   * Home members of an already-authenticated ACCOUNT, and picking one swaps
+   * the account token for that member's own.
+   */
+  sessionToken?: string;
   onLogin: (session: MembershipLoginSession) => void | Promise<void>;
   onManualLogin: () => void;
   onDemoMode?: () => void;
@@ -454,7 +462,7 @@ async function attemptLogin(opts: OpenCardPickerOptions, user: PublicUser, passw
   const card = cardEls[cardIndex];
   card?.classList.add('mc-loading');
   try {
-    const session = await authenticateUser(opts.serverUrl, user.name, password);
+    const session = await signInAsPublicUser(opts.serverUrl, user, password, opts.sessionToken);
     opts.log?.(`[System] Authenticated as ${session.userName} via membership card.`);
     closeMembershipCardPicker();
     await opts.onLogin(session);
@@ -491,11 +499,11 @@ function buildCardElement(opts: OpenCardPickerOptions, user: PublicUser, index: 
   inner.appendChild(front);
   drawCardFront(front, user, null);
 
-  // Avatars are loaded best-effort: not setting crossOrigin so a Jellyfin
-  // server without CORS headers still renders the image (canvas is only
-  // ever displayed live here, never read back with getImageData/toDataURL,
-  // so a "tainted" canvas is harmless).
-  const avatarUrl = buildUserAvatarUrl(opts.serverUrl, user.id, user.primaryImageTag);
+  // Avatars are loaded best-effort: not setting crossOrigin so a server
+  // without CORS headers still renders the image (canvas is only ever
+  // displayed live here, never read back with getImageData/toDataURL, so a
+  // "tainted" canvas is harmless).
+  const avatarUrl = buildUserAvatarUrl(opts.serverUrl, user);
   if (avatarUrl) {
     const img = new Image();
     img.onload = () => drawCardFront(front, user, img);

--- a/src/playback-flow.ts
+++ b/src/playback-flow.ts
@@ -11,8 +11,8 @@
 // Explicit .ts specifiers: tests/playback-flow.test.ts loads this module
 // under `node --test`'s type-stripping loader, which can't resolve a bare
 // sibling specifier (same note as jellyfin.ts's own media-release-date.ts import).
-import type { Movie, Episode } from './jellyfin.ts';
-import { reportPlaybackStart, reportPlaybackProgress, reportPlaybackStopped } from './jellyfin.ts';
+import type { Movie, Episode } from './media-types.ts';
+import { reportPlaybackStart, reportPlaybackProgress, reportPlaybackStopped } from './media-backend.ts';
 
 const TICKS_PER_SECOND = 10_000_000;
 

--- a/src/plex.ts
+++ b/src/plex.ts
@@ -1,0 +1,1144 @@
+// PLEX BACKEND (issue #32) — the second implementation of MediaBackend.
+//
+// Everything here was written against a real 1.41.5 server (339 films, 125
+// series, 3 Home users) rather than from documentation, because Plex's API is
+// only semi-documented and several of the shapes below are not what the docs
+// would lead you to expect. The load-bearing findings, so the next person
+// doesn't have to re-derive them:
+//
+//   * A section listing returns the WHOLE section in one response — no paging
+//     token, no continuation. What it does NOT return is per-track streams or
+//     cast portraits, which is why the sync makes a second pass (below).
+//   * /library/metadata accepts COMMA-SEPARATED rating keys. That turns "full
+//     metadata for 339 films" into ~7 requests instead of 339, and is what
+//     makes the second pass affordable at all.
+//   * A section listing mixes `type: "collection"` rows in with the movies.
+//     They are filtered out here and re-read separately for their artwork.
+//   * Collection MEMBERSHIP rides on the item itself (a `Collection` tag), so
+//     unlike Jellyfin there is no membership pass to run.
+//   * Durations and positions are MILLISECONDS. The store's model is ticks
+//     (100 ns), so everything crossing this boundary is scaled by 10_000.
+//   * Track selection is keyed on Stream.id, NOT Stream.index (that one is the
+//     ffmpeg index and selecting on it silently picks the wrong track).
+//   * Direct play needs a PART id, which a rating key alone can't give you —
+//     see partIdFor() and the note above it.
+//   * The server reflects Origin in Access-Control-Allow-Origin, so the
+//     browser build talks to it directly with no proxy.
+import { invoke } from '@tauri-apps/api/core';
+import type {
+  Episode,
+  HlsStreamOptions,
+  LibrarySummary,
+  MediaLibrary,
+  MediaPlaybackInfo,
+  MediaSession,
+  MediaStreamInfo,
+  Movie,
+  MovieVersion,
+  PublicUser,
+} from './media-types.ts';
+import {
+  COPY_VIDEO_BITRATE,
+  DEFAULT_VIDEO_BITRATE,
+  collapseDuplicateVersions,
+  collectionArt,
+  collectionSyncStats,
+  collectionTmdbIds,
+  formatBytes,
+  is4kFrame,
+  isHevcMain10Supported,
+  isHevcPassThroughEnabled,
+  qualityTag,
+  resetCollectionState,
+} from './media-shared.ts';
+import {
+  normalizeUrl,
+  rememberKnownLibraries,
+  type CatalogSyncOptions,
+  type EpisodeRef,
+  type LinkFlow,
+  type MediaBackend,
+} from './media-backend.ts';
+
+const PRODUCT = 'Halcyon Video';
+const DEVICE = 'HTPC';
+const VERSION = '0.3.1';
+const PLATFORM = 'Web';
+const PLEX_TV = 'https://plex.tv';
+
+// Ticks per millisecond — the store counts in 100 ns ticks, Plex in ms.
+const TICKS_PER_MS = 10_000;
+
+// How many rating keys to put in one /library/metadata batch. 50 keeps the
+// request line comfortably inside every proxy's URL limit while still cutting
+// a 2,000-title library to 40 round-trips.
+const METADATA_BATCH = 50;
+
+// Plex stream types.
+const STREAM_VIDEO = 1;
+const STREAM_AUDIO = 2;
+const STREAM_SUBTITLE = 3;
+
+// ─── Client identity ──────────────────────────────────────────────────────────
+
+// Plex ties an auth token to the client identifier that requested it, so this
+// MUST be stable across restarts — regenerating it invalidates every token the
+// store holds and silently signs the user out. Persisted on first use.
+const CLIENT_ID_KEY = 'plex_client_id';
+
+function clientIdentifier(): string {
+  try {
+    const existing = localStorage?.getItem(CLIENT_ID_KEY);
+    if (existing) return existing;
+  } catch { /* private mode — fall through to an ephemeral id */ }
+  // crypto.randomUUID is present in every webview this app runs in; the
+  // fallback only matters for a non-browser test context.
+  const fresh =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? `halcyon-${crypto.randomUUID()}`
+      : `halcyon-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+  try {
+    localStorage?.setItem(CLIENT_ID_KEY, fresh);
+  } catch { /* ditto */ }
+  return fresh;
+}
+
+/** The X-Plex-* identity every request carries. */
+function plexHeaders(token?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json', // without this Plex answers in XML
+    'X-Plex-Product': PRODUCT,
+    'X-Plex-Version': VERSION,
+    'X-Plex-Client-Identifier': clientIdentifier(),
+    'X-Plex-Device': DEVICE,
+    'X-Plex-Device-Name': PRODUCT,
+    'X-Plex-Platform': PLATFORM,
+  };
+  if (token) headers['X-Plex-Token'] = token;
+  return headers;
+}
+
+// ─── Transport ────────────────────────────────────────────────────────────────
+
+/**
+ * One request to a Plex endpoint (the media server or plex.tv), routed through
+ * Tauri when running packaged and plain fetch in the browser — the same split
+ * jellyfin.ts makes, for the same reason: the packaged build has no origin a
+ * server would allow, so it can't use fetch.
+ */
+async function plexRequest(
+  method: string,
+  url: string,
+  token?: string,
+  body?: string
+): Promise<string> {
+  const headers = plexHeaders(token);
+  const hasTauri = typeof window !== 'undefined' && (window as any).__TAURI_INTERNALS__ !== undefined;
+  if (hasTauri) {
+    return await invoke<string>('plex_request', { method, url, headers, body });
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 60000);
+  try {
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: body || undefined,
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`HTTP error ${response.status}: ${text}`);
+    }
+    return await response.text();
+  } catch (e: any) {
+    clearTimeout(timeoutId);
+    if (e?.name === 'AbortError') throw new Error(`Request to ${url} timed out after 60 seconds`);
+    throw e;
+  }
+}
+
+/** GET a Plex endpoint and return its MediaContainer (never null). */
+async function plexGet(url: string, token?: string): Promise<any> {
+  const raw = await plexRequest('GET', url, token);
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(raw || 'Plex returned an invalid response.');
+  }
+  return parsed?.MediaContainer ?? {};
+}
+
+/** MediaContainer.Metadata as an array, whatever the server returned. */
+function metadataOf(container: any): any[] {
+  const meta = container?.Metadata;
+  return Array.isArray(meta) ? meta : [];
+}
+
+/** Append the token as a query param — for URLs handed to <img>/<video>/hls.js,
+ *  which can't carry an X-Plex-Token header. */
+function withToken(url: string, token: string): string {
+  return `${url}${url.includes('?') ? '&' : '?'}X-Plex-Token=${encodeURIComponent(token)}`;
+}
+
+// ─── Reaching the media server from a browser ─────────────────────────────────
+
+// A Plex Media Server reflects the request Origin only for loopback callers.
+// Every other origin gets a fixed `Access-Control-Allow-Origin:
+// https://app.plex.tv`, so a store served at http://<lan-ip>:1420 — the
+// documented HTPC deployment — has every request to the server blocked by the
+// browser, including ones the server answered 200. Plex, unlike Jellyfin, has
+// no setting to allow another origin.
+//
+// So when the page itself isn't on loopback, media-server traffic goes through
+// the dev/preview server's /plex-proxy middleware (vite.config.ts) instead:
+// same-origin to the browser, forwarded host-side where CORS doesn't apply.
+// This covers the API, poster textures (loaded with crossOrigin='anonymous',
+// so they genuinely need it) and HLS.
+//
+// plex.tv is NOT proxied — it answers `Access-Control-Allow-Origin: *`, so
+// sign-in, the link flow and the Home user list all work directly.
+//
+// The Tauri build never takes this road: its requests go through the Rust-side
+// plex_request, which no browser policy applies to.
+const PROXY_PREFIX = '/plex-proxy';
+
+function needsServerProxy(): boolean {
+  if (typeof window === 'undefined' || typeof location === 'undefined') return false;
+  if ((window as any).__TAURI_INTERNALS__ !== undefined) return false;
+  return !/^(localhost|127\.0\.0\.1|\[::1\])$/.test(location.hostname);
+}
+
+// Which base a media-server URL should be built against from here.
+function pmsUrl(realBase: string, path: string): string {
+  return (needsServerProxy() ? PROXY_PREFIX : realBase) + path;
+}
+
+// The proxy forwards to ONE registered base (see the plugin's note on why the
+// target isn't in the URL). Registration is memoized per base and re-run when
+// the store is pointed somewhere else.
+let registeredBase: string | null = null;
+let registering: Promise<void> | null = null;
+
+async function ensurePmsProxy(realBase: string): Promise<void> {
+  if (!needsServerProxy() || registeredBase === realBase) return;
+  if (!registering) {
+    registering = (async () => {
+      try {
+        await fetch(`${PROXY_PREFIX}/__target`, {
+          method: 'POST',
+          headers: { 'X-Proxy-Target': realBase },
+        });
+        registeredBase = realBase;
+      } catch (e) {
+        console.warn('[Plex] Could not register the proxy target:', e);
+      } finally {
+        registering = null;
+      }
+    })();
+  }
+  await registering;
+}
+
+/** GET a media-server endpoint, through the proxy when the origin needs it. */
+async function pmsGet(realBase: string, path: string, token?: string): Promise<any> {
+  await ensurePmsProxy(realBase);
+  return plexGet(pmsUrl(realBase, path), token);
+}
+
+/** Non-GET media-server request, same routing as pmsGet. */
+async function pmsRequest(
+  method: string,
+  realBase: string,
+  path: string,
+  token?: string,
+  body?: string
+): Promise<string> {
+  await ensurePmsProxy(realBase);
+  return plexRequest(method, pmsUrl(realBase, path), token, body);
+}
+
+// ─── Part-id bookkeeping ──────────────────────────────────────────────────────
+
+// Direct play streams `/library/parts/{partId}/file.ext`, and a rating key
+// alone cannot produce a part id — only the item's own metadata carries it.
+// buildStaticStreamUrl is synchronous (it's called before the playback-info
+// probe, see launchVideoPlayback), so the id has to already be known by then.
+//
+// Every route that reaches playback passes through one of the fetchers below
+// first — catalog sync for a film, fetchSeriesEpisodes / fetchFirstEpisode for
+// an episode, fetchItemPlaybackInfo for anything probed on demand — so each of
+// them records what it saw here. The invariant that makes a miss harmless:
+// playbackInfoFromMedia() only reports a `container` for a part it has
+// recorded, and isDirectPlaySafe() refuses anything with no container. A miss
+// therefore degrades to HLS, which always works, instead of building a URL
+// that 404s.
+const partIds = new Map<string, number>();
+
+function partKey(itemId: string, mediaIndex = 0): string {
+  return `${itemId}:${mediaIndex}`;
+}
+
+function rememberPart(itemId: string, mediaIndex: number, partId: unknown): void {
+  if (typeof partId === 'number') partIds.set(partKey(itemId, mediaIndex), partId);
+}
+
+function partIdFor(itemId: string, mediaIndex = 0): number | undefined {
+  return partIds.get(partKey(itemId, mediaIndex));
+}
+
+// ─── Field mapping ────────────────────────────────────────────────────────────
+
+/** Plex tag arrays ([{tag: "Action"}, ...]) as plain names. */
+function tags(list: any): string[] {
+  return Array.isArray(list)
+    ? list.map((t: any) => (typeof t === 'string' ? t : t?.tag)).filter((t: any): t is string => !!t)
+    : [];
+}
+
+/** TMDB id out of the item's Guid array ([{id: "tmdb://646"}, ...]). */
+function tmdbIdOf(item: any): number | undefined {
+  const guids: any[] = Array.isArray(item?.Guid) ? item.Guid : [];
+  for (const g of guids) {
+    const m = /^tmdb:\/\/(\d+)/.exec(String(g?.id ?? ''));
+    if (m) return Number(m[1]);
+  }
+  return undefined;
+}
+
+/** Absolute URL for a Plex image path, sized through the photo transcoder.
+ *
+ *  Going through /photo/:/transcode is not an optimization detail — a raw
+ *  poster off this server measured 1.4 MB, and the transcoded 400x600 version
+ *  51 KB. At a couple of thousand cases on the shelves that is the difference
+ *  between a store that boots and one that eats a gigabyte of texture memory
+ *  in posters alone. */
+function imageUrl(
+  base: string,
+  token: string,
+  path: string | undefined,
+  width: number,
+  height: number
+): string | undefined {
+  if (!path) return undefined;
+  const inner = encodeURIComponent(path);
+  // Queued, not awaited: this is sync, and every route that produces image URLs
+  // has already run a catalog fetch through pmsGet, which registers the target.
+  void ensurePmsProxy(base);
+  return withToken(
+    pmsUrl(base, `/photo/:/transcode?width=${width}&height=${height}&minSize=1&upscale=1&url=${inner}`),
+    token
+  );
+}
+
+/** HDR class from a video stream, in the vocabulary MediaPlaybackInfo uses. */
+function videoRangeOf(stream: any): string | undefined {
+  if (!stream) return undefined;
+  if (stream.DOVIPresent) return 'DOVI';
+  const trc = String(stream.colorTrc ?? '').toLowerCase();
+  if (trc === 'smpte2084') return 'HDR10';
+  if (trc === 'arib-std-b67') return 'HLG';
+  // A 10-bit source with no transfer function declared is still meaningfully
+  // "not plain SDR", but calling it HDR would put an HDR badge on ordinary
+  // 10-bit encodes — so only the explicit signals above count.
+  return 'SDR';
+}
+
+/** Audio + subtitle tracks of one Plex part, for the player's track picker. */
+function streamsFromPart(part: any): MediaStreamInfo[] | undefined {
+  const raw = part?.Stream;
+  if (!Array.isArray(raw)) return undefined;
+  const streams: MediaStreamInfo[] = raw
+    .filter((s: any) => s?.streamType === STREAM_AUDIO || s?.streamType === STREAM_SUBTITLE)
+    .filter((s: any) => typeof s?.id === 'number')
+    .map((s: any) => ({
+      // Stream.id, deliberately — see the header note. Plex's own `index` is
+      // the ffmpeg stream index and is NOT what /library/parts selects on.
+      index: s.id,
+      type: s.streamType === STREAM_AUDIO ? ('Audio' as const) : ('Subtitle' as const),
+      language: s.language || undefined,
+      displayTitle: s.extendedDisplayTitle || s.displayTitle || undefined,
+      codec: s.codec || undefined,
+      isDefault: !!s.default,
+      channels: s.streamType === STREAM_AUDIO && typeof s.channels === 'number' ? s.channels : undefined,
+    }));
+  return streams.length > 0 ? streams : undefined;
+}
+
+/** Container/codec info of one Plex Media entry. */
+function playbackInfoFromMedia(media: any, itemId: string, mediaIndex: number): MediaPlaybackInfo | undefined {
+  if (!media) return undefined;
+  const part = Array.isArray(media.Part) ? media.Part[0] : undefined;
+  const videoStream = Array.isArray(part?.Stream)
+    ? part.Stream.find((s: any) => s?.streamType === STREAM_VIDEO)
+    : undefined;
+  const audioCodecs: string[] = Array.isArray(part?.Stream)
+    ? part.Stream.filter((s: any) => s?.streamType === STREAM_AUDIO && s?.codec).map((s: any) =>
+        String(s.codec).toLowerCase()
+      )
+    : media.audioCodec
+      ? [String(media.audioCodec).toLowerCase()]
+      : [];
+  // Only claim a container when the part id is known — see the partIds note.
+  // Without it direct play can't be built, and isDirectPlaySafe treats a
+  // missing container as "not safe", which routes the title to HLS instead.
+  const known = partIdFor(itemId, mediaIndex) !== undefined;
+  return {
+    container: known && media.container ? String(media.container).toLowerCase() : undefined,
+    videoCodec: media.videoCodec ? String(media.videoCodec).toLowerCase() : undefined,
+    audioCodecs,
+    width: typeof media.width === 'number' ? media.width : undefined,
+    height: typeof media.height === 'number' ? media.height : undefined,
+    // Plex reports aspect ratio as a number (1.66); the model wants the
+    // printable form the tech-specs table shows.
+    aspectRatio: typeof media.aspectRatio === 'number' ? `${media.aspectRatio.toFixed(2)}:1` : undefined,
+    videoRange: videoRangeOf(videoStream),
+  };
+}
+
+/** Is this Media entry 4K? Plex's own bucket, cross-checked against the frame
+ *  size so an oddly-tagged entry still lands where the store expects. */
+function mediaIs4k(media: any): boolean {
+  if (String(media?.videoResolution ?? '').toLowerCase() === '4k') return true;
+  return is4kFrame(media?.width, media?.height);
+}
+
+/**
+ * One MovieVersion per Plex Media entry. Plex models alternate editions
+ * exactly the way the store does — several Media entries under one item — so
+ * this is a direct translation rather than the reconstruction Jellyfin needs.
+ * The 2+-only pruning happens later, in collapseDuplicateVersions.
+ */
+function buildVersions(item: any, itemId: string): MovieVersion[] | undefined {
+  const media: any[] = Array.isArray(item?.Media) ? item.Media : [];
+  if (media.length === 0) return undefined;
+  const versions = media.map((m: any, idx: number) => {
+    const part = Array.isArray(m.Part) ? m.Part[0] : undefined;
+    rememberPart(itemId, idx, part?.id);
+    const is4k = mediaIs4k(m);
+    const bits = [
+      qualityTag(m.width, m.height) ?? (is4k ? '4K' : undefined),
+      videoRangeOf(Array.isArray(part?.Stream) ? part.Stream.find((s: any) => s?.streamType === STREAM_VIDEO) : undefined) !== 'SDR'
+        ? videoRangeOf(Array.isArray(part?.Stream) ? part.Stream.find((s: any) => s?.streamType === STREAM_VIDEO) : undefined)
+        : undefined,
+      m.videoCodec ? String(m.videoCodec).toUpperCase() : undefined,
+      typeof part?.size === 'number' ? formatBytes(part.size) : undefined,
+    ].filter(Boolean);
+    return {
+      itemId,
+      // The transcoder addresses an alternate edition by its POSITION in
+      // Media[] (mediaIndex), not by Media.id — so the position is what the
+      // store carries as the opaque source handle.
+      mediaSourceId: String(idx),
+      label: bits.join(' · ') || 'Version',
+      is4k,
+      width: typeof m.width === 'number' ? m.width : undefined,
+      height: typeof m.height === 'number' ? m.height : undefined,
+      localPath: part?.file || undefined,
+      mediaStreams: streamsFromPart(part),
+      mediaPlaybackInfo: playbackInfoFromMedia(m, itemId, idx),
+    } satisfies MovieVersion;
+  });
+  // Two rips of the same film at the same resolution, codec and rounded size
+  // produce the same label — real in any library that ingested a file twice,
+  // and a picker row that reads identically to its neighbour tells the user
+  // nothing. Fall back to the file name, which is the thing that actually
+  // differs, and only then to a positional suffix.
+  const counts = new Map<string, number>();
+  for (const v of versions) counts.set(v.label, (counts.get(v.label) ?? 0) + 1);
+  for (const [i, v] of versions.entries()) {
+    if ((counts.get(v.label) ?? 0) < 2) continue;
+    const fileName = v.localPath?.split('/').pop();
+    v.label = fileName ? `${v.label} · ${fileName}` : `${v.label} · #${i + 1}`;
+  }
+  return versions;
+}
+
+/** Per-user watch state off the item's own fields. */
+function watchState(item: any): Partial<Movie> {
+  const viewCount = typeof item?.viewCount === 'number' ? item.viewCount : 0;
+  const lastViewedAt = typeof item?.lastViewedAt === 'number' ? item.lastViewedAt : undefined;
+  const viewOffset = typeof item?.viewOffset === 'number' ? item.viewOffset : 0;
+  return {
+    played: viewCount > 0,
+    playCount: viewCount || undefined,
+    // Plex stamps epoch SECONDS; the model wants ISO.
+    lastPlayedDate: lastViewedAt ? new Date(lastViewedAt * 1000).toISOString() : undefined,
+    resumePositionTicks: viewOffset > 0 ? viewOffset * TICKS_PER_MS : undefined,
+  };
+}
+
+/** One Plex movie/show row as the store's Movie. Exported for unit tests. */
+export function toMovie(item: any, base: string, token: string, libraryName: string): Movie {
+  const id = String(item.ratingKey);
+  const isSeries = item.type === 'show';
+  const durationMs = typeof item.duration === 'number' ? item.duration : 0;
+  const durationMin = Math.round(durationMs / 60000);
+  const media: any[] = Array.isArray(item.Media) ? item.Media : [];
+  const primary = media[0];
+  const roles: any[] = Array.isArray(item.Role) ? item.Role : [];
+  const versions = isSeries ? undefined : buildVersions(item, id);
+
+  return {
+    id,
+    title: item.title ?? 'Untitled',
+    year: typeof item.year === 'number' ? item.year : 2000,
+    premiereDate: item.originallyAvailableAt || undefined,
+    duration: isSeries ? 'Series' : durationMin > 0 ? `${durationMin}m` : 'N/A',
+    rating: item.contentRating || 'NR',
+    overview: item.summary || 'No description available.',
+    director: tags(item.Director)[0] || 'Unknown Director',
+    actors: roles.map((r: any) => r?.tag).filter(Boolean).slice(0, 5),
+    // Portraits live on plex.tv's metadata CDN and need no token, so they are
+    // used verbatim. Only present after the metadata pass — a section listing
+    // gives role tags with no id or thumb.
+    castPeople: roles
+      .filter((r: any) => r?.tag && r?.id !== undefined)
+      .slice(0, 5)
+      .map((r: any) => ({
+        id: String(r.id),
+        name: String(r.tag),
+        imageUrl: typeof r.thumb === 'string' && r.thumb ? r.thumb : undefined,
+      })),
+    genres: tags(item.Genre),
+    localPath: (Array.isArray(primary?.Part) ? primary.Part[0]?.file : undefined) || '',
+    posterUrl: imageUrl(base, token, item.thumb, 400, 600),
+    backdropUrl: imageUrl(base, token, item.art, 1280, 720),
+    // Plex stamps epoch SECONDS; the model (and the New Releases wall's
+    // ordering) wants ISO.
+    dateCreated: typeof item.addedAt === 'number' ? new Date(item.addedAt * 1000).toISOString() : '',
+    isSeries,
+    is4k: !isSeries && !!primary && mediaIs4k(primary),
+    // `audienceRating` is the viewer score on Plex's 0-10 scale, which is what
+    // the shelf's star rating expects. `rating` is the CRITIC score on the
+    // same 0-10 scale — the store's criticRating is 0-100, hence the x10.
+    // ratingImage/audienceRatingImage name the source (rottentomatoes://...)
+    // but the scales are fixed regardless of which agent supplied them.
+    communityRating: typeof item.audienceRating === 'number' ? item.audienceRating : undefined,
+    criticRating: typeof item.rating === 'number' ? Math.round(item.rating * 10) : undefined,
+    libraryName,
+    studios: item.studio ? [String(item.studio)] : [],
+    mediaStreams: isSeries ? undefined : streamsFromPart(Array.isArray(primary?.Part) ? primary.Part[0] : undefined),
+    mediaPlaybackInfo: isSeries ? undefined : playbackInfoFromMedia(primary, id, 0),
+    // Plex reports no per-item poster aspect ratio; its posters are uniformly
+    // 2:3, which is flat mode's own default, so leaving this unset is correct
+    // rather than merely convenient.
+    primaryImageAspectRatio: undefined,
+    versions,
+    // Membership rides on the item — no second pass, unlike Jellyfin. A film
+    // in several collections keeps the first one: one shelf spot.
+    collectionName: tags(item.Collection)[0] || undefined,
+    tmdbId: tmdbIdOf(item),
+    runTimeTicks: isSeries || durationMs <= 0 ? undefined : durationMs * TICKS_PER_MS,
+    ...watchState(item),
+  };
+}
+
+/** One Plex episode row as the store's Episode. Exported for unit tests. */
+export function toEpisode(item: any, base: string, token: string): Episode {
+  const id = String(item.ratingKey);
+  const media: any[] = Array.isArray(item.Media) ? item.Media : [];
+  const part = Array.isArray(media[0]?.Part) ? media[0].Part[0] : undefined;
+  rememberPart(id, 0, part?.id);
+  const durationMs = typeof item.duration === 'number' ? item.duration : 0;
+  const viewOffset = typeof item.viewOffset === 'number' ? item.viewOffset : 0;
+  return {
+    id,
+    seriesId: String(item.grandparentRatingKey ?? ''),
+    seriesName: item.grandparentTitle ?? '',
+    seasonNumber: typeof item.parentIndex === 'number' ? item.parentIndex : 0,
+    episodeNumber: typeof item.index === 'number' ? item.index : 0,
+    name: item.title ?? '',
+    overview: item.summary ?? '',
+    path: part?.file ?? '',
+    runTimeTicks: durationMs > 0 ? durationMs * TICKS_PER_MS : undefined,
+    resumePositionTicks: viewOffset > 0 ? viewOffset * TICKS_PER_MS : undefined,
+    thumbUrl: imageUrl(base, token, item.thumb, 480, 270),
+    seasonId: item.parentRatingKey !== undefined ? String(item.parentRatingKey) : undefined,
+    seasonPrimaryUrl: imageUrl(base, token, item.parentThumb, 400, 600),
+  };
+}
+
+// ─── Catalog sync ─────────────────────────────────────────────────────────────
+
+/** Video sections of the server, with the non-video ones logged and dropped. */
+async function fetchVideoSections(base: string, token: string): Promise<{ key: string; title: string; type: string }[]> {
+  const container = await pmsGet(base, '/library/sections', token);
+  const dirs: any[] = Array.isArray(container?.Directory) ? container.Directory : [];
+  return dirs
+    .filter((d: any) => {
+      const keep = d?.type === 'movie' || d?.type === 'show';
+      // Always log the verdict per section — "why is my library missing?"
+      // should be answerable from the console without a debugger.
+      console.info(
+        `[Plex] Section "${d?.title}" (type=${d?.type}): ${keep ? 'syncing' : 'skipped (non-video)'}`
+      );
+      return keep;
+    })
+    .map((d: any) => ({ key: String(d.key), title: String(d.title), type: String(d.type) }));
+}
+
+/**
+ * Second pass over a section's items: full metadata, comma-batched. This is
+ * what supplies per-track streams and cast portraits, neither of which a
+ * section listing carries. Failures degrade rather than abort — a batch that
+ * doesn't come back just leaves those titles with listing-level detail, which
+ * is enough to shelve and play them.
+ */
+async function enrichWithMetadata(
+  base: string,
+  token: string,
+  items: any[],
+  onProgress?: (stage: string) => void
+): Promise<Map<string, any>> {
+  const byId = new Map<string, any>();
+  for (let i = 0; i < items.length; i += METADATA_BATCH) {
+    const chunk = items.slice(i, i + METADATA_BATCH);
+    const keys = chunk.map((it) => it.ratingKey).join(',');
+    onProgress?.('page');
+    try {
+      const container = await pmsGet(base, `/library/metadata/${keys}`, token);
+      for (const full of metadataOf(container)) byId.set(String(full.ratingKey), full);
+    } catch (e) {
+      console.warn(`[Plex] Metadata batch ${i / METADATA_BATCH + 1} failed; using listing detail:`, e);
+    }
+  }
+  return byId;
+}
+
+/** Collection artwork + TMDB ids for one section, for the collection displays. */
+async function syncCollections(base: string, token: string, sectionKey: string): Promise<void> {
+  let container: any;
+  try {
+    container = await pmsGet(base, `/library/sections/${sectionKey}/collections?includeGuids=1`, token);
+  } catch (e) {
+    console.warn(`[Plex] Could not list collections for section ${sectionKey}:`, e);
+    return;
+  }
+  for (const col of metadataOf(container)) {
+    const name = col?.title;
+    if (!name) continue;
+    collectionSyncStats.boxSets++;
+    collectionArt.set(String(name), {
+      posterUrl: imageUrl(base, token, col.thumb, 400, 600),
+      backdropUrl: imageUrl(base, token, col.art, 1280, 720),
+    });
+    const tmdb = tmdbIdOf(col);
+    if (tmdb !== undefined) {
+      collectionTmdbIds.set(String(name), tmdb);
+      collectionSyncStats.scraped++;
+    }
+  }
+}
+
+async function fetchLibrariesAndMovies(
+  rawUrl: string,
+  token: string,
+  _userId: string,
+  onProgress?: (stage: string) => void,
+  opts?: CatalogSyncOptions
+): Promise<MediaLibrary[]> {
+  if (!token || !rawUrl) throw new Error('Missing connection credentials.');
+  const base = normalizeUrl(rawUrl);
+  console.log(`[Plex] Querying sections on ${base}...`);
+  resetCollectionState();
+
+  const sections = await fetchVideoSections(base, token);
+  rememberKnownLibraries(sections.map((s) => ({ id: s.key, name: s.title })));
+
+  const excluded = opts?.excludeLibraryIds;
+  const carried = excluded?.size
+    ? sections.filter((s) => {
+        const skip = excluded.has(s.key);
+        if (skip) {
+          console.info(
+            `[Plex] Section "${s.title}": skipped (not carried by this store — Settings → Connection → Store Libraries)`
+          );
+        }
+        return !skip;
+      })
+    : sections;
+
+  const libraries: MediaLibrary[] = [];
+  // Sections are synced one at a time rather than in parallel: a section
+  // listing plus its metadata batches is already a lot of concurrent work for
+  // a NAS-hosted server, and two sections racing measurably slowed the whole
+  // sync on the box this was written against.
+  for (const section of carried) {
+    onProgress?.(`library "${section.title}"`);
+    console.log(`[Plex] Syncing section "${section.title}" (${section.key})...`);
+    try {
+      // type=1 films / type=2 shows keeps the `collection` rows a bare /all
+      // returns out of the catalog; they're read separately for artwork.
+      const typeParam = section.type === 'show' ? '2' : '1';
+      const container = await pmsGet(
+        base,
+        `/library/sections/${section.key}/all?type=${typeParam}&includeGuids=1&includeCollections=1`,
+        token
+      );
+      const listing = metadataOf(container).filter((it: any) => it?.type === 'movie' || it?.type === 'show');
+      if (listing.length === 0) continue;
+
+      const full = await enrichWithMetadata(base, token, listing, onProgress);
+      const movies = listing.map((it: any) => {
+        // Prefer the enriched record, falling back to the listing row. The
+        // listing carries watch state that a plain metadata fetch also has, so
+        // either source is complete enough on its own.
+        const merged = full.get(String(it.ratingKey)) ?? it;
+        return toMovie(merged, base, token, section.title);
+      });
+      const collapsed = collapseDuplicateVersions(movies, `section "${section.title}"`);
+
+      const genresSet = new Set<string>();
+      collapsed.forEach((m) => m.genres.forEach((g) => genresSet.add(g)));
+
+      libraries.push({
+        id: section.key,
+        name: section.title,
+        movies: collapsed,
+        genres: Array.from(genresSet).sort(),
+      });
+
+      onProgress?.('collection membership');
+      await syncCollections(base, token, section.key);
+    } catch (err) {
+      console.error(`[Plex] Failed to sync section "${section.title}":`, err);
+    }
+  }
+
+  if (libraries.length === 0) throw new Error('No movies found in your Plex libraries.');
+  onProgress?.('done');
+  console.log(`[Plex] Successfully mapped ${libraries.length} libraries.`);
+  return libraries;
+}
+
+// ─── Series ───────────────────────────────────────────────────────────────────
+
+async function fetchSeriesEpisodes(
+  rawUrl: string,
+  token: string,
+  _userId: string,
+  seriesId: string
+): Promise<Episode[]> {
+  const base = normalizeUrl(rawUrl);
+  try {
+    // allLeaves returns every episode of the show across all seasons in one
+    // response, already in season-then-episode order.
+    const container = await pmsGet(base, `/library/metadata/${seriesId}/allLeaves`, token);
+    return metadataOf(container).map((e: any) => toEpisode(e, base, token));
+  } catch (e) {
+    console.error(`[Plex] Failed to list episodes for series ${seriesId}:`, e);
+    return [];
+  }
+}
+
+async function fetchFirstEpisodeOfSeries(
+  rawUrl: string,
+  token: string,
+  userId: string,
+  seriesId: string
+): Promise<EpisodeRef | null> {
+  const episodes = await fetchSeriesEpisodes(rawUrl, token, userId, seriesId);
+  const first = episodes[0];
+  return first ? { id: first.id, path: first.path } : null;
+}
+
+async function fetchItemPlaybackInfo(
+  rawUrl: string,
+  token: string,
+  _userId: string,
+  itemId: string
+): Promise<MediaPlaybackInfo | undefined> {
+  const base = normalizeUrl(rawUrl);
+  try {
+    const container = await pmsGet(base, `/library/metadata/${itemId}`, token);
+    const item = metadataOf(container)[0];
+    const media = Array.isArray(item?.Media) ? item.Media[0] : undefined;
+    const part = Array.isArray(media?.Part) ? media.Part[0] : undefined;
+    rememberPart(itemId, 0, part?.id);
+    return playbackInfoFromMedia(media, itemId, 0);
+  } catch (e) {
+    console.error(`[Plex] Failed to probe media info for item ${itemId}:`, e);
+    return undefined;
+  }
+}
+
+// ─── Streaming ────────────────────────────────────────────────────────────────
+
+function buildStaticStreamUrl(rawUrl: string, token: string, itemId: string, mediaSourceId?: string): string {
+  const base = normalizeUrl(rawUrl);
+  const mediaIndex = mediaSourceId ? Number(mediaSourceId) || 0 : 0;
+  const partId = partIdFor(itemId, mediaIndex);
+  if (partId === undefined) {
+    // Unreachable in practice (see the partIds note) — but if it ever happens,
+    // say so rather than handing the player a URL that 404s. The caller only
+    // uses this when isDirectPlaySafe passed, which needs a container, which
+    // playbackInfoFromMedia withholds precisely when this is unknown.
+    console.warn(`[Plex] No part id recorded for item ${itemId}; direct play unavailable.`);
+    return '';
+  }
+  // The timestamp segment real Plex clients include is optional — verified
+  // against 1.41.5, which serves the same 206 without it.
+  void ensurePmsProxy(base);
+  return withToken(pmsUrl(base, `/library/parts/${partId}/file`), token);
+}
+
+// Session handle baked into the most recently built HLS URL, so the player can
+// tear the transcode down before rebuilding it. Same contract as the Jellyfin
+// backend's PlaySessionId.
+let lastSessionId: string | undefined;
+
+function buildHlsStreamUrl(rawUrl: string, token: string, itemId: string, opts?: HlsStreamOptions): string {
+  const base = normalizeUrl(rawUrl);
+  const session = `halcyon-${itemId}-${Date.now()}`;
+  lastSessionId = session;
+
+  const hevcCopy =
+    isHevcPassThroughEnabled() && (opts?.sourceVideoCodec === 'hevc' || opts?.sourceVideoCodec === 'h265');
+  // Same reasoning as the Jellyfin path: a copy-eligible source gets the high
+  // ceiling so the server remuxes instead of re-encoding down; everything else
+  // gets the SourceBuffer-sized default. Plex counts in KILOBITS per second.
+  const maxKbps = Math.round((opts?.maxBitrate ?? (hevcCopy ? COPY_VIDEO_BITRATE : DEFAULT_VIDEO_BITRATE)) / 1000);
+
+  const params = new URLSearchParams({
+    path: `/library/metadata/${itemId}`,
+    mediaIndex: opts?.mediaSourceId ?? '0',
+    partIndex: '0',
+    protocol: 'hls',
+    fastSeek: '1',
+    // directPlay off, directStream on: let the server remux/copy whatever it
+    // can and only re-encode what it must.
+    directPlay: '0',
+    directStream: hevcCopy ? '1' : '0',
+    subtitleSize: '100',
+    audioBoost: '100',
+    location: 'lan',
+    maxVideoBitrate: String(maxKbps),
+    videoQuality: '100',
+    session,
+    'X-Plex-Client-Identifier': clientIdentifier(),
+    'X-Plex-Platform': PLATFORM,
+    'X-Plex-Token': token,
+  });
+  if (opts?.maxWidth) params.set('videoResolution', `${opts.maxWidth}x${Math.round((opts.maxWidth * 9) / 16)}`);
+  // Plex seeks a transcode with an OFFSET IN SECONDS, not a start position in
+  // the source's own units.
+  if (opts?.startPositionTicks) params.set('offset', String(Math.floor(opts.startPositionTicks / 10_000_000)));
+  // 10-bit HEVC can't be copied to a webview that only decodes Main.
+  if (hevcCopy && !isHevcMain10Supported()) params.set('videoBitDepth', '8');
+
+  // Track selection is NOT a stream-URL parameter on Plex — it's a property of
+  // the part, set with a PUT before the stream is opened (see selectTracks).
+  // Firing it here keeps buildHlsStreamUrl's synchronous signature while still
+  // honoring the picker: the PUT lands well before the first segment request,
+  // and a failed selection degrades to the container's default track rather
+  // than breaking playback.
+  if (opts?.audioStreamIndex !== undefined || opts?.subtitleStreamIndex !== undefined) {
+    void selectTracks(base, token, itemId, opts.mediaSourceId, opts.audioStreamIndex, opts.subtitleStreamIndex);
+  }
+
+  void ensurePmsProxy(base);
+  return pmsUrl(base, `/video/:/transcode/universal/start.m3u8?${params.toString()}`);
+}
+
+/**
+ * Point the item's part at specific audio/subtitle streams. Plex remembers the
+ * selection server-side per part, which is why it isn't a stream parameter.
+ * `0` is Plex's "no subtitle" sentinel, so turning captions back off is an
+ * explicit 0 rather than an omitted field.
+ */
+async function selectTracks(
+  base: string,
+  token: string,
+  itemId: string,
+  mediaSourceId?: string,
+  audioStreamIndex?: number,
+  subtitleStreamIndex?: number
+): Promise<void> {
+  const partId = partIdFor(itemId, mediaSourceId ? Number(mediaSourceId) || 0 : 0);
+  if (partId === undefined) {
+    console.warn(`[Plex] No part id for item ${itemId}; keeping the container's default tracks.`);
+    return;
+  }
+  const params = new URLSearchParams({ allParts: '1' });
+  if (audioStreamIndex !== undefined) params.set('audioStreamID', String(audioStreamIndex));
+  if (subtitleStreamIndex !== undefined) params.set('subtitleStreamID', String(subtitleStreamIndex));
+  try {
+    await pmsRequest('PUT', base, `/library/parts/${partId}?${params.toString()}`, token);
+  } catch (e) {
+    console.warn(`[Plex] Track selection failed for part ${partId}:`, e);
+  }
+}
+
+async function stopActiveEncoding(sessionId: string, log?: (msg: string) => void): Promise<void> {
+  const url = localStorage?.getItem('jellyfin_url');
+  const token = localStorage?.getItem('jellyfin_token');
+  if (!url || !token) return;
+  const base = normalizeUrl(url);
+  try {
+    await pmsRequest('GET', base, `/video/:/transcode/universal/stop?session=${encodeURIComponent(sessionId)}`, token);
+  } catch (e: any) {
+    console.warn('[Plex] Failed to stop active encoding:', e);
+    log?.(`[Player] stopActiveEncoding failed: ${e?.message ?? e}`);
+  }
+}
+
+function isStreamCopyUrl(src: string): boolean {
+  try {
+    const v = new URL(src, 'http://x').searchParams.get('maxVideoBitrate');
+    // maxVideoBitrate is in kbps here, the ceiling constant in bits/s.
+    return v !== null && Number(v) * 1000 >= COPY_VIDEO_BITRATE;
+  } catch {
+    return false;
+  }
+}
+
+// ─── Progress reporting ───────────────────────────────────────────────────────
+
+/** Plex's single timeline endpoint covers start, progress, and stop. */
+async function reportTimeline(
+  rawUrl: string,
+  token: string,
+  itemId: string,
+  state: 'playing' | 'paused' | 'stopped',
+  positionTicks: number
+): Promise<void> {
+  const base = normalizeUrl(rawUrl);
+  const params = new URLSearchParams({
+    ratingKey: itemId,
+    key: `/library/metadata/${itemId}`,
+    state,
+    time: String(Math.max(0, Math.floor(positionTicks / TICKS_PER_MS))),
+  });
+  try {
+    await pmsRequest('GET', base, `/:/timeline?${params.toString()}`, token);
+  } catch (e) {
+    console.warn(`[Plex] Failed to report ${state} for item ${itemId}:`, e);
+  }
+}
+
+// ─── Sign-in ──────────────────────────────────────────────────────────────────
+
+/** The account behind a token, as the store's session. */
+async function sessionFromToken(token: string): Promise<MediaSession> {
+  const raw = await plexRequest('GET', `${PLEX_TV}/api/v2/user`, token);
+  let account: any;
+  try {
+    account = JSON.parse(raw);
+  } catch {
+    throw new Error('Plex returned an invalid account response.');
+  }
+  if (!account?.id) throw new Error('That token does not identify a Plex account.');
+  return {
+    accessToken: token,
+    userId: String(account.id),
+    userName: String(account.username || account.title || account.email || 'Plex user'),
+  };
+}
+
+/**
+ * Plex Home members, as membership cards. Requires the account token — unlike
+ * Jellyfin there is no unauthenticated list on the server itself, because Plex
+ * keeps the user list on the account rather than the server.
+ *
+ * `protected` members need their Home PIN to switch, which the card picker
+ * collects the same way it collects a Jellyfin password.
+ */
+async function fetchPublicUsers(_url: string, token?: string): Promise<PublicUser[]> {
+  if (!token) return []; // no session yet — caller falls back to signing in
+  const raw = await plexRequest('GET', `${PLEX_TV}/api/v2/home/users`, token);
+  let data: any;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error('Plex returned an invalid Home user list.');
+  }
+  const users: any[] = Array.isArray(data?.users) ? data.users : Array.isArray(data) ? data : [];
+  return users
+    .filter((u: any) => u?.id !== undefined && (u?.title || u?.username))
+    .map((u: any) => ({
+      id: String(u.id),
+      name: String(u.title || u.username),
+      hasPassword: !!u.protected,
+      avatarUrl: typeof u.thumb === 'string' ? u.thumb : undefined,
+      switchId: u.uuid ? String(u.uuid) : undefined,
+    }));
+}
+
+/**
+ * Swap the account token for THAT Home member's own token, so the catalog
+ * carries their watch state and the timeline reports land on their history.
+ * This is the step with no Jellyfin equivalent: Jellyfin authenticates each
+ * user directly, Plex authenticates the account and then switches within it.
+ */
+async function signInAsPublicUser(
+  _url: string,
+  user: PublicUser,
+  secret?: string,
+  token?: string
+): Promise<MediaSession> {
+  if (!token) throw new Error('Sign in to the Plex account before picking a member.');
+  if (!user.switchId) throw new Error(`No Home id for "${user.name}" — sign in by name instead.`);
+  const pin = secret ? `?pin=${encodeURIComponent(secret)}` : '';
+  const raw = await plexRequest('POST', `${PLEX_TV}/api/v2/home/users/${user.switchId}/switch${pin}`, token);
+  let data: any;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error('Plex refused the member switch.');
+  }
+  if (!data?.authToken) throw new Error(`Could not switch to "${user.name}". Check the PIN.`);
+  return {
+    accessToken: String(data.authToken),
+    userId: String(data.id ?? user.id),
+    userName: String(data.title || user.name),
+  };
+}
+
+/**
+ * Sign in with a plex.tv account name and password. Kept because the setup
+ * terminal's manual screen offers it, but the link flow below is the better
+ * road on an HTPC — and an account with 2FA can only use the link flow, since
+ * this endpoint has nowhere to put the second factor.
+ */
+async function authenticateUser(_url: string, username: string, password?: string): Promise<MediaSession> {
+  const raw = await plexRequest(
+    'POST',
+    `${PLEX_TV}/api/v2/users/signin`,
+    undefined,
+    JSON.stringify({ login: username, password: password ?? '' })
+  );
+  let data: any;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error('Plex returned an invalid sign-in response.');
+  }
+  if (!data?.authToken) throw new Error('Plex refused those credentials.');
+  return {
+    accessToken: String(data.authToken),
+    userId: String(data.id ?? ''),
+    userName: String(data.username || data.title || username),
+  };
+}
+
+/**
+ * The plex.tv/link PIN flow — a four-character code the user types on another
+ * device. This is the right road on an HTPC: no keyboard needed on the box
+ * itself, and it's the only sign-in that works with 2FA.
+ */
+async function beginLink(): Promise<LinkFlow> {
+  const raw = await plexRequest('POST', `${PLEX_TV}/api/v2/pins`);
+  let pin: any;
+  try {
+    pin = JSON.parse(raw);
+  } catch {
+    throw new Error('Plex returned an invalid link code.');
+  }
+  if (!pin?.id || !pin?.code) throw new Error('Plex issued no link code.');
+
+  const expiresAt = pin.expiresAt ? Date.parse(pin.expiresAt) : Date.now() + 15 * 60 * 1000;
+  let cancelled = false;
+
+  return {
+    code: String(pin.code),
+    verificationUrl: 'plex.tv/link',
+    expiresAt,
+    cancel() {
+      cancelled = true;
+    },
+    async wait(): Promise<MediaSession | null> {
+      // 3s between polls: fast enough that approval feels immediate on the
+      // CRT, slow enough that a 15-minute code costs plex.tv ~300 requests.
+      while (!cancelled && Date.now() < expiresAt) {
+        await new Promise((r) => setTimeout(r, 3000));
+        if (cancelled) return null;
+        try {
+          const body = await plexRequest('GET', `${PLEX_TV}/api/v2/pins/${pin.id}`);
+          const state = JSON.parse(body);
+          if (state?.authToken) return await sessionFromToken(String(state.authToken));
+        } catch {
+          // A blip must not drop a linking HTPC back to the form — keep
+          // polling until the code genuinely expires.
+        }
+      }
+      return null;
+    },
+  };
+}
+
+// ─── Backend ──────────────────────────────────────────────────────────────────
+
+export const plexBackend: MediaBackend = {
+  kind: 'plex',
+  label: 'Plex',
+
+  normalizeUrl,
+
+  async identify(rawUrl: string): Promise<boolean> {
+    // /identity is Plex's unauthenticated "who am I" endpoint — it answers
+    // even on a claimed server that 401s everything else.
+    try {
+      const container = await pmsGet(normalizeUrl(rawUrl), '/identity');
+      return typeof container?.machineIdentifier === 'string';
+    } catch {
+      return false;
+    }
+  },
+
+  async validateToken(rawUrl: string, token: string): Promise<boolean> {
+    if (!rawUrl || !token) return false;
+    try {
+      await pmsGet(normalizeUrl(rawUrl), '/', token);
+      return true;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (/^HTTP error (401|403):/.test(msg)) return false;
+      throw e; // transient — never tear down a session over a blip (#125)
+    }
+  },
+
+  authenticateUser,
+  fetchPublicUsers,
+  buildUserAvatarUrl: (_url: string, user: PublicUser) => user.avatarUrl ?? null,
+  signInAsPublicUser,
+  beginLink,
+  adoptToken: (_url: string, token: string) => sessionFromToken(token),
+
+  async fetchLibraryList(rawUrl: string, token: string): Promise<LibrarySummary[]> {
+    if (!token || !rawUrl) throw new Error('Missing connection credentials.');
+    const sections = await fetchVideoSections(normalizeUrl(rawUrl), token);
+    const list = sections.map((s) => ({ id: s.key, name: s.title }));
+    rememberKnownLibraries(list);
+    return list;
+  },
+  fetchLibrariesAndMovies,
+
+  fetchSeriesEpisodes,
+  fetchFirstEpisodeOfSeries,
+
+  // Every subtitle track is burned in server-side. Plex does serve subtitle
+  // streams, but no VTT-sidecar endpoint of its has been verified against a
+  // real server, and shipping an unverified URL here would silently break
+  // captions rather than merely cost a transcode. Burn-in is what this backend
+  // has always done; the cheap road is a follow-up, gated on measuring it.
+  subtitleDelivery: (_streams, streamIndex) =>
+    streamIndex === undefined ? { kind: 'none' } : { kind: 'burn-in', streamIndex },
+  buildSubtitleTrackUrl: () => null,
+
+  fetchItemPlaybackInfo,
+  buildStaticStreamUrl,
+  buildHlsStreamUrl,
+  lastHlsPlaySessionId: () => lastSessionId,
+  stopActiveEncoding,
+  isStreamCopyUrl,
+
+  reportPlaybackStart: (url, token, itemId) => reportTimeline(url, token, itemId, 'playing', 0),
+  reportPlaybackProgress: (url, token, itemId, positionTicks, isPaused) =>
+    reportTimeline(url, token, itemId, isPaused ? 'paused' : 'playing', positionTicks),
+  reportPlaybackStopped: (url, token, itemId, positionTicks) =>
+    reportTimeline(url, token, itemId, 'stopped', positionTicks),
+};

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -917,10 +917,18 @@ export function registerCoreSettings(): void {
   // exists, but is never persisted (see commitTextSetting's special case).
   const cred = (key: string, label: string, kind: SettingKind, opts?: Partial<SettingDef>): void =>
     registerSetting({ key, label, kind, group: 'Connection', default: '', applyMode: 'reload', ...opts });
-  cred('jellyfin_url', 'Jellyfin URL', 'text');
-  cred('jellyfin_username', 'Jellyfin Username', 'text');
-  cred('jellyfin_password', 'Jellyfin Password', 'secret', {
-    hint: 'Blank keeps session. A password re-authenticates.',
+  // The url/username keys keep their historical `jellyfin_` spelling whichever
+  // server is connected (see media-backend.ts's note on why renaming them would
+  // sign every existing install out), but the LABELS are server-neutral now
+  // that a store can be supplied by either — they're read by a user who may
+  // never have run Jellyfin. Static rather than derived from the active
+  // backend: settings register before a backend is necessarily resolvable.
+  cred('jellyfin_url', 'Media Server URL', 'text', {
+    hint: 'Jellyfin or Plex — the store identifies whichever answers.',
+  });
+  cred('jellyfin_username', 'Media Server Username', 'text');
+  cred('jellyfin_password', 'Media Server Password', 'secret', {
+    hint: 'Blank keeps session. A password re-authenticates. Plex: paste a token here.',
   });
 
   cred('jellyseerr_url', 'Jellyseerr URL', 'text');

--- a/src/store-setup-flow.ts
+++ b/src/store-setup-flow.ts
@@ -16,7 +16,14 @@ import {
   fetchLibraryList,
   authenticateUser,
   normalizeUrl,
-} from './jellyfin';
+  identifyServer,
+  URL_KEY,
+  activeBackend,
+  setActiveBackendKind,
+  persistSession,
+  LAST_USER_ID_KEY,
+  type LinkFlow,
+} from './media-backend.ts';
 import {
   openMembershipCardPicker,
   isMembershipPickerOpen,
@@ -26,6 +33,8 @@ import { excludedLibraryIds, setLibraryCarried } from './library-settings';
 import {
   SetupScreen,
   SetupKey,
+  SETUP_PROVIDERS,
+  type SetupProvider,
   initialHomeScreen,
   setupScreenKey,
   setupScreenChar,
@@ -157,58 +166,179 @@ export function closeSetupTerminal(opts?: { keepCamera?: boolean }): void {
   if (!opts?.keepCamera) deps.scene()?.exitSearchMode();
 }
 
-async function dial(address: string): Promise<void> {
+// The in-flight link flow, so backing out of the screen stops its polling
+// rather than leaving it running against a code nobody will type.
+let pendingLink: LinkFlow | null = null;
+
+function cancelPendingLink(): void {
+  pendingLink?.cancel();
+  pendingLink = null;
+}
+
+/**
+ * Work out which server answers at the typed address and point the store at
+ * it. Falls back to the DISTRIBUTOR row's choice when nothing identifiable
+ * answers, so an address behind a proxy that hides the probe endpoints still
+ * connects if the user picked the right row.
+ */
+async function adoptServerKind(url: string, picked: SetupProvider): Promise<void> {
+  const detected = await identifyServer(url);
+  if (detected) {
+    setActiveBackendKind(detected);
+    deps?.log(`[Setup] ${url} answers as ${activeBackend().label}.`);
+    return;
+  }
+  // `picked` is passed in rather than read off `screen`: dial() has already
+  // replaced the home screen with the dialing one by the time this runs, so
+  // reading the DISTRIBUTOR row here found no row at all and left the store
+  // pointed at whatever it was before — which is how a dialed Plex address
+  // ended up being asked for a Jellyfin user list.
+  setActiveBackendKind(picked === 'PLEX' ? 'plex' : 'jellyfin');
+  deps?.log(`[Setup] ${url} did not identify itself; assuming ${activeBackend().label}.`);
+}
+
+/**
+ * Plex's sign-in-by-code road: show the code on the CRT, poll until the user
+ * approves it on another device, then carry on into the membership cards with
+ * the account token in hand.
+ */
+async function linkFlow(url: string): Promise<void> {
   if (!deps) return;
-  const url = normalizeUrl(address.trim());
-  // Remember the dialed server IMMEDIATELY, not at afterAuth(): both routes to
-  // the CRT sign-in screen below (an empty card list, a refused one) skip
-  // afterAuth entirely, and manualSignIn() reads pendingUrl. Without this it
-  // fell back to localStorage's jellyfin_url — unset on a true first run — and
-  // authenticated against '', i.e. the app's own origin, so a single-user
-  // Jellyfin (public card list empty) could NEVER be connected to from here.
-  pendingUrl = url;
-  screen = { kind: 'dialing', address: url, step: 'LOOKING UP MEMBERSHIP CARDS...' };
+  const backend = activeBackend();
+  if (!backend.beginLink) return;
+  let flow: LinkFlow;
+  try {
+    flow = await backend.beginLink(url);
+  } catch (e: any) {
+    deps.log(`[Setup] Could not get a link code: ${e?.message ?? e}`);
+    // No route to plex.tv (offline box, locked-down network) — the manual
+    // screen still works, and for Plex it accepts a pasted token.
+    screen = { kind: 'manual-auth', row: 0, username: '', password: '',
+               error: 'NO LINK CODE. SIGN IN BY NAME.' };
+    render();
+    return;
+  }
+  pendingLink = flow;
+  screen = {
+    kind: 'link',
+    provider: backend.label.toUpperCase(),
+    code: flow.code,
+    verificationUrl: flow.verificationUrl,
+    step: 'WAITING FOR APPROVAL...',
+  };
   render();
+
+  const session = await flow.wait();
+  if (pendingLink !== flow) return; // cancelled or superseded while waiting
+  pendingLink = null;
+  if (!session) {
+    screen = { ...initialHomeScreen(url), row: 1, error: 'LINK CODE EXPIRED. TRY AGAIN.' };
+    render();
+    return;
+  }
+  deps.log(`[Setup] Linked to ${backend.label} as ${session.userName}.`);
+  await offerMembers(url, session.accessToken, session);
+}
+
+/**
+ * Fan the server's users out as membership cards, or fall through to signing
+ * in by name when it lists none. Shared by both roads into the store: a
+ * Jellyfin dial (no token yet) and a completed Plex link (account token).
+ */
+async function offerMembers(
+  url: string,
+  token: string | undefined,
+  fallback?: MembershipLoginSession
+): Promise<void> {
+  if (!deps) return;
   let users;
   try {
-    users = await fetchPublicUsers(url);
+    users = await fetchPublicUsers(url, token);
   } catch (e: any) {
     const msg = String(e?.message ?? e);
     deps.log(`[Setup] No membership card list from ${url}: ${msg}`);
+    if (fallback) {
+      // Already authenticated (a completed link) — a missing card list is not
+      // a reason to make the user sign in a second time.
+      await afterAuth(url, fallback);
+      return;
+    }
     // A server that ANSWERED and refused the list (public users switched off,
-    // a reverse proxy blocking /Users/Public) is perfectly usable — it just
+    // a reverse proxy blocking the endpoint) is perfectly usable — it just
     // can't fan the cards out. Sign in by name instead of dead-ending on the
     // home screen, which is what the DOM login form has always done. Only a
     // server that said nothing at all is a bad address.
     screen = /HTTP error \d+/.test(msg)
       ? { kind: 'manual-auth', row: 0, username: '', password: '',
           error: 'NO CARD LIST HERE. SIGN IN BY NAME.' }
-      : { ...initialHomeScreen(address), row: 1, error: 'NO ANSWER. CHECK THE ADDRESS + CORS.' };
+      : { ...initialHomeScreen(url), row: 1, error: 'NO ANSWER. CHECK THE ADDRESS + CORS.' };
     render();
     return;
   }
-  if (users.length > 0) {
-    deps.log(`[Setup] Found ${users.length} membership card(s) on ${url}.`);
-    screen = { kind: 'members', count: users.length };
-    render();
-    openMembershipCardPicker({
-      serverUrl: url,
-      users,
-      lastUserId: localStorage.getItem('jellyfin_last_userid'),
-      onLogin: (session) => afterAuth(url, session),
-      // "Sign in manually" from the picker lands on the CRT sign-in screen —
-      // the DOM login form is no longer part of first-run.
-      onManualLogin: () => {
-        screen = { kind: 'manual-auth', row: 0, username: '', password: '' };
-        render();
-      },
-      onDemoMode: () => runDemo(),
-      log: (msg) => deps?.log(msg),
-    });
-  } else {
+  if (users.length === 0) {
+    // Plex already authenticated the ACCOUNT to get here, so a Home list that
+    // comes back empty (a solo account has no Home members) means the account
+    // itself is the member — carry straight on rather than asking again.
+    if (fallback) {
+      await afterAuth(url, fallback);
+      return;
+    }
     screen = { kind: 'manual-auth', row: 0, username: '', password: '' };
     render();
+    return;
   }
+  deps.log(`[Setup] Found ${users.length} membership card(s) on ${url}.`);
+  screen = { kind: 'members', count: users.length };
+  render();
+  openMembershipCardPicker({
+    serverUrl: url,
+    users,
+    sessionToken: token,
+    lastUserId: localStorage.getItem(LAST_USER_ID_KEY),
+    onLogin: (session) => afterAuth(url, session),
+    // "Sign in manually" from the picker lands on the CRT sign-in screen —
+    // the DOM login form is no longer part of first-run.
+    onManualLogin: () => {
+      screen = { kind: 'manual-auth', row: 0, username: '', password: '' };
+      render();
+    },
+    onDemoMode: () => runDemo(),
+    log: (msg) => deps?.log(msg),
+  });
+}
+
+async function dial(address: string): Promise<void> {
+  if (!deps) return;
+  // Read the DISTRIBUTOR row BEFORE the screen is replaced below — it is the
+  // fallback when the address doesn't identify itself.
+  const picked: SetupProvider = screen.kind === 'home' ? SETUP_PROVIDERS[screen.provider] : 'JELLYFIN';
+  const url = normalizeUrl(address.trim());
+  // Remember the dialed server IMMEDIATELY, not at afterAuth(): every route to
+  // the CRT sign-in screen below (an empty card list, a refused one, an
+  // expired link code) skips afterAuth entirely, and manualSignIn() reads
+  // pendingUrl. Without this it fell back to the stored URL — unset on a true
+  // first run — and authenticated against '', i.e. the app's own origin, so a
+  // single-user server (public card list empty) could NEVER be connected to
+  // from here.
+  pendingUrl = url;
+  cancelPendingLink();
+
+  screen = { kind: 'dialing', address: url, step: 'IDENTIFYING DISTRIBUTOR...' };
+  render();
+  await adoptServerKind(url, picked);
+
+  // A backend with a link flow (Plex) has to authenticate the ACCOUNT before
+  // it can list anyone, so the code screen comes first and the cards follow
+  // it. A backend without one (Jellyfin) serves its card list unauthenticated
+  // and goes straight there.
+  if (activeBackend().beginLink) {
+    await linkFlow(url);
+    return;
+  }
+
+  screen = { kind: 'dialing', address: url, step: 'LOOKING UP MEMBERSHIP CARDS...' };
+  render();
+  await offerMembers(url, undefined);
 }
 
 async function manualSignIn(): Promise<void> {
@@ -225,11 +355,24 @@ async function manualSignIn(): Promise<void> {
   }
   screen = { kind: 'dialing', address: url, step: `SIGNING IN ${username.toUpperCase().slice(0, 26)}...` };
   render();
+  const backend = activeBackend();
   try {
     const session = await authenticateUser(url, username.trim(), password);
     await afterAuth(url, session);
   } catch (e: any) {
     const msg = String(e?.message ?? e);
+    // Escape hatch: a backend that can adopt a raw token (Plex) accepts one
+    // pasted into the NAME field with no password. That covers the cases the
+    // link flow can't — an account with 2FA, a box with no route to plex.tv,
+    // a scripted deploy — without a screen of its own.
+    if (backend.adoptToken && !password) {
+      try {
+        const session = await backend.adoptToken(url, username.trim());
+        deps.log(`[Setup] Adopted a pasted ${backend.label} token.`);
+        await afterAuth(url, session);
+        return;
+      } catch { /* not a token either — report the original failure below */ }
+    }
     screen = {
       kind: 'manual-auth', row: 2, username, password: '',
       error: msg.includes('401') ? 'SIGN-IN REFUSED. CHECK NAME + PASSWORD.' : 'SIGN-IN FAILED. SERVER UNREACHABLE.',
@@ -243,10 +386,7 @@ async function afterAuth(url: string, session: MembershipLoginSession): Promise<
   if (!deps) return;
   pendingUrl = url;
   pendingSession = session;
-  localStorage.setItem('jellyfin_url', url);
-  localStorage.setItem('jellyfin_token', session.accessToken);
-  localStorage.setItem('jellyfin_userid', session.userId);
-  localStorage.setItem('jellyfin_last_userid', session.userId);
+  persistSession(activeBackend().kind, url, session);
   deps.log(`[Setup] Authenticated as ${session.userName}.`);
   screen = { kind: 'dialing', address: url, step: 'PULLING THE CATALOG LIST...' };
   render();
@@ -321,8 +461,13 @@ export async function setupTerminalInput(kind: SetupKey): Promise<void> {
     case 'sign-in':
       await manualSignIn();
       return;
+    case 'cancel-link':
+      cancelPendingLink();
+      screen = initialHomeScreen(pendingUrl || localStorage.getItem(URL_KEY));
+      render();
+      return;
     case 'back-home':
-      screen = initialHomeScreen(pendingUrl || localStorage.getItem('jellyfin_url'));
+      screen = initialHomeScreen(pendingUrl || localStorage.getItem(URL_KEY));
       render();
       return;
     case 'open-store':

--- a/src/store-setup-screens.ts
+++ b/src/store-setup-screens.ts
@@ -19,10 +19,22 @@ export type SetupAction =
   | 'change-server' // notice: drop the saved server, back to a blank home
   | 'open-store'    // libraries: choices made, sync + stock
   | 'sign-in'       // manual-auth: authenticate the typed name/password
+  | 'cancel-link'   // link: abandon the pending code and go back
   | 'back-home';    // manual-auth: abandon sign-in
 
-/** One provider row today; the list is the seam PLEX (#32) slots into. */
-export const SETUP_PROVIDERS = ['JELLYFIN'] as const;
+/** Distributors this store can be supplied by (#32). The row is a manual
+ *  override AND the fallback: dial() probes the typed address and switches to
+ *  whatever actually answers, so the row only decides the default port and
+ *  what to assume when nothing identifiable answers. */
+export const SETUP_PROVIDERS = ['JELLYFIN', 'PLEX'] as const;
+
+export type SetupProvider = (typeof SETUP_PROVIDERS)[number];
+
+/** Default address per provider, offered before the user types their own. */
+export const SETUP_PROVIDER_DEFAULTS: Record<SetupProvider, string> = {
+  JELLYFIN: 'http://localhost:8096',
+  PLEX: 'http://localhost:32400',
+};
 
 export interface SetupLibraryRow {
   id: string;
@@ -38,6 +50,7 @@ export type SetupScreen =
   | { kind: 'members'; count: number }
   | { kind: 'manual-auth'; row: number; username: string; password: string; error?: string }
   | { kind: 'libraries'; rows: SetupLibraryRow[]; row: number; error?: string }
+  | { kind: 'link'; provider: string; code: string; verificationUrl: string; step: string }
   | { kind: 'sync'; stage: string; pages: number }
   | { kind: 'arriving' }
   | { kind: 'notice'; address: string; detail: string; row: number };
@@ -98,6 +111,10 @@ export function setupScreenKey(s: SetupScreen, key: SetupKey): { state: SetupScr
       }
       return { state: s };
     }
+    case 'link':
+      // The code is live and being polled; the only thing to decide here is
+      // whether to abandon it.
+      return key === 'back' ? { state: s, action: 'cancel-link' } : { state: s };
     case 'dialing':
     case 'members':
     case 'sync':
@@ -195,6 +212,24 @@ export function setupScreenLines(s: SetupScreen): { lines: string[]; cursorLine:
           s.step.slice(0, 40),
         ],
         cursorLine: 5,
+      };
+    case 'link':
+      return {
+        lines: [
+          'NEW STORE SETUP — OPENING DAY',
+          '',
+          `LINK THIS STORE TO ${s.provider}.`.slice(0, 40),
+          '',
+          'ON ANOTHER DEVICE, OPEN',
+          `  ${s.verificationUrl}`.slice(0, 40),
+          'AND ENTER THIS CODE:',
+          '',
+          // The code is the whole point of the screen — centred and spaced so
+          // it reads across a room from the CRT.
+          `        ${s.code.split('').join(' ')}`.slice(0, 40),
+          s.step.slice(0, 40),
+        ],
+        cursorLine: 8,
       };
     case 'members':
       return {

--- a/src/video-player.ts
+++ b/src/video-player.ts
@@ -1,5 +1,5 @@
 import type Hls from 'hls.js';
-import { stopActiveEncoding, getLastHlsPlaySessionId, isStreamCopyUrl } from './jellyfin';
+import { stopActiveEncoding, getLastHlsPlaySessionId, isStreamCopyUrl } from './media-backend.ts';
 
 let HlsMod: typeof import('hls.js').default | null = null;
 async function loadHls() {

--- a/tests/plex-mapping.test.ts
+++ b/tests/plex-mapping.test.ts
@@ -1,0 +1,265 @@
+// Plex → domain-model mapping. The fixtures below are trimmed from real
+// responses of a Plex Media Server 1.41.5, because the shapes that matter here
+// are exactly the ones documentation gets wrong: which rating is on which
+// scale, where HDR is signalled, and the difference between a Stream's `id`
+// (what track selection uses) and its `index` (the ffmpeg one, which silently
+// selects the wrong track).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// plex.ts reaches for localStorage to keep its client identifier stable.
+(globalThis as any).localStorage ??= {
+  _s: new Map<string, string>(),
+  getItem(k: string) { return this._s.get(k) ?? null; },
+  setItem(k: string, v: string) { this._s.set(k, v); },
+  removeItem(k: string) { this._s.delete(k); },
+};
+
+const { toMovie, toEpisode } = await import('../src/plex.ts');
+
+const BASE = 'http://plex.local:32400';
+const TOKEN = 'tok';
+
+/** Trimmed from /library/metadata/11373 — Dr. No, in a hand-made collection. */
+const DR_NO = {
+  ratingKey: '11373',
+  type: 'movie',
+  title: 'Agent 007 med rätt att döda',
+  originalTitle: 'Dr. No',
+  studio: 'EON Productions',
+  contentRating: 'PG',
+  summary: 'James Bond möter Dr. No.',
+  rating: 9.5,          // critic, 0-10
+  audienceRating: 8.2,  // viewers, 0-10
+  year: 1962,
+  originallyAvailableAt: '1962-10-10',
+  thumb: '/library/metadata/11373/thumb/1784580524',
+  art: '/library/metadata/11373/art/1784580524',
+  duration: 6590416,    // ms
+  addedAt: 1784578406,  // epoch SECONDS
+  viewCount: 2,
+  lastViewedAt: 1784600000,
+  Guid: [{ id: 'imdb://tt0055928' }, { id: 'tmdb://646' }, { id: 'tvdb://450' }],
+  Genre: [{ tag: 'Action' }, { tag: 'Adventure' }],
+  Collection: [{ tag: 'James Bond' }],
+  Director: [{ tag: 'Terence Young' }],
+  Role: [
+    { id: 578, tag: 'Sean Connery', role: 'James Bond', thumb: 'https://metadata-static.plex.tv/a.jpg' },
+    { id: 71571, tag: 'Ursula Andress', role: 'Honey Ryder' },
+  ],
+  Media: [{
+    id: 14108, duration: 6590416, width: 1808, height: 1080, aspectRatio: 1.66,
+    audioCodec: 'dca', videoCodec: 'h264', videoResolution: '1080', container: 'mkv',
+    Part: [{
+      id: 14108, key: '/library/parts/14108/1784471753/file.mkv',
+      file: '/volume1/Movies/Dr. No (1962)/dr.no.mkv', size: 5399241794, container: 'mkv',
+      Stream: [
+        { id: 3, streamType: 1, codec: 'h264', index: 0, width: 1808, height: 1080 },
+        { id: 4, streamType: 2, codec: 'dca', index: 1, channels: 6, language: 'English',
+          displayTitle: 'English (DTS 5.1)', default: true },
+        { id: 5, streamType: 3, codec: 'srt', index: 2, language: 'Svenska', displayTitle: 'Svenska' },
+      ],
+    }],
+  }],
+};
+
+test('maps the core shelf fields off a section item', () => {
+  const m = toMovie(DR_NO, BASE, TOKEN, 'Filmer');
+  assert.equal(m.id, '11373');
+  assert.equal(m.title, 'Agent 007 med rätt att döda');
+  assert.equal(m.year, 1962);
+  assert.equal(m.premiereDate, '1962-10-10');
+  assert.equal(m.duration, '110m');
+  assert.equal(m.rating, 'PG');
+  assert.equal(m.director, 'Terence Young');
+  assert.deepEqual(m.genres, ['Action', 'Adventure']);
+  assert.equal(m.libraryName, 'Filmer');
+  assert.deepEqual(m.studios, ['EON Productions']);
+  assert.equal(m.collectionName, 'James Bond');
+  assert.equal(m.tmdbId, 646);
+  assert.equal(m.isSeries, false);
+  assert.equal(m.localPath, '/volume1/Movies/Dr. No (1962)/dr.no.mkv');
+});
+
+test('keeps the two rating scales apart', () => {
+  const m = toMovie(DR_NO, BASE, TOKEN, 'Filmer');
+  // audienceRating is already the model's 0-10 star scale...
+  assert.equal(m.communityRating, 8.2);
+  // ...while criticRating is a 0-100 percentage, so the 0-10 critic score x10.
+  assert.equal(m.criticRating, 95);
+});
+
+test('converts Plex milliseconds to the store ticks', () => {
+  const m = toMovie(DR_NO, BASE, TOKEN, 'Filmer');
+  assert.equal(m.runTimeTicks, 6590416 * 10_000);
+});
+
+test('converts epoch seconds to ISO for the New Releases wall', () => {
+  const m = toMovie(DR_NO, BASE, TOKEN, 'Filmer');
+  assert.equal(m.dateCreated, new Date(1784578406 * 1000).toISOString());
+  assert.equal(m.played, true);
+  assert.equal(m.playCount, 2);
+  assert.equal(m.lastPlayedDate, new Date(1784600000 * 1000).toISOString());
+});
+
+test('carries audio/subtitle tracks keyed on the Plex stream id, not its ffmpeg index', () => {
+  const m = toMovie(DR_NO, BASE, TOKEN, 'Filmer');
+  const audio = m.mediaStreams!.filter((s) => s.type === 'Audio');
+  const subs = m.mediaStreams!.filter((s) => s.type === 'Subtitle');
+  assert.equal(audio.length, 1);
+  assert.equal(subs.length, 1);
+  // Stream.id === 4, Stream.index === 1. Selecting on the index picks the
+  // wrong track, so the model must carry the id.
+  assert.equal(audio[0].index, 4);
+  assert.equal(audio[0].channels, 6);
+  assert.equal(audio[0].isDefault, true);
+  assert.equal(subs[0].index, 5);
+  assert.equal(subs[0].language, 'Svenska');
+  // The video stream is not a selectable track.
+  assert.ok(!m.mediaStreams!.some((s) => s.index === 3));
+});
+
+test('routes posters through the photo transcoder rather than the raw image', () => {
+  const m = toMovie(DR_NO, BASE, TOKEN, 'Filmer');
+  assert.match(m.posterUrl!, /\/photo\/:\/transcode\?/);
+  assert.match(m.posterUrl!, /width=400&height=600/);
+  assert.match(m.posterUrl!, /X-Plex-Token=tok/);
+  assert.ok(m.posterUrl!.includes(encodeURIComponent('/library/metadata/11373/thumb/1784580524')));
+});
+
+test('takes cast portraits verbatim and drops the ones with none', () => {
+  const m = toMovie(DR_NO, BASE, TOKEN, 'Filmer');
+  assert.deepEqual(m.actors, ['Sean Connery', 'Ursula Andress']);
+  assert.equal(m.castPeople![0].imageUrl, 'https://metadata-static.plex.tv/a.jpg');
+  assert.equal(m.castPeople![1].imageUrl, undefined);
+});
+
+test('reports a container only once the part id is known, so a miss falls back to HLS', () => {
+  // A fresh item whose part carries no id: direct play cannot be addressed, so
+  // withholding the container is what makes isDirectPlaySafe refuse it.
+  const noPart = {
+    ...DR_NO, ratingKey: '999',
+    Media: [{ ...DR_NO.Media[0], Part: [{ ...DR_NO.Media[0].Part[0], id: undefined }] }],
+  };
+  const m = toMovie(noPart, BASE, TOKEN, 'Filmer');
+  assert.equal(m.mediaPlaybackInfo!.container, undefined);
+  // The codec is still reported — it only drives the transcode hint.
+  assert.equal(m.mediaPlaybackInfo!.videoCodec, 'h264');
+
+  // With a part id present the container comes through.
+  const ok = toMovie(DR_NO, BASE, TOKEN, 'Filmer');
+  assert.equal(ok.mediaPlaybackInfo!.container, 'mkv');
+  assert.equal(ok.mediaPlaybackInfo!.aspectRatio, '1.66:1');
+});
+
+test('flags Dolby Vision and HDR10 off the video stream, not the codec', () => {
+  const dovi = {
+    ...DR_NO, ratingKey: '2001',
+    Media: [{ ...DR_NO.Media[0], videoResolution: '4k', width: 3840, height: 2076, videoCodec: 'hevc',
+      Part: [{ ...DR_NO.Media[0].Part[0], id: 2073,
+        Stream: [{ id: 1, streamType: 1, codec: 'hevc', bitDepth: 10, colorTrc: 'bt709', DOVIPresent: true }] }] }],
+  };
+  assert.equal(toMovie(dovi, BASE, TOKEN, 'F').mediaPlaybackInfo!.videoRange, 'DOVI');
+
+  const hdr10 = structuredClone(dovi);
+  (hdr10 as any).Media[0].Part[0].Stream[0] = { id: 1, streamType: 1, codec: 'hevc', colorTrc: 'smpte2084' };
+  assert.equal(toMovie(hdr10, BASE, TOKEN, 'F').mediaPlaybackInfo!.videoRange, 'HDR10');
+
+  // A plain 10-bit encode with no transfer function declared is NOT HDR —
+  // badging it would put an HDR sticker on ordinary anime rips.
+  const plain10 = structuredClone(dovi);
+  (plain10 as any).Media[0].Part[0].Stream[0] = { id: 1, streamType: 1, codec: 'hevc', bitDepth: 10 };
+  assert.equal(toMovie(plain10, BASE, TOKEN, 'F').mediaPlaybackInfo!.videoRange, 'SDR');
+});
+
+test("takes Plex's own 4K bucket, and the frame size when it disagrees", () => {
+  const tagged = { ...DR_NO, ratingKey: '3001', Media: [{ ...DR_NO.Media[0], videoResolution: '4k' }] };
+  assert.equal(toMovie(tagged, BASE, TOKEN, 'F').is4k, true);
+  // Untagged but plainly 4K by frame size.
+  const bySize = { ...DR_NO, ratingKey: '3002',
+    Media: [{ ...DR_NO.Media[0], videoResolution: '', width: 3840, height: 2160 }] };
+  assert.equal(toMovie(bySize, BASE, TOKEN, 'F').is4k, true);
+  assert.equal(toMovie(DR_NO, BASE, TOKEN, 'F').is4k, false);
+});
+
+test('turns several Media entries into version choices, addressed by position', () => {
+  const twin = {
+    ...DR_NO, ratingKey: '4001',
+    Media: [
+      { ...DR_NO.Media[0], videoResolution: '4k', width: 3840, height: 2160, videoCodec: 'hevc',
+        Part: [{ id: 900, file: '/m/a-4k.mkv', size: 54_000_000_000, Stream: [] }] },
+      { ...DR_NO.Media[0], Part: [{ id: 901, file: '/m/a-1080.mkv', size: 8_000_000_000, Stream: [] }] },
+    ],
+  };
+  const m = toMovie(twin, BASE, TOKEN, 'F');
+  assert.equal(m.versions!.length, 2);
+  // The transcoder addresses an edition by its POSITION in Media[].
+  assert.deepEqual(m.versions!.map((v) => v.mediaSourceId), ['0', '1']);
+  assert.equal(m.versions![0].is4k, true);
+  assert.match(m.versions![0].label, /4K/);
+  assert.match(m.versions![0].label, /HEVC/);
+  assert.match(m.versions![0].label, /50\.3 GB/);
+  assert.equal(m.versions![1].localPath, '/m/a-1080.mkv');
+});
+
+test('disambiguates two versions that would otherwise read identically', () => {
+  const dupe = {
+    ...DR_NO, ratingKey: '4002',
+    Media: [
+      { ...DR_NO.Media[0], Part: [{ id: 910, file: '/m/freelance.remux.mkv', size: 1_500_000_000, Stream: [] }] },
+      { ...DR_NO.Media[0], Part: [{ id: 911, file: '/m/freelance.webdl.mkv', size: 1_500_000_000, Stream: [] }] },
+    ],
+  };
+  const labels = toMovie(dupe, BASE, TOKEN, 'F').versions!.map((v) => v.label);
+  assert.notEqual(labels[0], labels[1]);
+  assert.match(labels[0], /freelance\.remux\.mkv/);
+  assert.match(labels[1], /freelance\.webdl\.mkv/);
+});
+
+test('a series is a container: no versions, no streams, no runtime', () => {
+  const show = {
+    ratingKey: '11104', type: 'show', title: '100 höjdare', year: 2004,
+    summary: '', thumb: '/library/metadata/11104/thumb/1', duration: 1448472,
+    childCount: 2, leafCount: 19, Genre: [{ tag: 'Comedy' }], Role: [],
+  };
+  const m = toMovie(show, BASE, TOKEN, 'TV-serier');
+  assert.equal(m.isSeries, true);
+  assert.equal(m.duration, 'Series');
+  assert.equal(m.versions, undefined);
+  assert.equal(m.mediaStreams, undefined);
+  assert.equal(m.mediaPlaybackInfo, undefined);
+  assert.equal(m.runTimeTicks, undefined);
+  assert.equal(m.is4k, false);
+});
+
+test('maps an episode with its season/series references', () => {
+  const ep = {
+    ratingKey: '11106', type: 'episode', title: 'Sveriges roligaste ögonblick 100-89',
+    summary: 'Nedräkningen börjar.', index: 1, parentIndex: 1,
+    grandparentRatingKey: 11104, grandparentTitle: '100 höjdare',
+    parentRatingKey: 11105, parentThumb: '/library/metadata/11105/thumb/2',
+    thumb: '/library/metadata/11106/thumb/3', duration: 1448472, viewOffset: 60000,
+    Media: [{ id: 1, Part: [{ id: 77, file: '/tv/s01e01.avi', Stream: [] }] }],
+  };
+  const e = toEpisode(ep, BASE, TOKEN);
+  assert.equal(e.id, '11106');
+  assert.equal(e.seriesId, '11104');
+  assert.equal(e.seriesName, '100 höjdare');
+  assert.equal(e.seasonNumber, 1);
+  assert.equal(e.episodeNumber, 1);
+  assert.equal(e.path, '/tv/s01e01.avi');
+  assert.equal(e.runTimeTicks, 1448472 * 10_000);
+  assert.equal(e.resumePositionTicks, 60000 * 10_000);
+  assert.equal(e.seasonId, '11105');
+  assert.ok(e.thumbUrl!.includes('photo/:/transcode'));
+  assert.ok(e.seasonPrimaryUrl!.includes(encodeURIComponent('/library/metadata/11105/thumb/2')));
+});
+
+test('an unwatched title reports no resume position', () => {
+  const fresh = { ...DR_NO, ratingKey: '5001', viewCount: undefined, lastViewedAt: undefined };
+  const m = toMovie(fresh, BASE, TOKEN, 'F');
+  assert.equal(m.played, false);
+  assert.equal(m.playCount, undefined);
+  assert.equal(m.resumePositionTicks, undefined);
+  assert.equal(m.lastPlayedDate, undefined);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -422,6 +422,114 @@ function integrationProxyPlugin() {
   };
 }
 
+// Reverse proxy for a PLEX MEDIA SERVER, which cannot be reached directly from
+// a browser served on anything but loopback.
+//
+// Measured against PMS 1.41.5: it reflects the request Origin only for
+// localhost / 127.0.0.1, and answers every other origin with a fixed
+// `Access-Control-Allow-Origin: https://app.plex.tv` — so a store served at
+// http://<lan-ip>:1420 (the documented HTPC deployment) has every request to
+// it blocked, including the ones that succeed with a 200. Unlike Jellyfin,
+// Plex has no setting to add an allowed origin. The Tauri build sidesteps this
+// through its Rust-side plex_request; a browser build needs this.
+//
+// Why not /dev-proxy: that one carries the destination in an X-Proxy-Target
+// header, and the things that break here are <img> textures and hls.js segment
+// requests, neither of which can set headers. So the destination has to live in
+// the URL — and to keep that from being an open proxy, it is not IN the URL:
+// the client POSTs the base once (custom header, so a cross-origin caller
+// needs a preflight this never approves), and every later request is forwarded
+// to THAT base only. A foreign page therefore cannot repoint it, and the worst
+// it could do is reach a Plex server the user already configured.
+function plexProxyPlugin() {
+  const PREFIX = "/plex-proxy";
+  let base: string | null = null;
+
+  async function handler(req: any, res: any, next: any) {
+    if (!req.url.startsWith(PREFIX)) return next();
+    const rest = req.url.slice(PREFIX.length);
+
+    // Registration: POST /plex-proxy/__target with X-Proxy-Target.
+    if (rest.startsWith("/__target")) {
+      const target = String(req.headers["x-proxy-target"] || "");
+      if (!/^https?:\/\/[^/]+$/.test(target.replace(/\/$/, ""))) {
+        res.statusCode = 400;
+        res.end("bad or missing X-Proxy-Target");
+        return;
+      }
+      base = target.replace(/\/$/, "");
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
+
+    if (!base) {
+      res.statusCode = 409;
+      res.end("no Plex target registered");
+      return;
+    }
+
+    try {
+      const headers: Record<string, string> = {};
+      // Everything Plex authenticates and negotiates on, plus Range so seeking
+      // a direct-played file still works through the hop.
+      for (const [k, v] of Object.entries(req.headers)) {
+        if (k === "accept" || k === "range" || k === "content-type" || k.startsWith("x-plex-")) {
+          headers[k] = String(v);
+        }
+      }
+      const method = String(req.method || "GET");
+      const chunks: Buffer[] = [];
+      if (method !== "GET" && method !== "HEAD") for await (const c of req) chunks.push(c);
+
+      const upstream = await fetch(base + rest, {
+        method,
+        headers,
+        body: chunks.length ? Buffer.concat(chunks) : undefined,
+      });
+
+      res.statusCode = upstream.status;
+      for (const h of ["content-type", "content-range", "accept-ranges", "cache-control"]) {
+        const v = upstream.headers.get(h);
+        if (v) res.setHeader(h, v);
+      }
+      // Content-Length is forwarded ONLY when the upstream body wasn't encoded.
+      // fetch() negotiates gzip and transparently DECODES the body, so the
+      // upstream Content-Length describes the compressed bytes, not the ones
+      // being written here — passing it through truncates the response at the
+      // compressed length. That silently cut Plex's /identity JSON from 162
+      // bytes to 152, so it no longer parsed and the store decided the address
+      // wasn't a Plex server at all. Without the header Node falls back to
+      // chunked encoding, which is correct for any length; a 206 still carries
+      // its Content-Range, so seeking a direct-played file is unaffected.
+      if (!upstream.headers.get("content-encoding")) {
+        const len = upstream.headers.get("content-length");
+        if (len) res.setHeader("content-length", len);
+      }
+      // Streamed, not buffered: this carries multi-GB direct-play bodies and
+      // HLS segments, and Buffer.concat on those would put the whole film in
+      // the dev server's heap.
+      if (!upstream.body) return res.end();
+      // @ts-expect-error node:stream has no type declarations here (see header)
+      const { Readable } = await import("node:stream");
+      Readable.fromWeb(upstream.body as any).pipe(res);
+    } catch (err) {
+      res.statusCode = 502;
+      res.end(String(err));
+    }
+  }
+
+  return {
+    name: "plex-proxy",
+    configureServer(server: any) {
+      server.middlewares.use(handler);
+    },
+    configurePreviewServer(server: any) {
+      server.middlewares.use(handler);
+    },
+  };
+}
+
 // Same rules vite applies to a Host header (see isHostAllowedWithoutCache):
 // raw IPs and localhost always pass, entries match exactly, and a leading dot
 // matches the domain plus its subdomains.
@@ -503,6 +611,7 @@ export default defineConfig(async () => ({
     feedbackPinPlugin(),
     mpvPlayerPlugin(),
     integrationProxyPlugin(),
+    plexProxyPlugin(),
     remotePlayPlugin(),
   ],
 


### PR DESCRIPTION
The media layer was Jellyfin-shaped throughout: jellyfin.ts owned the client, the library sync, artwork URLs, watch state and the playback hand-off, and it also owned the domain model, so ~60 modules imported the Jellyfin client just to get at `Movie`. This puts a seam in the middle of that and stands a second server up on the other side of it (#32).

The split:

  media-types.ts   the domain model — no server in it
  media-shared.ts  logic belonging to the store or the webview rather than the
                   server: duplicate-version collapsing, direct-play safety,
                   the collection side-tables, the transcode ceilings
  media-backend.ts the MediaBackend contract, the active-backend registry, and
                   a facade whose functions carry the same names and signatures
                   the app has always called
  jellyfin.ts      backend #1, now 400 lines lighter
  plex.ts          backend #2

Call sites keep calling free functions and the facade routes each one to whichever backend the store is pointed at. That is what kept this to 8 touched call-site files instead of ~60, and it means a call site never has to know which server it is talking to.

Storage keys keep their historical `jellyfin_` spelling: renaming them would sign every existing install out on upgrade for no user-visible gain. Only the server KIND is new, and its absence means Jellyfin — correct for every store that existed before this.

Plex specifics, all of them measured against a real 1.41.5 server rather than taken from documentation:

- Sign-in is the plex.tv/link PIN flow, shown on the counter terminal — no keyboard needed on an HTPC, and the only road that works with 2FA. A pasted X-Plex-Token is accepted too, for headless and scripted deploys.
- Membership cards are Plex Home members; picking one switches to that member's own token so watch state lands on their history.
- A section listing arrives whole, and /library/metadata takes comma-separated rating keys, so full metadata for 339 films is ~7 requests. A 458-title library syncs in about 3 seconds.
- Collection membership rides on the item, so there is no membership pass. Plex collections carry no TMDB id, but mergeCollectionGaps already resolves one through a member title, so collection gaps still work.
- Track selection is keyed on Stream.id, not the ffmpeg Stream.index.

A Plex Media Server only allows browser requests from loopback, answering every other origin with a fixed app.plex.tv CORS header, and unlike Jellyfin has no setting to add one. A store served over the LAN would therefore have every request to it blocked. Media-server traffic from a non-loopback origin is routed through the app's own /plex-proxy instead, host-side, where CORS does not apply; this covers the API, poster textures and HLS. plex.tv itself answers `*` and is not proxied. The desktop build never takes this road.


Claude-Session: https://claude.ai/code/session_01JNcD8ekwbV1CtHW8kcmQ5X