### PR TITLE
[ed patrol] Fix playback routing tests for async transcode preflight

### DIFF
--- a/tests/playback-routing.test.ts
+++ b/tests/playback-routing.test.ts
@@ -20,9 +20,14 @@ const store = new Map<string, string>();
   clear: () => store.clear(),
 };
 
+// transcodeStreamUrl awaits preflightPlexTranscodeDecision on Plex (#76),
+// which hits fetch(); mock fetch so it doesn't fail with a connection error.
+(globalThis as any).fetch = async () => new Response('ok', { status: 200 });
+
 const {
   directStreamUrl,
   transcodeStreamUrl,
+  transcodeStreamUrlSync,
   playbackIsDirectSafe,
 } = await import('../src/playback-routing.ts');
 
@@ -32,24 +37,31 @@ const MP4 = { container: 'mp4', videoCodec: 'h264', audioCodecs: ['aac'] };
 beforeEach(() => store.clear());
 const useBackend = (kind: string) => store.set('provider_kind', kind);
 
-test('an install with no provider_kind still behaves as Jellyfin', () => {
-  const url = transcodeStreamUrl(SERVER, 'tok', '42', {});
+test('an install with no provider_kind still behaves as Jellyfin', async () => {
+  const url = await transcodeStreamUrl(SERVER, 'tok', '42', {});
   assert.match(url, /\/Videos\/42\//, 'installs predating the boundary must not change');
+  const syncUrl = transcodeStreamUrlSync(SERVER, 'tok', '42', {});
+  assert.match(syncUrl, /\/Videos\/42\//);
 });
 
-test('Jellyfin routes to Jellyfin endpoints', () => {
+test('Jellyfin routes to Jellyfin endpoints', async () => {
   useBackend('jellyfin');
   assert.match(directStreamUrl(SERVER, 'tok', '42'), /\/Videos\/42\//);
-  assert.match(transcodeStreamUrl(SERVER, 'tok', '42', {}), /\/Videos\/42\//);
+  assert.match(await transcodeStreamUrl(SERVER, 'tok', '42', {}), /\/Videos\/42\//);
+  assert.match(transcodeStreamUrlSync(SERVER, 'tok', '42', {}), /\/Videos\/42\//);
   assert.equal(playbackIsDirectSafe(MP4), true, 'a plain mp4/h264/aac is direct-playable');
 });
 
-test('Plex routes to Plex endpoints, and never to a Jellyfin route', () => {
+test('Plex routes to Plex endpoints, and never to a Jellyfin route', async () => {
   useBackend('plex');
-  const hls = transcodeStreamUrl(SERVER, 'tok', '42', {});
+  const hls = await transcodeStreamUrl(SERVER, 'tok', '42', {});
   assert.match(hls, /\/video\/:\/transcode\/universal\/start\.m3u8/);
   assert.match(hls, /X-Plex-Token=tok/);
   assert.doesNotMatch(hls, /\/Videos\//, 'the bug this file exists for');
+
+  const syncHls = transcodeStreamUrlSync(SERVER, 'tok', '42', {});
+  assert.match(syncHls, /\/video\/:\/transcode\/universal\/start\.m3u8/);
+  assert.match(syncHls, /X-Plex-Token=tok/);
 
   // Even the direct builder — unreachable today, see playbackIsDirectSafe —
   // must not fabricate a Jellyfin URL if a future direct path calls it.
@@ -66,23 +78,34 @@ test('Plex declines synchronous direct play regardless of codecs', () => {
   );
 });
 
-test('switching backend switches the playback path with no reload', () => {
+test('switching backend switches the playback path with no reload', async () => {
   useBackend('jellyfin');
-  assert.match(transcodeStreamUrl(SERVER, 'tok', '7', {}), /\/Videos\/7\//);
+  assert.match(await transcodeStreamUrl(SERVER, 'tok', '7', {}), /\/Videos\/7\//);
+  assert.match(transcodeStreamUrlSync(SERVER, 'tok', '7', {}), /\/Videos\/7\//);
   useBackend('plex');
-  assert.match(transcodeStreamUrl(SERVER, 'tok', '7', {}), /transcode\/universal/);
+  assert.match(await transcodeStreamUrl(SERVER, 'tok', '7', {}), /transcode\/universal/);
+  assert.match(transcodeStreamUrlSync(SERVER, 'tok', '7', {}), /transcode\/universal/);
 });
 
-test('a resume position survives into the stream URL on both backends', () => {
+test('a resume position survives into the stream URL on both backends', async () => {
   const oneMinute = 60 * 10_000_000; // ticks
   useBackend('jellyfin');
   assert.match(
-    transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    await transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    /StartTimeTicks=600000000/
+  );
+  assert.match(
+    transcodeStreamUrlSync(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
     /StartTimeTicks=600000000/
   );
   useBackend('plex');
   assert.match(
-    transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    await transcodeStreamUrl(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
+    /offset=60/,
+    'Plex takes seconds where Jellyfin takes ticks'
+  );
+  assert.match(
+    transcodeStreamUrlSync(SERVER, 'tok', '7', { startPositionTicks: oneMinute }),
     /offset=60/,
     'Plex takes seconds where Jellyfin takes ticks'
   );


### PR DESCRIPTION
### Summary
Commit `3085f16` updated `transcodeStreamUrl` in `src/playback-routing.ts` to be `async` (to await Plex transcode-decision pre-flight) and introduced `transcodeStreamUrlSync`. However, `tests/playback-routing.test.ts` was not updated and continued to assert against the return value synchronously, resulting in 5 test failures (`AssertionError: The "string" argument must be of type string. Received type object (Promise)`). Additionally, Plex routing in tests attempted live `fetch` calls to an unmocked URL.

### Changes
- Updated `tests/playback-routing.test.ts` to `await transcodeStreamUrl(...)`.
- Added test coverage for `transcodeStreamUrlSync(...)`.
- Mocked `globalThis.fetch` in the test file so Plex pre-flight calls succeed cleanly without unhandled rejections.

### Verification
- `npm test`: All 302 tests pass cleanly with 0 failures.
- `npm run build`: File budget, provider boundary, slot check, TypeScript compilation, and Vite build pass with 0 errors.