### PR TITLE
Release v0.7.7: let the image build see the provider-boundary guard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@
 !src
 !public
 !tools/check-file-budget.mjs
+!tools/check-provider-boundary.mjs
 !tools/list-slots.mjs
 !tools/remote-play-server.mjs
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "halcyon-video",
   "private": true,
-  "version": "0.7.6",
+  "version": "0.7.7",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Follow-up to v0.7.6, whose Docker image failed to publish on both architectures.

- `.dockerignore` is a whitelist, so a new script in the build chain must be re-included by name. The provider-boundary guard added with the Plex episode fix was not, and the image build died on `Cannot find module /app/tools/check-provider-boundary.mjs`.
- **A plain `git clone` build was never affected** — the file is tracked and ships in the release tree. Only the image's build context lacked it.
- v0.7.6's tag stays where it is; published tags never move.

Verified by building the image locally, end to end, before tagging.