### PR TITLE
[ed patrol] Handoff streaming titles in 2.5D flat detail view

### DIFF
--- a/src/flat/flat-detail.ts
+++ b/src/flat/flat-detail.ts
@@ -8,7 +8,7 @@ import { getActiveTheme } from '../themes';
 import { getActiveLogoSpec } from '../logo-spec';
 import { drawLogo } from '../logo-renderer';
 import { flatSignal } from './flat-lifecycle';
-import { resolveEpisodePlaybackArgs } from './flat-playback';
+import { resolveEpisodePlaybackArgs, resolveDetailButtonState } from './flat-playback';
 
 let launchVideoPlaybackFn: ((movie: Movie, overrideItemId?: string, overridePath?: string) => Promise<void>) | null = null;
 
@@ -143,22 +143,8 @@ export function openDetailsOverlay(
   // Determine button text/state
   const isRequested = (movie.discovery || movie.collectionGap) &&
     (movie.discoveryRequested || isDiscoveryRequested(movie.tmdbId));
-  let playBtnText = 'Play';
-  let playBtnDisabled = '';
-  let playBtnIcon = '▶';
-
-  if (movie.game) {
-    playBtnText = 'Rent';
-    playBtnIcon = '🎮';
-  } else if (movie.discovery || movie.collectionGap) {
-    playBtnText = isRequested ? (movie.collectionGap ? 'Coming Soon' : 'Requested') : 'Request';
-    playBtnIcon = isRequested ? '✓' : '✦';
-    playBtnDisabled = isRequested ? 'disabled' : '';
-  } else if (movie.comingSoon) {
-    playBtnText = 'Coming Soon';
-    playBtnIcon = '⏱';
-    playBtnDisabled = 'disabled';
-  }
+  const { text: playBtnText, icon: playBtnIcon, disabled: isBtnDisabled } = resolveDetailButtonState(movie, isRequested);
+  const playBtnDisabled = isBtnDisabled ? 'disabled' : '';
 
   // The clamshell lip's small embossed brand mark: the ACTIVE emblem, painted
   // from the LogoSpec onto an offscreen canvas (one-shot — flat mode is DOM,
@@ -184,7 +170,7 @@ export function openDetailsOverlay(
               <span class="flat-detail-badge-platform">${movie.platform}</span>
               <span class="flat-detail-meta-divider">|</span>
               <span class="flat-detail-meta-item">${movie.year}</span>
-            ` : movie.discovery ? `
+            ` : (movie.discovery || movie.streaming) ? `
               <span class="flat-detail-meta-item">${movie.year}</span>
             ` : `
               <span class="flat-detail-meta-item">${movie.year}</span>
@@ -203,7 +189,7 @@ export function openDetailsOverlay(
 
           <p class="flat-detail-overview">${movie.overview || 'No description available.'}</p>
 
-          ${(movie.game || movie.discovery) ? '' : `
+          ${(movie.game || movie.discovery || movie.streaming) ? '' : `
           <div class="flat-detail-credits">
             <div class="flat-detail-credits-label">Director</div>
             <div class="flat-detail-credits-value">${movie.director || 'Unknown'}</div>
@@ -426,6 +412,18 @@ export function openDetailsOverlay(
       } else {
         logSystemMessage(`[System] Failed to request "${movie.title}" (Jellyseerr unreachable or rejected the request).`);
       }
+    } else if (movie.streaming) {
+      if (movie.streamingUrl) {
+        logSystemMessage(`[System] Opening ${movie.streamingServiceName || 'the streaming service'} for "${movie.title}"...`);
+        try {
+          window.open(movie.streamingUrl, '_blank', 'noopener');
+        } catch {
+          logSystemMessage(`[System] Couldn't open the link for "${movie.title}" (popup blocked?).`);
+        }
+      } else {
+        logSystemMessage(`[System] No watch URL configured for "${movie.title}".`);
+      }
+      closeOverlay();
     } else {
       if (movie.isSeries) {
         if (episodesList.length > 0) {

--- a/src/flat/flat-playback.ts
+++ b/src/flat/flat-playback.ts
@@ -32,8 +32,47 @@
 // is the guard: it takes no server, no session, no provider, so a network
 // call — right target or wrong — cannot be smuggled back into it without a
 // reviewer noticing the new parameter.
-import type { Episode } from '../jellyfin.ts';
+import type { Episode, Movie } from '../jellyfin.ts';
 
 export function resolveEpisodePlaybackArgs(ep: Episode): { itemId: string; path: string } {
   return { itemId: ep.id, path: ep.path };
 }
+
+export interface FlatDetailButtonState {
+  text: string;
+  icon: string;
+  disabled: boolean;
+}
+
+/**
+ * Pure button state resolution for the 2.5D detail overlay (flat-detail.ts):
+ * games -> Rent (🎮)
+ * discovery/collectionGap -> Request / Requested / Coming Soon (✦ / ✓)
+ * streaming -> Watch on <SERVICE> (↗)
+ * comingSoon -> Coming Soon (⏱, disabled)
+ * library titles -> Play (▶)
+ */
+export function resolveDetailButtonState(movie: Partial<Movie>, isRequested = false): FlatDetailButtonState {
+  if (movie.game) {
+    return { text: 'Rent', icon: '🎮', disabled: false };
+  }
+  if (movie.discovery || movie.collectionGap) {
+    return {
+      text: isRequested ? (movie.collectionGap ? 'Coming Soon' : 'Requested') : 'Request',
+      icon: isRequested ? '✓' : '✦',
+      disabled: isRequested,
+    };
+  }
+  if (movie.streaming) {
+    return {
+      text: `Watch on ${movie.streamingServiceName || 'Streaming'}`,
+      icon: '↗',
+      disabled: false,
+    };
+  }
+  if (movie.comingSoon) {
+    return { text: 'Coming Soon', icon: '⏱', disabled: true };
+  }
+  return { text: 'Play', icon: '▶', disabled: false };
+}
+

--- a/tests/flat-detail.test.ts
+++ b/tests/flat-detail.test.ts
@@ -24,10 +24,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer, type Server } from 'node:http';
-import type { Episode } from '../src/jellyfin.ts';
+import type { Episode, Movie } from '../src/jellyfin.ts';
 import { fetchFirstEpisodeOfSeries } from '../src/jellyfin.ts';
 import { fetchPlexFirstEpisodeOfSeries } from '../src/plex.ts';
-import { resolveEpisodePlaybackArgs } from '../src/flat/flat-playback.ts';
+import { resolveEpisodePlaybackArgs, resolveDetailButtonState } from '../src/flat/flat-playback.ts';
 
 function mkEpisode(extra: Partial<Episode> = {}): Episode {
   return {
@@ -114,3 +114,98 @@ test('Plex: asking for an episode-as-series (the GH #71 trap) resolves null, exa
     assert.equal(result, null);
   });
 });
+
+// ── Layer 3: detail action button state resolution ───────────────────────────
+
+test('resolveDetailButtonState: standard library movie resolves to Play (enabled)', () => {
+  const movie: Partial<Movie> = { id: 'm-1', title: 'Twin Peaks: Fire Walk With Me' };
+  assert.deepEqual(resolveDetailButtonState(movie), {
+    text: 'Play',
+    icon: '▶',
+    disabled: false,
+  });
+});
+
+test('resolveDetailButtonState: game title resolves to Rent (enabled)', () => {
+  const game: Partial<Movie> = { id: 'g-1', title: 'Chrono Trigger', game: true, platform: 'SNES' };
+  assert.deepEqual(resolveDetailButtonState(game), {
+    text: 'Rent',
+    icon: '🎮',
+    disabled: false,
+  });
+});
+
+test('resolveDetailButtonState: unrequested discovery title resolves to Request (enabled)', () => {
+  const discovery: Partial<Movie> = { id: 'd-1', title: 'Dune: Part Two', discovery: true, tmdbId: 693134 };
+  assert.deepEqual(resolveDetailButtonState(discovery, false), {
+    text: 'Request',
+    icon: '✦',
+    disabled: false,
+  });
+});
+
+test('resolveDetailButtonState: requested discovery title resolves to Requested (disabled)', () => {
+  const discovery: Partial<Movie> = { id: 'd-1', title: 'Dune: Part Two', discovery: true, tmdbId: 693134 };
+  assert.deepEqual(resolveDetailButtonState(discovery, true), {
+    text: 'Requested',
+    icon: '✓',
+    disabled: true,
+  });
+});
+
+test('resolveDetailButtonState: unrequested collection gap resolves to Request (enabled)', () => {
+  const gap: Partial<Movie> = { id: 'c-1', title: 'The Empire Strikes Back', collectionGap: true, tmdbId: 1891 };
+  assert.deepEqual(resolveDetailButtonState(gap, false), {
+    text: 'Request',
+    icon: '✦',
+    disabled: false,
+  });
+});
+
+test('resolveDetailButtonState: requested collection gap resolves to Coming Soon (disabled)', () => {
+  const gap: Partial<Movie> = { id: 'c-1', title: 'The Empire Strikes Back', collectionGap: true, tmdbId: 1891 };
+  assert.deepEqual(resolveDetailButtonState(gap, true), {
+    text: 'Coming Soon',
+    icon: '✓',
+    disabled: true,
+  });
+});
+
+test('resolveDetailButtonState: streaming title resolves to Watch on <SERVICE> (enabled)', () => {
+  const streaming: Partial<Movie> = {
+    id: 'streaming_netflix_12345',
+    title: 'Glass Onion',
+    streaming: true,
+    streamingServiceId: 'netflix',
+    streamingServiceName: 'NETFLIX',
+    streamingUrl: 'https://www.netflix.com/search?q=Glass%20Onion',
+  };
+  assert.deepEqual(resolveDetailButtonState(streaming), {
+    text: 'Watch on NETFLIX',
+    icon: '↗',
+    disabled: false,
+  });
+});
+
+test('resolveDetailButtonState: streaming title without explicit service name falls back to Streaming', () => {
+  const streaming: Partial<Movie> = {
+    id: 'streaming_custom_99999',
+    title: 'Indie Film',
+    streaming: true,
+  };
+  assert.deepEqual(resolveDetailButtonState(streaming), {
+    text: 'Watch on Streaming',
+    icon: '↗',
+    disabled: false,
+  });
+});
+
+test('resolveDetailButtonState: coming soon movie resolves to Coming Soon (disabled)', () => {
+  const comingSoon: Partial<Movie> = { id: 'cs-1', title: 'Upcoming Film', comingSoon: true };
+  assert.deepEqual(resolveDetailButtonState(comingSoon), {
+    text: 'Coming Soon',
+    icon: '⏱',
+    disabled: true,
+  });
+});
+


### PR DESCRIPTION
### Problem
When inspecting a streaming-service title (`movie.streaming === true`, GH #86) in 2.5D flat mode:
1. The detail card rendered a generic "Play" button with a "▶" icon rather than "Watch on <SERVICE>" (e.g. "Watch on NETFLIX") with "↗".
2. Clicking the action button routed directly to `launchVideoPlaybackFn(movie)` instead of handing off to the service URL via `window.open(movie.streamingUrl, "_blank", "noopener")`. Because streaming titles are synthetic items with no local media source, this caused local video player launch attempts to fail.
3. The metadata and credits display showed placeholder fields ("N/A", "NR", "Unknown Director") rather than suppressing unpopulated fields for synthetic streaming titles.

### Fix
- Extracted pure helper `resolveDetailButtonState` in [`src/flat/flat-playback.ts`](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/flat/flat-playback.ts) that maps `movie.streaming` to `Watch on <SERVICE>` / `↗` alongside existing types (games, discovery, collection gaps, coming soon).
- Updated [`src/flat/flat-detail.ts`](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/flat/flat-detail.ts) to use `resolveDetailButtonState`, open `movie.streamingUrl` in a new tab upon click, and clean up metadata/credits layout for streaming titles.
- Added comprehensive unit test coverage in [`tests/flat-detail.test.ts`](file:///home/nobara-user/Documents/antigravity/halcyon-ed/tests/flat-detail.test.ts).

### Verification
- `npm test`: 311 tests passing cleanly.
- `npm run build`: verified file budgets, provider boundaries, slots, typescript compilation, and vite production build.