### PR TITLE
[ed patrol] Clean up VR affordance listener and dispose VR on scene teardown

### DIFF
--- a/src/store-vr.ts
+++ b/src/store-vr.ts
@@ -111,6 +111,8 @@ function getOrCreateState(scene: StoreScene): VRState {
   return state;
 }
 
+const disposedScenes = new WeakSet<StoreScene>();
+
 // Called once from StoreScene.initThree(). Feature-detects navigator.xr +
 // immersive-vr support and, if present, unhides the standalone Enter VR
 // button (vr-entry-overlay, index.html) — no-ops cleanly on Tauri desktop or
@@ -120,12 +122,12 @@ export function setupVRAffordance(scene: StoreScene): void {
   if (!btn || !navigator.xr) return;
 
   navigator.xr.isSessionSupported('immersive-vr').then((supported) => {
-    if (!supported) return;
+    if (!supported || disposedScenes.has(scene)) return;
     btn.hidden = false;
-    btn.addEventListener('click', () => {
+    btn.onclick = () => {
       btn.disabled = true;
       void enterVR(scene);
-    });
+    };
   }).catch(() => { /* isSessionSupported itself can reject on some UAs — stay hidden */ });
 }
 
@@ -346,4 +348,33 @@ function cleanupAfterSession(scene: StoreScene, state: VRState): void {
   scene.resumeRendering();
   setVRButtonEnabled(true);
   scene.onConsoleLog('[System] Exited VR.', 'system');
+}
+
+/**
+ * Tear down any active VR session and release DOM affordances on StoreScene disposal.
+ * Called from StoreScene.destroy().
+ */
+export function disposeVR(scene: StoreScene): void {
+  disposedScenes.add(scene);
+  const state = vrStates.get(scene);
+  if (state) {
+    if (state.session) {
+      void state.session.end().catch(() => { /* already dead — nothing to clean up */ });
+      state.session = null;
+    }
+    vrStates.delete(scene);
+  }
+  try {
+    if (scene.renderer?.xr) {
+      scene.renderer.setAnimationLoop(null);
+      scene.renderer.xr.enabled = false;
+    }
+  } catch {
+    /* ignore renderer disposal errors */
+  }
+  const btn = document.getElementById('walk-vr-enter') as HTMLButtonElement | null;
+  if (btn && btn.onclick) {
+    btn.onclick = null;
+  }
+  setVRButtonEnabled(true);
 }

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -6039,6 +6039,8 @@ export class StoreScene {
     this.floorAOTex = null;
     this.floorMat = null;
 
+    vr.disposeVR(this);
+
     window.removeEventListener('keydown', this.handleWalkKeyDown);
     window.removeEventListener('keydown', this.onClaspKey, true);
     this.renderer.domElement.removeEventListener('pointermove', this.onClaspPointerMove);


### PR DESCRIPTION
### Problem
1. In [src/store-vr.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/store-vr.ts), `setupVRAffordance` attached a new `'click'` event listener onto the static DOM element `#walk-vr-enter` every time `StoreScene` was initialized. During settings/theme/render mode/library changes where `StoreScene` is rebuilt, each destroyed scene was retained in memory through the event listener closure, causing memory leaks of entire 3D scene graphs and triggering duplicate `enterVR()` calls on stale scene instances when the button was clicked.
2. In [src/three-scene.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/three-scene.ts), `StoreScene.destroy()` did not clean up active WebXR sessions, xr animation loops, or the DOM click listener.

### Solution
- Switched `setupVRAffordance` in [src/store-vr.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/store-vr.ts) to bind `btn.onclick` instead of adding stacked listeners, and added a `disposedScenes` check to ensure delayed `isSessionSupported` resolutions do not re-bind dead scenes.
- Added and exported `disposeVR(scene)` in [src/store-vr.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/store-vr.ts) to gracefully terminate active VR sessions, cancel the XR animation loop, clean up `vrStates`, unbind `btn.onclick`, and reset button state.
- Invoked `vr.disposeVR(this)` inside `StoreScene.destroy()` in [src/three-scene.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/three-scene.ts).

### Verification
- Ran `npm test` (302 tests passing cleanly).
- Ran `npm run build` (file budget gate, provider boundary check, slot mappings, TypeScript compilation, and Vite production bundle passed cleanly with 0 errors).