### PR TITLE
[ed patrol] Route mpv playback reporting through playback router

### DIFF
--- a/src/playback-flow.ts
+++ b/src/playback-flow.ts
@@ -12,7 +12,7 @@
 // under `node --test`'s type-stripping loader, which can't resolve a bare
 // sibling specifier (same note as jellyfin.ts's own media-release-date.ts import).
 import type { Movie, Episode } from './jellyfin.ts';
-import { reportPlaybackStart, reportPlaybackProgress, reportPlaybackStopped } from './jellyfin.ts';
+import { playbackStarted, playbackProgressed, playbackStopped } from './playback-routing.ts';
 
 const TICKS_PER_SECOND = 10_000_000;
 
@@ -153,8 +153,8 @@ export async function playLocalWithMpv(
   onExit: (positionTicks: number, endedNaturally: boolean) => void,
   log: (msg: string) => void
 ): Promise<boolean> {
-  const jellyfinUrl = localStorage.getItem('jellyfin_url');
-  const token = localStorage.getItem('jellyfin_token');
+  const jellyfinUrl = typeof localStorage !== 'undefined' ? localStorage.getItem('jellyfin_url') : null;
+  const token = typeof localStorage !== 'undefined' ? localStorage.getItem('jellyfin_token') : null;
   const startSeconds = Math.max(0, Math.floor(startPositionTicks / TICKS_PER_SECOND));
 
   let id: string;
@@ -175,29 +175,29 @@ export async function playLocalWithMpv(
   }
 
   log(`[Video] Playing off disk in mpv (from ${startSeconds}s).`);
-  if (jellyfinUrl && token) reportPlaybackStart(jellyfinUrl, token, itemId);
+  if (jellyfinUrl && token) playbackStarted(jellyfinUrl, token, itemId);
 
   // Poll for position so Continue Watching still tracks, and so closing mpv
   // returns to the store the same way the in-app player's Back does.
   let lastTicks = startPositionTicks;
-  const poll = window.setInterval(async () => {
+  const poll = setInterval(async () => {
     try {
       const res = await fetch(`/__play?id=${encodeURIComponent(id)}`);
       if (!res.ok) throw new Error(String(res.status));
       const s = await res.json();
       lastTicks = Math.round((s.position ?? 0) * TICKS_PER_SECOND);
       if (!s.exited) {
-        if (jellyfinUrl && token) reportPlaybackProgress(jellyfinUrl, token, itemId, lastTicks, false);
+        if (jellyfinUrl && token) playbackProgressed(jellyfinUrl, token, itemId, lastTicks, false);
         return;
       }
-      window.clearInterval(poll);
+      clearInterval(poll);
       if (s.error) log(`[Video] mpv error: ${s.error}`);
-      if (jellyfinUrl && token) reportPlaybackStopped(jellyfinUrl, token, itemId, lastTicks);
+      if (jellyfinUrl && token) playbackStopped(jellyfinUrl, token, itemId, lastTicks, durationTicks);
       onExit(lastTicks, isMpvNaturalFinish(lastTicks, durationTicks));
     } catch {
       // Endpoint vanished (server restarted) — stop polling rather than spin.
       // Ambiguous exit: never autoplay on a guess.
-      window.clearInterval(poll);
+      clearInterval(poll);
       onExit(lastTicks, false);
     }
   }, 5000);

--- a/tests/playback-flow.test.ts
+++ b/tests/playback-flow.test.ts
@@ -16,6 +16,7 @@ import {
   resolveActiveItemTiming,
   markWatchedAndFindNext,
   isMpvNaturalFinish,
+  playLocalWithMpv,
   type SeriesQueue,
 } from '../src/playback-flow.ts';
 
@@ -130,3 +131,136 @@ test('isMpvNaturalFinish: within tolerance of the known runtime counts as finish
   assert.equal(isMpvNaturalFinish(duration - 2 * TICKS_PER_SECOND, duration), true); // within tolerance
   assert.equal(isMpvNaturalFinish(duration - 30 * TICKS_PER_SECOND, duration), false); // an early quit
 });
+
+test('playLocalWithMpv: returns false when endpoint is unreachable', async () => {
+  const origFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async () => {
+      throw new Error('Connection refused');
+    };
+    const started = await playLocalWithMpv(
+      '/media/test.mkv',
+      'movie-1',
+      0,
+      1000,
+      {},
+      () => {},
+      () => {}
+    );
+    assert.equal(started, false);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test('playLocalWithMpv: routes playback reporting to active provider (Jellyfin vs Plex)', async () => {
+  const origFetch = globalThis.fetch;
+  const origLocalStorage = globalThis.localStorage;
+  const origSetInterval = globalThis.setInterval;
+  const origClearInterval = globalThis.clearInterval;
+
+  const store = new Map<string, string>();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+  };
+
+  store.set('jellyfin_url', 'http://media.local:8096');
+  store.set('jellyfin_token', 'test-token');
+
+  const requests: string[] = [];
+  const timerCallbacks: Array<() => Promise<void> | void> = [];
+  (globalThis as any).setInterval = (fn: any) => {
+    timerCallbacks.push(fn);
+    return 123 as any;
+  };
+  (globalThis as any).clearInterval = () => {};
+
+  try {
+    let mpvExited = false;
+    let mpvPosition = 10;
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requests.push(url);
+      if (url === '/__play') {
+        return new Response(JSON.stringify({ id: 'mpv-1' }), { status: 200 });
+      }
+      if (url.startsWith('/__play?id=')) {
+        return new Response(JSON.stringify({ id: 'mpv-1', position: mpvPosition, exited: mpvExited }), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    // Test under Jellyfin
+    store.set('provider_kind', 'jellyfin');
+    requests.length = 0;
+    timerCallbacks.length = 0;
+    mpvExited = false;
+    let exitedNaturally = false;
+    const startedJellyfin = await playLocalWithMpv(
+      '/media/test.mkv',
+      'item-1',
+      0,
+      100 * 10_000_000,
+      {},
+      (_ticks, natural) => { exitedNaturally = natural; },
+      () => {}
+    );
+    assert.equal(startedJellyfin, true);
+    assert(requests.some((r) => r.includes('/Sessions/Playing')), 'Jellyfin receives /Sessions/Playing on start');
+    assert(!requests.some((r) => r.includes('/:/progress')), 'Plex endpoint not called under Jellyfin');
+
+    // Poll progress under Jellyfin
+    requests.length = 0;
+    await timerCallbacks[0]();
+    assert(requests.some((r) => r.includes('/Sessions/Playing/Progress')), 'Jellyfin receives progress');
+
+    // Exit under Jellyfin
+    requests.length = 0;
+    mpvExited = true;
+    mpvPosition = 99; // finished naturally
+    await timerCallbacks[0]();
+    assert(requests.some((r) => r.includes('/Sessions/Playing/Stopped')), 'Jellyfin receives stop');
+    assert.equal(exitedNaturally, true);
+
+    // Test under Plex
+    store.set('provider_kind', 'plex');
+    requests.length = 0;
+    timerCallbacks.length = 0;
+    mpvExited = false;
+    mpvPosition = 20;
+    exitedNaturally = false;
+    const startedPlex = await playLocalWithMpv(
+      '/media/test.mkv',
+      'item-2',
+      0,
+      100 * 10_000_000,
+      {},
+      (_ticks, natural) => { exitedNaturally = natural; },
+      () => {}
+    );
+    assert.equal(startedPlex, true);
+    assert(!requests.some((r) => r.includes('/Sessions/Playing')), 'Jellyfin start endpoint not called under Plex');
+
+    // Poll progress under Plex
+    requests.length = 0;
+    await timerCallbacks[0]();
+    assert(requests.some((r) => r.includes('/:/progress') && r.includes('state=playing')), 'Plex receives progress ping');
+
+    // Exit naturally under Plex (>=90% for scrobble, within 3s for natural finish)
+    requests.length = 0;
+    mpvExited = true;
+    mpvPosition = 99;
+    await timerCallbacks[0]();
+    assert(requests.some((r) => r.includes('/:/scrobble')), 'Plex receives scrobble on natural finish');
+    assert.equal(exitedNaturally, true);
+  } finally {
+    globalThis.fetch = origFetch;
+    globalThis.localStorage = origLocalStorage;
+    globalThis.setInterval = origSetInterval;
+    globalThis.clearInterval = origClearInterval;
+  }
+});
+
+

--- a/tools/check-provider-boundary.mjs
+++ b/tools/check-provider-boundary.mjs
@@ -63,10 +63,6 @@ const ALLOWED = {
     names: ['authenticateUser', 'buildUserAvatarUrl'],
     why: 'the picker is on the old path deliberately — it wants a reshape behind multiUserPicker',
   },
-  'src/playback-flow.ts': {
-    names: ['reportPlaybackStart', 'reportPlaybackProgress', 'reportPlaybackStopped'],
-    why: 'playback reporting, called through playback-routing.ts on the Plex side',
-  },
   'src/playback-routing.ts': {
     names: [
       'buildStaticStreamUrl',


### PR DESCRIPTION
### Problem

`playLocalWithMpv` in [src/playback-flow.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/playback-flow.ts) directly imported and invoked `reportPlaybackStart`, `reportPlaybackProgress`, and `reportPlaybackStopped` from [src/jellyfin.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/jellyfin.ts) rather than routing through [src/playback-routing.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/playback-routing.ts).

On a Plex install (where `jellyfin_url` and `jellyfin_token` hold the PMS address and accessToken):
1. mpv playback start sent Jellyfin `POST /Sessions/Playing` requests to the Plex server URL, failing immediately.
2. The 5-second progress poller sent Jellyfin `POST /Sessions/Playing/Progress` requests to the Plex server (404ing), completely failing to write resume timestamps (`/:/progress`) to PMS while watching in mpv.
3. On stop or completion, Jellyfin `POST /Sessions/Playing/Stopped` was sent to the Plex server instead of `reportPlexPlaybackStopped`, so PMS never scrobbled completed titles (`/:/scrobble`) or updated final stop offsets.
4. [tools/check-provider-boundary.mjs](file:///home/nobara-user/Documents/antigravity/halcyon-ed/tools/check-provider-boundary.mjs) had an obsolete exemption claiming `src/playback-flow.ts` was calling through `playback-routing.ts` on the Plex side.

### Solution

- Updated `playLocalWithMpv` in [src/playback-flow.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/playback-flow.ts) to import and call `playbackStarted`, `playbackProgressed`, and `playbackStopped` from [src/playback-routing.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/playback-routing.ts), passing `durationTicks` into `playbackStopped` for Plex scrobble threshold calculation.
- Hardened `playLocalWithMpv` for safe global access (`typeof localStorage !== "undefined"`, global `setInterval` / `clearInterval`).
- Removed `src/playback-flow.ts` from `ALLOWED` in [tools/check-provider-boundary.mjs](file:///home/nobara-user/Documents/antigravity/halcyon-ed/tools/check-provider-boundary.mjs).
- Added unit test coverage in [tests/playback-flow.test.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/tests/playback-flow.test.ts) verifying mpv playback start, progress, and exit reporting for both Jellyfin and Plex backends.

### Verification

- `npm test`: 304 tests passing cleanly (including new playback-flow mpv tests).
- `npm run build`: verified file budgets, provider boundaries, slots check, TypeScript compile, and Vite production bundle all pass cleanly with 0 errors.