### PR TITLE
Release v0.6.2: the cornice turns the stepped corner, and the bag keeps its contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "halcyon-video",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "halcyon-video",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/checkout-bag.ts
+++ b/src/checkout-bag.ts
@@ -133,6 +133,7 @@ interface BagItem {
 // Scratch (module-level, zero per-frame allocations)
 const _v = new THREE.Vector3();
 const _v2 = new THREE.Vector3();
+const _v3 = new THREE.Vector3();
 const _q = new THREE.Quaternion();
 const _e = new THREE.Euler();
 const _exitQ = new THREE.Quaternion();
@@ -154,6 +155,11 @@ export class CheckoutBag {
   private prev: Float32Array;
   private rest: Float32Array;
   private nodeCount: number;
+  // Which sheet each node belongs to: +1 front, -1 back, 0 for the side-seam
+  // columns (one node serves both sheets there, so it has no side of its own).
+  // collideItems() uses this to keep a sheet in front of the contents it is
+  // supposed to be covering — see the wrong-side branch there.
+  private sheetSide: Int8Array;
   // vertex -> node (verts duplicate nodes only at UV seams)
   private vertNode: Int16Array;
   // constraints
@@ -266,6 +272,22 @@ export class CheckoutBag {
     this.rest = rest;
     this.pos = new Float32Array(rest);
     this.prev = new Float32Array(rest);
+
+    const sheetSide = new Int8Array(this.nodeCount);
+    for (let r = 0; r <= ROWS; r++) {
+      for (let i = 0; i < COLS; i++) {
+        const seam = i === 0 || i === COLS - 1;
+        sheetSide[F(r, i)] = seam ? 0 : 1;
+        if (!seam) sheetSide[B(r, i)] = -1;
+      }
+    }
+    for (let t = 0; t < 2; t++) {
+      for (let i = TAB_I0; i <= TAB_I1; i++) {
+        sheetSide[FT(t, i)] = 1;
+        sheetSide[BT(t, i)] = -1;
+      }
+    }
+    this.sheetSide = sheetSide;
 
     // ── Vertices / UVs / faces ─────────────────────────────────────────────
     // The print maps u = 0..1 left→right ON EACH OUTWARD FACE (the back sheet
@@ -951,6 +973,13 @@ export class CheckoutBag {
       const hy = it.hy + margin;
       const hz = it.hz + margin;
       const r2 = it.radius * it.radius;
+      // Which way the case's own +z points in bag space. The slots tilt every
+      // case (ITEM_SLOTS rotX/rotY), so the plane through its faces is tilted
+      // too, and a FRONT-sheet node above the case's centre line lands on the
+      // NEGATIVE side of it. Resolving that node to the nearest face shoves the
+      // plastic BEHIND the case, which is what left the clamshell standing
+      // outside the bag. Nodes are therefore kept on their own sheet's side.
+      const frontFacing = _v3.set(0, 0, 1).applyQuaternion(m.quaternion).z >= 0 ? 1 : -1;
       for (let i = 0; i < n; i++) {
         const b = i * 3;
         const wx = pos[b] - px;
@@ -965,7 +994,9 @@ export class CheckoutBag {
         const dx = hx - ax;
         const dy = hy - ay;
         const dz = hz - az;
-        if (dz <= dx && dz <= dy) _v.z = _v.z >= 0 ? hz : -hz;
+        const wantZ = this.sheetSide[i] * frontFacing;
+        if (wantZ !== 0 && (_v.z >= 0 ? 1 : -1) !== wantZ) _v.z = wantZ * hz;
+        else if (dz <= dx && dz <= dy) _v.z = _v.z >= 0 ? hz : -hz;
         else if (dx <= dy) _v.x = _v.x >= 0 ? hx : -hx;
         else _v.y = _v.y >= 0 ? hy : -hy;
         _v.applyQuaternion(m.quaternion);
@@ -995,8 +1026,13 @@ export class CheckoutBag {
         const dx = hx - ax;
         const dy = hy - ay;
         const dz = hz - az;
+        // Only an edge whose two ends share a sheet has a side to be kept on;
+        // the seam edges that stitch front to back legitimately cross over.
+        const sideA = this.sheetSide[conA[k]];
+        const wantZ = (sideA === this.sheetSide[conB[k]] ? sideA : 0) * frontFacing;
         _v2.set(0, 0, 0);
-        if (dz <= dx && dz <= dy) _v2.z = _v.z >= 0 ? dz : -dz;
+        if (wantZ !== 0 && (_v.z >= 0 ? 1 : -1) !== wantZ) _v2.z = wantZ * hz - _v.z;
+        else if (dz <= dx && dz <= dy) _v2.z = _v.z >= 0 ? dz : -dz;
         else if (dx <= dy) _v2.x = _v.x >= 0 ? dx : -dx;
         else _v2.y = _v.y >= 0 ? dy : -dy;
         _v2.applyQuaternion(m.quaternion);

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,22 +21,27 @@ import {
   JellyfinLibrary,
   fetchFirstEpisodeOfSeries,
   fetchSeriesEpisodes,
-  reportPlaybackStart,
-  reportPlaybackStopped,
-  reportPlaybackProgress,
-  buildHlsStreamUrl,
   isHevcPassThroughEnabled,
-  buildStaticStreamUrl,
   buildSubtitleTrackUrl,
   pickSubtitleDelivery,
-  isDirectPlaySafe,
-  fetchItemPlaybackInfo,
   MediaPlaybackInfo,
   MovieVersion,
   Episode,
   collectionTmdbIds,
   collectionSyncStats
 } from './jellyfin';
+// Playback endpoints differ per backend; this routes them (GH #32). The
+// catalog went through the provider in 0.5.3 and playback did not, which was
+// invisible until a second backend existed.
+import {
+  directStreamUrl,
+  transcodeStreamUrl,
+  probeItemPlaybackInfo,
+  playbackIsDirectSafe,
+  playbackStarted,
+  playbackProgressed,
+  playbackStopped,
+} from './playback-routing';
 import {
   fetchComingSoonMovies,
   fetchDiscoverMovies,
@@ -3183,7 +3188,7 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
 
   ui.isPlaybackActive = true;
 
-  const staticSrc = buildStaticStreamUrl(jellyfinUrl, token, playbackId, mediaSourceId);
+  const staticSrc = directStreamUrl(jellyfinUrl, token, playbackId, mediaSourceId);
 
   // Decide direct-play vs. HLS transcode from the item's real container/codecs
   // BEFORE playing: WebKitGTK silently drops audio tracks whose codec isn't in
@@ -3192,7 +3197,7 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
   // Movies carry this info from the catalog sync (Fields=MediaSources); a
   // series episode (overrideItemId) isn't in the catalog, so probe it here.
   const mediaInfo: MediaPlaybackInfo | undefined = overrideItemId
-    ? (userId ? await fetchItemPlaybackInfo(jellyfinUrl, token, userId, playbackId) : undefined)
+    ? (userId ? await probeItemPlaybackInfo(jellyfinUrl, token, userId, playbackId) : undefined)
     : (version?.mediaPlaybackInfo ?? movie.mediaPlaybackInfo);
   // Codec hint for buildHlsStreamUrl: HEVC sources get hevc pass-through
   // (fMP4) when the webview can decode it; everything else stays on TS.
@@ -3256,8 +3261,8 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
   // Direct play can't switch audio tracks, and burned-in subtitles are encoded
   // server-side — either forces the HLS transcode path. Text subtitles no
   // longer do.
-  const directPlayable = isDirectPlaySafe(mediaInfo) && initialAudioIndex === undefined && burnInSubtitleIndex === undefined;
-  const hlsSrc = buildHlsStreamUrl(jellyfinUrl, token, playbackId, {
+  const directPlayable = playbackIsDirectSafe(mediaInfo) && initialAudioIndex === undefined && burnInSubtitleIndex === undefined;
+  const hlsSrc = transcodeStreamUrl(jellyfinUrl, token, playbackId, {
     sourceVideoCodec,
     mediaSourceId,
     audioStreamIndex: initialAudioIndex,
@@ -3280,7 +3285,7 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
   // Fire-and-forget: awaiting here would sever the user-gesture chain before
   // video.play(), tripping autoplay policy. (It never rejects — errors are
   // caught and logged inside.)
-  void reportPlaybackStart(jellyfinUrl, token, playbackId);
+  playbackStarted(jellyfinUrl, token, playbackId);
 
   // Yield GPU/CPU to the decoder (only if not hidden). Diegetic playback
   // keeps the renderer alive — the room IS the screen (ambient TVs are
@@ -3319,10 +3324,10 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
     // to dismiss the controls doesn't dump the viewer at the storefront.
     // Couch playback (diegetic) just returns to the room, no confirm needed.
     confirmExit: !diegetic,
-    buildStream: (sel) => buildHlsStreamUrl(jellyfinUrl, token, playbackId, { ...sel, sourceVideoCodec, mediaSourceId }),
+    buildStream: (sel) => transcodeStreamUrl(jellyfinUrl, token, playbackId, { ...sel, sourceVideoCodec, mediaSourceId }),
     log: (msg) => logToConsole(msg, 'video'),
     onProgress: (positionTicks, isPaused) => {
-      reportPlaybackProgress(jellyfinUrl, token, playbackId, positionTicks, isPaused);
+      playbackProgressed(jellyfinUrl, token, playbackId, positionTicks, isPaused);
     },
     onClose: (positionTicks, endedNaturally) => {
       ui.isPlaybackActive = false;
@@ -3330,7 +3335,7 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
         // The WebGL context died while the movie played; the store behind the
         // player is a dead canvas. Report the stop, then take the reload we
         // deferred instead of "resuming" a frozen scene. Issue #70.
-        reportPlaybackStopped(jellyfinUrl, token, playbackId, positionTicks);
+        playbackStopped(jellyfinUrl, token, playbackId, positionTicks, movie.runTimeTicks);
         logToConsole('[System] Applying deferred context-loss reload...', 'system');
         setTimeout(() => location.reload(), 250);
         return;
@@ -3344,7 +3349,7 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
       // for STARTING a title, not for continuing one.
       const nextEp = markWatchedAndFindNext(movie, endedNaturally, seriesQueue, playbackId, () => storeScene?.restockSlottedFixtures());
       if (nextEp) {
-        reportPlaybackStopped(jellyfinUrl, token, playbackId, positionTicks);
+        playbackStopped(jellyfinUrl, token, playbackId, positionTicks, movie.runTimeTicks);
         logToConsole(`[Video] "${movie.title}" — up next: ${episodeLabel(nextEp)}.`, 'video');
         // Diegetic playback keeps the room on screen (the overlay is
         // transparent there), so only the fullscreen path bridges the gap.
@@ -3363,7 +3368,7 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
       // renderer/ambient state was never paused for diegetic playback.
       if (diegetic) {
         storeScene?.detachBackRoomVideo();
-        reportPlaybackStopped(jellyfinUrl, token, playbackId, positionTicks);
+        playbackStopped(jellyfinUrl, token, playbackId, positionTicks, movie.runTimeTicks);
         logToConsole(`[Video] Stopped "${movie.title}". Back on the couch.`, 'video');
         return;
       }
@@ -3373,7 +3378,7 @@ export async function launchVideoPlayback(movie: Movie, overrideItemId?: string,
       // so shelves can be picked right away.
       storeScene?.returnToEntrance();
       updateMovieHUD(storeScene?.getSelectedMovie() || null);
-      reportPlaybackStopped(jellyfinUrl, token, playbackId, positionTicks);
+      playbackStopped(jellyfinUrl, token, playbackId, positionTicks, movie.runTimeTicks);
       logToConsole(`[Video] Stopped "${movie.title}". Returned through the entrance.`, 'video');
     },
     onFatalError: () => {

--- a/src/playback-routing.ts
+++ b/src/playback-routing.ts
@@ -1,0 +1,147 @@
+// Which backend's playback endpoints the player talks to (GH #32).
+//
+// The catalog went through the provider in 0.5.3, but PLAYBACK did not:
+// main.ts still called jellyfin.ts's stream builders and report functions
+// directly. That was harmless while Jellyfin was the only backend and became a
+// real bug the moment Plex landed — a Plex install browsed fine and then built
+// `/Videos/<id>/stream` URLs against a server that has no such route, so
+// pressing play did nothing and no resume point was ever written.
+//
+// This module is the seam, deliberately SYNCHRONOUS for the URL builders: the
+// player rebuilds its stream URL inside a user-gesture chain (`buildStream`)
+// and inside track-switch callbacks, and awaiting there would sever the gesture
+// and trip autoplay policy. MediaSourceProvider.resolvePlaybackSource is async
+// because a backend may have to probe, so it is the wrong shape for those call
+// sites; the per-backend sync builders are what this routes to.
+//
+// Jellyfin's path is byte-identical to what it was — same functions, same
+// arguments, same order.
+import { activeProviderKind } from './providers/provider-registry.ts';
+import {
+  buildStaticStreamUrl,
+  buildHlsStreamUrl,
+  fetchItemPlaybackInfo,
+  reportPlaybackStart,
+  reportPlaybackProgress,
+  reportPlaybackStopped,
+} from './jellyfin.ts';
+import {
+  buildPlexHlsStreamUrl,
+  fetchPlexItemPlaybackInfo,
+  reportPlexPlaybackProgress,
+  reportPlexPlaybackStopped,
+} from './plex.ts';
+import { isDirectPlaySafe as codecsAreDirectPlaySafe } from './playback-capability.ts';
+import type { MediaPlaybackInfo } from './providers/media-source-provider.ts';
+
+const isPlex = () => activeProviderKind() === 'plex';
+
+export interface StreamUrlOptions {
+  sourceVideoCodec?: string;
+  mediaSourceId?: string;
+  audioStreamIndex?: number;
+  subtitleStreamIndex?: number;
+  startPositionTicks?: number;
+  maxBitrate?: number;
+  maxWidth?: number;
+}
+
+/**
+ * Whether the raw file is safe to hand the webview.
+ *
+ * Always FALSE on Plex, and not because Plex can't direct-play: its direct URL
+ * is addressed by a Part key that only a per-item metadata request returns, and
+ * this decision is made synchronously with nothing but the item's codecs in
+ * hand. Plex's `directStream=1` transcode stream-copies a compatible file
+ * anyway, so the cost of routing every Plex title through it is a remux at
+ * worst, not a re-encode — the wrong trade would be blocking the gesture chain
+ * on a probe to save it.
+ */
+export function playbackIsDirectSafe(info: MediaPlaybackInfo | undefined | null): boolean {
+  if (isPlex()) return false;
+  return codecsAreDirectPlaySafe(info);
+}
+
+/** The untouched-file URL. Only ever consulted when playbackIsDirectSafe(). */
+export function directStreamUrl(
+  server: string,
+  token: string,
+  itemId: string,
+  mediaSourceId?: string
+): string {
+  if (isPlex()) {
+    // Unreachable while playbackIsDirectSafe() is false for Plex; kept correct
+    // rather than throwing, so a future direct path can't silently serve a
+    // Jellyfin URL.
+    return buildPlexHlsStreamUrl(server, token, itemId, { mediaSourceId }).url;
+  }
+  return buildStaticStreamUrl(server, token, itemId, mediaSourceId);
+}
+
+/** The transcode/HLS URL. */
+export function transcodeStreamUrl(
+  server: string,
+  token: string,
+  itemId: string,
+  opts: StreamUrlOptions
+): string {
+  if (isPlex()) {
+    // Plex selects audio/subtitle tracks through its own transcode-decision
+    // parameters rather than the stream indices Jellyfin takes; the picker's
+    // per-track switching is Jellyfin-only for now (see the README note).
+    return buildPlexHlsStreamUrl(server, token, itemId, {
+      maxBitrate: opts.maxBitrate,
+      startPositionTicks: opts.startPositionTicks,
+      mediaSourceId: opts.mediaSourceId,
+    }).url;
+  }
+  return buildHlsStreamUrl(server, token, itemId, opts);
+}
+
+/** Codec/container probe for an item the catalog didn't carry one for. */
+export async function probeItemPlaybackInfo(
+  server: string,
+  token: string,
+  userId: string,
+  itemId: string
+): Promise<MediaPlaybackInfo | undefined> {
+  if (isPlex()) {
+    return (await fetchPlexItemPlaybackInfo(server, token, itemId)).info;
+  }
+  return fetchItemPlaybackInfo(server, token, userId, itemId);
+}
+
+export function playbackStarted(server: string, token: string, itemId: string): void {
+  // Plex has no "started" write outside a timeline session; its first progress
+  // ping is what registers the play. See plex.ts's note on /:/timeline.
+  if (isPlex()) return;
+  void reportPlaybackStart(server, token, itemId);
+}
+
+export function playbackProgressed(
+  server: string,
+  token: string,
+  itemId: string,
+  positionTicks: number,
+  isPaused: boolean
+): void {
+  if (isPlex()) {
+    void reportPlexPlaybackProgress(server, token, itemId, positionTicks);
+    return;
+  }
+  void reportPlaybackProgress(server, token, itemId, positionTicks, isPaused);
+}
+
+export function playbackStopped(
+  server: string,
+  token: string,
+  itemId: string,
+  positionTicks: number,
+  runTimeTicks?: number
+): void {
+  if (isPlex()) {
+    void reportPlexPlaybackStopped(server, token, itemId, positionTicks, runTimeTicks);
+    return;
+  }
+  void reportPlaybackStopped(server, token, itemId, positionTicks);
+}

--- a/src/providers/active-provider.ts
+++ b/src/providers/active-provider.ts
@@ -3,27 +3,17 @@
 // next). Kept apart from provider-registry.ts because the registry is about
 // what this BUILD can speak, and this is about what this INSTALL is pointed
 // at; conflating them is how a second backend ends up half-selected.
-import { createProvider, DEFAULT_PROVIDER_KIND } from './provider-registry';
+import { createProvider, activeProviderKind, PROVIDER_KIND_KEY } from './provider-registry';
 import { registerBuiltInProviders } from './index';
 import type { MediaSourceProvider, ProviderSession } from './media-source-provider';
 
-/** Where the chosen backend is remembered. Absent on every install that
- *  predates the boundary, which is why reads fall back to Jellyfin rather than
- *  prompting — an existing store must boot into its own library with nobody
- *  touching a setting. */
-export const PROVIDER_KIND_KEY = 'provider_kind';
+// Which kind an install uses now lives in provider-registry.ts, so that reading
+// it doesn't drag in the implementations: playback-routing.ts needs the kind on
+// a synchronous path, and a test needs it without loading Tauri. Re-exported
+// because this is where callers already look for it.
+export { PROVIDER_KIND_KEY, activeProviderKind };
 
 let cached: MediaSourceProvider | null = null;
-
-export function activeProviderKind(): string {
-  try {
-    return localStorage.getItem(PROVIDER_KIND_KEY) || DEFAULT_PROVIDER_KIND;
-  } catch {
-    // Private-mode/locked storage: a store that can't read a preference should
-    // still open, on the backend every existing install uses.
-    return DEFAULT_PROVIDER_KIND;
-  }
-}
 
 /** Resolved once: the kind can't change without a reconnect, and constructing
  *  a provider is cheap but not free. */

--- a/src/providers/provider-registry.ts
+++ b/src/providers/provider-registry.ts
@@ -20,6 +20,25 @@ const registry = new Map<string, ProviderFactory>();
  *  the migration a no-op for them. */
 export const DEFAULT_PROVIDER_KIND = 'jellyfin';
 
+/** Where the chosen backend is remembered. Lives here rather than in
+ *  active-provider.ts because reading it must not drag in the registered
+ *  implementations: playback-routing.ts needs the KIND on a hot, synchronous
+ *  path, and tests need it without loading Tauri. active-provider.ts
+ *  re-exports both for its existing callers. */
+export const PROVIDER_KIND_KEY = 'provider_kind';
+
+/** Which backend THIS INSTALL is pointed at. Absent on every install that
+ *  predates the boundary, which is why it falls back to Jellyfin rather than
+ *  prompting — an existing store must boot into its own library untouched. */
+export function activeProviderKind(): string {
+  try {
+    return localStorage.getItem(PROVIDER_KIND_KEY) || DEFAULT_PROVIDER_KIND;
+  } catch {
+    // Private-mode/locked storage: still open, on the backend everyone uses.
+    return DEFAULT_PROVIDER_KIND;
+  }
+}
+
 export function registerProvider(kind: string, factory: ProviderFactory): void {
   registry.set(kind, factory);
 }

--- a/src/store-shell.ts
+++ b/src/store-shell.ts
@@ -2811,35 +2811,29 @@ export function buildCeilingFrame(scene: StoreScene, storeWidth: number, backWal
   let seamBackX = rightEdge - band;
   let seamRightZ = zBack + band;
   if (scene.hasStep) {
-    // Diagonal run across the stepped corner (issue #53): a single straight
-    // mirror band from the end of the back edge (stepX, zBack) to the start
-    // of the right edge (rightEdge, stepZ) — one hypotenuse instead of the
-    // old step-front + connector pair (one fewer Reflector, no zig-zag).
-    // Its chrome body is part of the mitred ring below.
-    const diagDX = rightEdge - stepX;
-    const diagDZ = stepZ - zBack;
-    const diagLen = Math.hypot(diagDX, diagDZ);
-    const diagYaw = -Math.atan2(diagDZ, diagDX);
-    const diagNX = -diagDZ / diagLen; // inward normal (into the store)
-    const diagNZ = diagDX / diagLen;
-    // Where the diagonal's inner (mirror) face meets the back run's face
-    // (z = zBack + bo) and the right run's face (x = rightEdge - bo). The
-    // mirror strips of all three runs extend to exactly these two points so
-    // the band reads as one continuous surface around the stepped corner
-    // instead of leaving chrome-only gaps at the seams.
-    const diagUX = diagDX / diagLen, diagUZ = diagDZ / diagLen;
-    const diagS1 = (bo * (1 - diagNZ)) / diagUZ; // param along the diag face at the back seam
-    const diagS2 = (diagDX - bo * (1 + diagNX)) / diagUX; // param at the right seam
-    seamBackX = stepX + diagNX * bo + diagS1 * diagUX;
-    seamRightZ = zBack + diagNZ * bo + diagS2 * diagUZ;
-    const diagSMid = (diagS1 + diagS2) / 2;
+    // The cornice turns the stepped corner the way the WALL turns it — back
+    // run, connector, stepped-forward face — each run held off its own wall
+    // face by WALL_GAP, exactly as the 1990 wall stripe traces it
+    // (wall-stripe-1990.ts).
+    //
+    // This replaces a single hypotenuse from (stepX, zBack) to (rightEdge,
+    // stepZ). That chord was cheaper by one Reflector, but the step does not
+    // cut the corner off — it leaves a SOLID block at the back right, and the
+    // chord ran straight through it. The block's inner corner stood 3.1 ft
+    // proud of the chord on the 'wide' setting and 2.2 ft on the default,
+    // both deeper than the 1.8 ft band, so the gold wall sheared clean
+    // through chrome and mirror alike (feedback/062).
+    seamBackX = stepX - bo;
+    seamRightZ = stepZ + bo;
+    // Connector (runs along Z at x = stepX, faces -X into the room).
     addEdge(
-      diagS2 - diagS1,
-      new THREE.Vector3(
-        stepX + diagNX * bo + diagSMid * diagUX, mirrorY,
-        zBack + diagNZ * bo + diagSMid * diagUZ
-      ),
-      diagYaw
+      stepZ - zBack,
+      new THREE.Vector3(stepX - bo, mirrorY, (zBack + stepZ) / 2 + bo), -Math.PI / 2
+    );
+    // Stepped-forward face (runs along X at z = stepZ, faces +Z).
+    addEdge(
+      rightEdge - stepX,
+      new THREE.Vector3((stepX + rightEdge) / 2 - bo, mirrorY, stepZ + bo), 0
     );
   }
   // Chrome body: the whole cornice as ONE mitred ring strip, front-left
@@ -2854,7 +2848,10 @@ export function buildCeilingFrame(scene: StoreScene, storeWidth: number, backWal
       { x: leftEdge, z: zBack },
       { x: stepX, z: zBack },
     ];
-    if (scene.hasStep) plan.push({ x: rightEdge, z: stepZ });
+    if (scene.hasStep) {
+      plan.push({ x: stepX, z: stepZ });      // connector, along the step's -X face
+      plan.push({ x: rightEdge, z: stepZ });  // the stepped-forward face
+    }
     plan.push({ x: rightEdge, z: zFront });
     plan.push({ x: STORE_CENTER_X + connectHalfB, z: zFront });
     buildBodyRing(plan);

--- a/tests/playback-routing.test.ts
+++ b/tests/playback-routing.test.ts
@@ -1,0 +1,89 @@
+// The playback path has to follow the SAME backend the catalog came from.
+//
+// This is regression cover for a bug that shipped in v0.6.0: the catalog moved
+// behind the provider in 0.5.3 but playback did not, so a Plex install browsed
+// its own library and then built Jellyfin `/Videos/<id>/stream` URLs against a
+// Plex server — no playback, and no resume point ever written. Nothing caught
+// it because with one backend the two paths were indistinguishable.
+//
+// These assertions are about WHICH server's endpoints get addressed. They are
+// cheap, and they are the thing that stays true when a third backend lands.
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// activeProviderKind() reads localStorage; Node has none. Shim before import.
+const store = new Map<string, string>();
+(globalThis as any).localStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => void store.set(k, String(v)),
+  removeItem: (k: string) => void store.delete(k),
+  clear: () => store.clear(),
+};
+
+const {
+  directStreamUrl,
+  transcodeStreamUrl,
+  playbackIsDirectSafe,
+} = await import('../src/playback-routing.ts');
+
+const SERVER = 'http://media.local:32400';
+const MP4 = { container: 'mp4', videoCodec: 'h264', audioCodecs: ['aac'] };
+
+beforeEach(() => store.clear());
+const useBackend = (kind: string) => store.set('provider_kind', kind);
+
+test('an install with no provider_kind still behaves as Jellyfin', () => {
+  const url = transcodeStreamUrl(SERVER, 'tok', '42', {});
+  assert.match(url, /\/Videos\/42\//, 'installs predating the boundary must not change');
+});
+
+test('Jellyfin routes to Jellyfin endpoints', () => {
+  useBackend('jellyfin');
+  assert.match(directStreamUrl(SERVER, 'tok', '42'), /\/Videos\/42\//);
+  assert.match(transcodeStreamUrl(SERVER, 'tok', '42', {}), /\/Videos\/42\//);
+  assert.equal(playbackIsDirectSafe(MP4), true, 'a plain mp4/h264/aac is direct-playable');
+});
+
+test('Plex routes to Plex endpoints, and never to a Jellyfin route', () => {
+  useBackend('plex');
+  const hls = transcodeStreamUrl(SERVER, 'tok', '42', {});
+  assert.match(hls, /\/video\/:\/transcode\/universal\/start\.m3u8/);
+  assert.match(hls, /X-Plex-Token=tok/);
+  assert.doesNotMatch(hls, /\/Videos\//, 'the bug this file exists for');
+
+  // Even the direct builder — unreachable today, see playbackIsDirectSafe —
+  // must not fabricate a Jellyfin URL if a future direct path calls it.
+  assert.doesNotMatch(directStreamUrl(SERVER, 'tok', '42'), /\/Videos\//);
+});
+
+test('Plex declines synchronous direct play regardless of codecs', () => {
+  useBackend('plex');
+  assert.equal(
+    playbackIsDirectSafe(MP4),
+    false,
+    "Plex's direct URL needs a Part key no synchronous caller holds; its " +
+      'directStream transcode stream-copies a compatible file anyway'
+  );
+});
+
+test('switching backend switches the playback path with no reload', () => {
+  useBackend('jellyfin');
+  assert.match(transcodeStreamUrl(SERVER, 'tok', '7', {}), /\/Videos\/7\//);
+  useBackend('plex');
+  assert.match(transcodeStreamUrl(SERVER, 'tok', '7', {}), /transcode\/universal/);
+});
+
+test('a resume position survives into the stream URL on both backends', () => {
+  const oneMinute = 60 * 10_000_000; // ticks
+  useBackend('jellyfin');
+  assert.match(
+    transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    /StartTimeTicks=600000000/
+  );
+  useBackend('plex');
+  assert.match(
+    transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    /offset=60/,
+    'Plex takes seconds where Jellyfin takes ticks'
+  );
+});


### PR DESCRIPTION
Two visual bugs the owner reported, plus a verification pass over the Plex backend that shipped in v0.6.1.

## The ceiling cornice sheared through the stepped corner

- The cornice cut the back-right corner off with **one diagonal chord**, end of the back run straight to the start of the right run — but the step doesn't cut that corner off, it leaves a **solid block**, and the chord ran through it.
- The block's inner corner stood **3.1 ft** proud of the chord on `wide` and **2.2 ft** on the default, both deeper than the 1.8 ft band, so the wall sheared through chrome and mirror together.
- Now turns the corner the way the wall does — back run, connector, stepped-forward face — each held off its own wall face by the same standoff the rest of the ring uses. Same path `wall-stripe-1990.ts` already traces.
- Costs one extra Reflector; mirrors share one global refresh budget, so that is close to free.
- Verified on all four `bb_corner` settings (wide / standard / shallow / none).

## A checked-out clamshell stood outside the bag

- Cases land in **tilted** slots, so a front-sheet cloth node above the case's centre line sits on the negative side of the case's own tilted plane.
- `collideItems()` resolved each node to its nearest box face — the **back** one for those nodes — so the solver pushed the plastic behind the case and left the clamshell outside it, from settle through the whole walk-out.
- The bag is two sheets, so each node now carries which one it belongs to and a node on the far side is sent back to its own side instead of out the nearest face.
- Measured, bag-local: frontmost cloth node over the case went **z=0.011 → z=0.177** against a case reaching z=0.111 — from 0.10 ft of case sticking out to 0.066 ft of plastic covering it.
- Solver still reaches sleep on the same beat, so the idle store is unaffected.

## Plex (v0.6.1) re-verified, no changes needed

- **236/236** unit tests, including the mock-server `plex-catalog` suite.
- `verify_plex.mjs` against a live PMS 1.43.3: catalog, guids, collections, series→episodes, resume write-then-read-back, real streams (direct play `206 video/mp4`, HLS playlist). All passed.
- `verify_plex_app.mjs` end to end: real plex.tv code minted, store stocked from Plex, nothing fell back to Jellyfin — and every play request went to `/video/:/transcode/universal`, **none** to a Jellyfin `/Videos/` route.
- Built bundle greps clean for `scrobble`, `plex-token`, `includeGuids`, `resolvePlaybackSource` — the check that caught the v0.6.0 tree-shaking bug.

## Not verified

- No perf trace run; neither change touches the frame path, and the bag solver was checked only for **reaching sleep**, not for frame cost.
- Nav-state suite not run — no nav or overlay surface changed.
- Cornice checked in `bb-1993` only; other themes share the same geometry path but were not shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ao5sS692CKaLMuQUqMGGK
