### PR TITLE
[ed patrol] Fix playback routing test suite for async transcodeStreamUrl

### DIFF
--- a/tests/playback-routing.test.ts
+++ b/tests/playback-routing.test.ts
@@ -20,9 +20,19 @@ const store = new Map<string, string>();
   clear: () => store.clear(),
 };
 
+// Plex transcode pre-flight makes a network call via fetch; shim in Node.
+(globalThis as any).fetch = async () => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  json: async () => ({}),
+  text: async () => '',
+});
+
 const {
   directStreamUrl,
   transcodeStreamUrl,
+  transcodeStreamUrlSync,
   playbackIsDirectSafe,
 } = await import('../src/playback-routing.ts');
 
@@ -32,24 +42,32 @@ const MP4 = { container: 'mp4', videoCodec: 'h264', audioCodecs: ['aac'] };
 beforeEach(() => store.clear());
 const useBackend = (kind: string) => store.set('provider_kind', kind);
 
-test('an install with no provider_kind still behaves as Jellyfin', () => {
-  const url = transcodeStreamUrl(SERVER, 'tok', '42', {});
+test('an install with no provider_kind still behaves as Jellyfin', async () => {
+  const url = await transcodeStreamUrl(SERVER, 'tok', '42', {});
   assert.match(url, /\/Videos\/42\//, 'installs predating the boundary must not change');
+  const syncUrl = transcodeStreamUrlSync(SERVER, 'tok', '42', {});
+  assert.match(syncUrl, /\/Videos\/42\//);
 });
 
-test('Jellyfin routes to Jellyfin endpoints', () => {
+test('Jellyfin routes to Jellyfin endpoints', async () => {
   useBackend('jellyfin');
   assert.match(directStreamUrl(SERVER, 'tok', '42'), /\/Videos\/42\//);
-  assert.match(transcodeStreamUrl(SERVER, 'tok', '42', {}), /\/Videos\/42\//);
+  assert.match(await transcodeStreamUrl(SERVER, 'tok', '42', {}), /\/Videos\/42\//);
+  assert.match(transcodeStreamUrlSync(SERVER, 'tok', '42', {}), /\/Videos\/42\//);
   assert.equal(playbackIsDirectSafe(MP4), true, 'a plain mp4/h264/aac is direct-playable');
 });
 
-test('Plex routes to Plex endpoints, and never to a Jellyfin route', () => {
+test('Plex routes to Plex endpoints, and never to a Jellyfin route', async () => {
   useBackend('plex');
-  const hls = transcodeStreamUrl(SERVER, 'tok', '42', {});
+  const hls = await transcodeStreamUrl(SERVER, 'tok', '42', {});
   assert.match(hls, /\/video\/:\/transcode\/universal\/start\.m3u8/);
   assert.match(hls, /X-Plex-Token=tok/);
   assert.doesNotMatch(hls, /\/Videos\//, 'the bug this file exists for');
+
+  const syncHls = transcodeStreamUrlSync(SERVER, 'tok', '42', {});
+  assert.match(syncHls, /\/video\/:\/transcode\/universal\/start\.m3u8/);
+  assert.match(syncHls, /X-Plex-Token=tok/);
+  assert.doesNotMatch(syncHls, /\/Videos\//);
 
   // Even the direct builder — unreachable today, see playbackIsDirectSafe —
   // must not fabricate a Jellyfin URL if a future direct path calls it.
@@ -66,23 +84,34 @@ test('Plex declines synchronous direct play regardless of codecs', () => {
   );
 });
 
-test('switching backend switches the playback path with no reload', () => {
+test('switching backend switches the playback path with no reload', async () => {
   useBackend('jellyfin');
-  assert.match(transcodeStreamUrl(SERVER, 'tok', '7', {}), /\/Videos\/7\//);
+  assert.match(await transcodeStreamUrl(SERVER, 'tok', '7', {}), /\/Videos\/7\//);
+  assert.match(transcodeStreamUrlSync(SERVER, 'tok', '7', {}), /\/Videos\/7\//);
   useBackend('plex');
-  assert.match(transcodeStreamUrl(SERVER, 'tok', '7', {}), /transcode\/universal/);
+  assert.match(await transcodeStreamUrl(SERVER, 'tok', '7', {}), /transcode\/universal/);
+  assert.match(transcodeStreamUrlSync(SERVER, 'tok', '7', {}), /transcode\/universal/);
 });
 
-test('a resume position survives into the stream URL on both backends', () => {
+test('a resume position survives into the stream URL on both backends', async () => {
   const oneMinute = 60 * 10_000_000; // ticks
   useBackend('jellyfin');
   assert.match(
-    transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    await transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    /StartTimeTicks=600000000/
+  );
+  assert.match(
+    transcodeStreamUrlSync(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
     /StartTimeTicks=600000000/
   );
   useBackend('plex');
   assert.match(
-    transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    await transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    /offset=60/,
+    'Plex takes seconds where Jellyfin takes ticks'
+  );
+  assert.match(
+    transcodeStreamUrlSync(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
     /offset=60/,
     'Plex takes seconds where Jellyfin takes ticks'
   );


### PR DESCRIPTION
### Summary of Changes

When commit 3085f16 ("Pre-flight Plex\x27s transcode decision before start.m3u8") made `transcodeStreamUrl` asynchronous and added `transcodeStreamUrlSync`, `tests/playback-routing.test.ts` was not updated to await `transcodeStreamUrl`, nor was `fetch` shimmed for Node test environments when evaluating Plex transcode pre-flight endpoints.

This PR updates `tests/playback-routing.test.ts` to:
- Properly await `transcodeStreamUrl` in test cases
- Provide a Node `fetch` shim so Plex transcode preflights resolve cleanly without unhandled network rejections
- Add test coverage verifying both `transcodeStreamUrl` and `transcodeStreamUrlSync` across Jellyfin and Plex backends

### Verification
- `npm run build` passed cleanly with 0 errors
- `npm test` runs 302 tests and all 302 pass