### PR TITLE
[ed patrol] Fix playback routing test suite for async Plex transcode decision pre-flight

### DIFF
--- a/tests/playback-routing.test.ts
+++ b/tests/playback-routing.test.ts
@@ -20,9 +20,19 @@ const store = new Map<string, string>();
   clear: () => store.clear(),
 };
 
+// transcodeStreamUrl awaits preflightPlexTranscodeDecision on Plex; mock fetch so
+// node tests don't make real network calls or fail when no mock server is running.
+(globalThis as any).fetch = async () => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  json: async () => ({}),
+});
+
 const {
   directStreamUrl,
   transcodeStreamUrl,
+  transcodeStreamUrlSync,
   playbackIsDirectSafe,
 } = await import('../src/playback-routing.ts');
 
@@ -32,24 +42,31 @@ const MP4 = { container: 'mp4', videoCodec: 'h264', audioCodecs: ['aac'] };
 beforeEach(() => store.clear());
 const useBackend = (kind: string) => store.set('provider_kind', kind);
 
-test('an install with no provider_kind still behaves as Jellyfin', () => {
-  const url = transcodeStreamUrl(SERVER, 'tok', '42', {});
+test('an install with no provider_kind still behaves as Jellyfin', async () => {
+  const url = await transcodeStreamUrl(SERVER, 'tok', '42', {});
   assert.match(url, /\/Videos\/42\//, 'installs predating the boundary must not change');
+  assert.match(transcodeStreamUrlSync(SERVER, 'tok', '42', {}), /\/Videos\/42\//);
 });
 
-test('Jellyfin routes to Jellyfin endpoints', () => {
+test('Jellyfin routes to Jellyfin endpoints', async () => {
   useBackend('jellyfin');
   assert.match(directStreamUrl(SERVER, 'tok', '42'), /\/Videos\/42\//);
-  assert.match(transcodeStreamUrl(SERVER, 'tok', '42', {}), /\/Videos\/42\//);
+  assert.match(await transcodeStreamUrl(SERVER, 'tok', '42', {}), /\/Videos\/42\//);
+  assert.match(transcodeStreamUrlSync(SERVER, 'tok', '42', {}), /\/Videos\/42\//);
   assert.equal(playbackIsDirectSafe(MP4), true, 'a plain mp4/h264/aac is direct-playable');
 });
 
-test('Plex routes to Plex endpoints, and never to a Jellyfin route', () => {
+test('Plex routes to Plex endpoints, and never to a Jellyfin route', async () => {
   useBackend('plex');
-  const hls = transcodeStreamUrl(SERVER, 'tok', '42', {});
+  const hls = await transcodeStreamUrl(SERVER, 'tok', '42', {});
   assert.match(hls, /\/video\/:\/transcode\/universal\/start\.m3u8/);
   assert.match(hls, /X-Plex-Token=tok/);
   assert.doesNotMatch(hls, /\/Videos\//, 'the bug this file exists for');
+
+  const hlsSync = transcodeStreamUrlSync(SERVER, 'tok', '42', {});
+  assert.match(hlsSync, /\/video\/:\/transcode\/universal\/start\.m3u8/);
+  assert.match(hlsSync, /X-Plex-Token=tok/);
+  assert.doesNotMatch(hlsSync, /\/Videos\//);
 
   // Even the direct builder — unreachable today, see playbackIsDirectSafe —
   // must not fabricate a Jellyfin URL if a future direct path calls it.
@@ -66,23 +83,34 @@ test('Plex declines synchronous direct play regardless of codecs', () => {
   );
 });
 
-test('switching backend switches the playback path with no reload', () => {
+test('switching backend switches the playback path with no reload', async () => {
   useBackend('jellyfin');
-  assert.match(transcodeStreamUrl(SERVER, 'tok', '7', {}), /\/Videos\/7\//);
+  assert.match(await transcodeStreamUrl(SERVER, 'tok', '7', {}), /\/Videos\/7\//);
+  assert.match(transcodeStreamUrlSync(SERVER, 'tok', '7', {}), /\/Videos\/7\//);
   useBackend('plex');
-  assert.match(transcodeStreamUrl(SERVER, 'tok', '7', {}), /transcode\/universal/);
+  assert.match(await transcodeStreamUrl(SERVER, 'tok', '7', {}), /transcode\/universal/);
+  assert.match(transcodeStreamUrlSync(SERVER, 'tok', '7', {}), /transcode\/universal/);
 });
 
-test('a resume position survives into the stream URL on both backends', () => {
+test('a resume position survives into the stream URL on both backends', async () => {
   const oneMinute = 60 * 10_000_000; // ticks
   useBackend('jellyfin');
   assert.match(
-    transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    await transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    /StartTimeTicks=600000000/
+  );
+  assert.match(
+    transcodeStreamUrlSync(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
     /StartTimeTicks=600000000/
   );
   useBackend('plex');
   assert.match(
-    transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    await transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    /offset=60/,
+    'Plex takes seconds where Jellyfin takes ticks'
+  );
+  assert.match(
+    transcodeStreamUrlSync(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
     /offset=60/,
     'Plex takes seconds where Jellyfin takes ticks'
   );


### PR DESCRIPTION
### Summary

When `transcodeStreamUrl` in `src/playback-routing.ts` was updated to be asynchronous (to pre-flight Plex transcode decisions via `/decision` before `start.m3u8`) and `transcodeStreamUrlSync` was introduced, `tests/playback-routing.test.ts` was not updated to reflect these signature changes. As a result, the test assertions received unresolved Promises and unmocked network fetch calls, causing 5 test failures.

### Changes
- Updated `tests/playback-routing.test.ts` to mock `globalThis.fetch` for unit tests.
- Updated `tests/playback-routing.test.ts` to await `transcodeStreamUrl` across test cases.
- Added assertions for `transcodeStreamUrlSync` to verify synchronous stream URL generation on both Jellyfin and Plex backends.
- All 293 tests now pass cleanly.