### PR TITLE
[ed patrol] Exclude unstocked and streaming titles from ambient TV pool

### DIFF
--- a/src/ambient-tv-pool.ts
+++ b/src/ambient-tv-pool.ts
@@ -1,0 +1,83 @@
+// Streamable title pool resolution for overhead CRT TVs (ambient-tvs.ts).
+//
+// Extracted to keep ambient-tvs.ts modular and directly testable under
+// `node --test`: the overhead TVs stream ambient video directly from the
+// store's media server (Jellyfin/Plex). Synthetic items — titles on
+// streaming services (GH #86), Jellyseerr discovery/gap/coming-soon titles,
+// and video games — have no playable video on the media server. Letting them
+// enter the streamable pool causes the TV fixture to request non-existent
+// media IDs from the server, 404/fail, and permanently step down to the
+// bundled promo loop or dead glass.
+
+import type { Movie } from './jellyfin.ts';
+import { isUnstockedTitle } from './store-layout.ts';
+
+export interface TvPoolLibrary {
+  id: string;
+  name?: string;
+  streaming?: boolean;
+  games?: boolean;
+  movies: Movie[];
+}
+
+export interface TvPoolResult {
+  pool: Movie[];
+  fromChosen: boolean;
+}
+
+/**
+ * Whether a title is a real, streamable media-server item that the overhead
+ * TVs can ask Jellyfin or Plex to encode.
+ */
+export function isTvStreamableTitle(
+  movie: Movie,
+  library?: { streaming?: boolean; games?: boolean }
+): boolean {
+  if (library?.streaming || library?.games) return false;
+  if (isUnstockedTitle(movie)) return false;
+  if (movie.game || (movie as { isGame?: boolean }).isGame) return false;
+  return true;
+}
+
+/**
+ * Build the list of media-server titles the overhead TVs may draw from.
+ *
+ * Honors explicitly chosen libraries (Settings → Playback → Overhead TVs)
+ * when selected, including TV series containers (whose first episode is
+ * resolved at stream time). When no libraries are chosen (the default),
+ * filters to family-genre films across the catalog, falling back to all
+ * streamable films if no family titles exist. Unstocked and synthetic titles
+ * are always excluded.
+ */
+export function buildTvStreamablePool(
+  libraries: TvPoolLibrary[],
+  chosenLibIds: Set<string>
+): TvPoolResult {
+  const allMovies: Movie[] = [];
+  const chosenMovies: Movie[] = [];
+  const FAMILY_GENRES = new Set(['Family']);
+
+  libraries.forEach((lib) => {
+    if (lib.streaming || lib.games) return;
+    lib.movies.forEach((m) => {
+      if (!isTvStreamableTitle(m, lib)) return;
+
+      // A library the user EXPLICITLY picked contributes everything it shelves,
+      // series containers included (#67).
+      if (chosenLibIds.has(lib.id)) chosenMovies.push(m);
+
+      // The unselected default is still films only. That heuristic is what runs
+      // on every store that has never opened the drawer.
+      if (m.isSeries) return;
+      allMovies.push(m);
+    });
+  });
+
+  if (chosenMovies.length > 0) {
+    return { pool: chosenMovies, fromChosen: true };
+  }
+
+  const family = allMovies.filter((m) => m.genres && m.genres.some((g) => FAMILY_GENRES.has(g)));
+  const pool = family.length > 0 ? family : allMovies;
+  return { pool, fromChosen: false };
+}

--- a/src/ambient-tvs.ts
+++ b/src/ambient-tvs.ts
@@ -20,6 +20,7 @@ import { getActiveTheme } from './themes';
 import { makeCurvedScreenGeometry, makeTubeOverlayMaterial, makeCrtTestCardTexture } from './crt-tube';
 import { makeCrtGlassMaterial } from './glass-reflection';
 import { tvPoolLibraryIds } from './library-settings';
+import { buildTvStreamablePool } from './ambient-tv-pool';
 import { TV_PATCH_LAYER } from './scene-shared';
 import { assetUrl } from './asset-url';
 import { activeProvider, sessionOf } from './providers/active-provider';
@@ -298,30 +299,9 @@ export class AmbientTvs implements StoreFixture {
     // store stopped carrying it) falls back the same way rather than going
     // dark. Same gate for live streaming and the test-card stand-in below.
     const chosen = tvPoolLibraryIds();
-    const allMovies: Movie[] = [];
-    const chosenMovies: Movie[] = [];
-    this.ctx.libraries.forEach(lib => lib.movies.forEach(m => {
-      // A library the user EXPLICITLY picked contributes everything it shelves,
-      // series containers included (#67). Dropping those before the library
-      // check meant a TV-Shows library contributed nothing whatever its toggle
-      // said — the first reporter had switched TV shows on and it could never
-      // have done anything. A series container isn't itself streamable, but it
-      // names an episode that is; openStream resolves one.
-      if (chosen.has(lib.id)) chosenMovies.push(m);
-      // The unselected default is still films only. That heuristic is what runs
-      // on every store that has never opened the drawer, and quietly putting
-      // television on their monitors is not this fix's to make.
-      if (m.isSeries) return;
-      allMovies.push(m);
-    }));
-    let pool: Movie[];
-    if (chosenMovies.length > 0) {
-      pool = chosenMovies;
+    const { pool, fromChosen } = buildTvStreamablePool(this.ctx.libraries, chosen);
+    if (fromChosen) {
       this.ctx.log(`[System] CRT TVs: drawing from ${chosen.size} selected library(ies).`, 'system');
-    } else {
-      const FAMILY_GENRES = new Set(['Family']);
-      pool = allMovies.filter(m => m.genres.some(g => FAMILY_GENRES.has(g)));
-      if (pool.length === 0) pool = allMovies;
     }
     (window as any).__tvPool = {
       selected: chosen.size,

--- a/tests/ambient-tv-pool.test.ts
+++ b/tests/ambient-tv-pool.test.ts
@@ -1,0 +1,163 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Movie } from '../src/jellyfin.ts';
+import {
+  buildTvStreamablePool,
+  isTvStreamableTitle,
+  type TvPoolLibrary,
+} from '../src/ambient-tv-pool.ts';
+
+function makeMovie(overrides: Partial<Movie> = {}): Movie {
+  return {
+    id: 'movie-1',
+    title: 'Test Movie',
+    genres: ['Action'],
+    isSeries: false,
+    ...overrides,
+  } as Movie;
+}
+
+test('isTvStreamableTitle: identifies streamable server titles vs synthetic/unstocked titles', () => {
+  const realFilm = makeMovie({ id: 'f-1', title: 'Real Film' });
+  assert.equal(isTvStreamableTitle(realFilm), true);
+
+  const streamingMovie = makeMovie({ id: 's-1', title: 'Stream Title', streaming: true });
+  assert.equal(isTvStreamableTitle(streamingMovie), false);
+
+  const discoveryMovie = makeMovie({ id: 'd-1', title: 'Discovery Title', discovery: true });
+  assert.equal(isTvStreamableTitle(discoveryMovie), false);
+
+  const gapMovie = makeMovie({ id: 'g-1', title: 'Gap Title', collectionGap: true });
+  assert.equal(isTvStreamableTitle(gapMovie), false);
+
+  const comingSoonMovie = makeMovie({ id: 'cs-1', title: 'Coming Soon', comingSoon: true });
+  assert.equal(isTvStreamableTitle(comingSoonMovie), false);
+
+  const gameMovie = makeMovie({ id: 'gm-1', title: 'Game Title', game: true });
+  assert.equal(isTvStreamableTitle(gameMovie), false);
+
+  const gameObjMovie = makeMovie({ id: 'gm-2', title: 'Game Object' } as any);
+  (gameObjMovie as any).isGame = true;
+  assert.equal(isTvStreamableTitle(gameObjMovie), false);
+
+  assert.equal(isTvStreamableTitle(realFilm, { streaming: true }), false);
+  assert.equal(isTvStreamableTitle(realFilm, { games: true }), false);
+});
+
+test('buildTvStreamablePool: unchosen default excludes streaming and synthetic titles', () => {
+  const realAction = makeMovie({ id: 'm-1', title: 'Die Hard', genres: ['Action'] });
+  const realFamily = makeMovie({ id: 'm-2', title: 'Toy Story', genres: ['Family', 'Animation'] });
+  const streamingFamily = makeMovie({ id: 's-1', title: 'Moana', genres: ['Family'], streaming: true });
+  const gapFamily = makeMovie({ id: 'g-1', title: 'Lion King', genres: ['Family'], collectionGap: true });
+
+  const libs: TvPoolLibrary[] = [
+    {
+      id: 'lib-movies',
+      name: 'Movies',
+      movies: [realAction, realFamily, gapFamily],
+    },
+    {
+      id: 'lib-netflix',
+      name: 'Netflix',
+      streaming: true,
+      movies: [streamingFamily],
+    },
+  ];
+
+  const result = buildTvStreamablePool(libs, new Set());
+  assert.equal(result.fromChosen, false);
+  // Only realFamily should be in the pool (family filter applied, synthetic excluded)
+  assert.deepEqual(result.pool, [realFamily]);
+});
+
+test('buildTvStreamablePool: unchosen default falls back to all streamable films when no family titles exist', () => {
+  const realAction = makeMovie({ id: 'm-1', title: 'Die Hard', genres: ['Action'] });
+  const realSciFi = makeMovie({ id: 'm-2', title: 'Alien', genres: ['Sci-Fi', 'Horror'] });
+  const streamingFilm = makeMovie({ id: 's-1', title: 'Extraction', genres: ['Action'], streaming: true });
+  const gameTitle = makeMovie({ id: 'gm-1', title: 'Chrono Trigger', game: true });
+
+  const libs: TvPoolLibrary[] = [
+    {
+      id: 'lib-movies',
+      name: 'Movies',
+      movies: [realAction, realSciFi],
+    },
+    {
+      id: 'lib-streaming',
+      name: 'Prime Video',
+      streaming: true,
+      movies: [streamingFilm],
+    },
+    {
+      id: 'lib-games',
+      name: 'Games',
+      games: true,
+      movies: [gameTitle],
+    },
+  ];
+
+  const result = buildTvStreamablePool(libs, new Set());
+  assert.equal(result.fromChosen, false);
+  assert.deepEqual(result.pool, [realAction, realSciFi]);
+});
+
+test('buildTvStreamablePool: unchosen default excludes series containers', () => {
+  const realFilm = makeMovie({ id: 'm-1', title: 'Die Hard', genres: ['Action'], isSeries: false });
+  const realSeries = makeMovie({ id: 'tv-1', title: 'Twin Peaks', genres: ['Drama'], isSeries: true });
+
+  const libs: TvPoolLibrary[] = [
+    {
+      id: 'lib-movies',
+      name: 'Movies',
+      movies: [realFilm],
+    },
+    {
+      id: 'lib-tv',
+      name: 'TV Shows',
+      movies: [realSeries],
+    },
+  ];
+
+  const result = buildTvStreamablePool(libs, new Set());
+  assert.equal(result.fromChosen, false);
+  assert.deepEqual(result.pool, [realFilm]);
+});
+
+test('buildTvStreamablePool: chosen libraries include series containers but still exclude synthetic stock', () => {
+  const realSeries = makeMovie({ id: 'tv-1', title: 'Twin Peaks', isSeries: true });
+  const gapSeries = makeMovie({ id: 'tv-2', title: 'Lost', isSeries: true, collectionGap: true });
+  const realFilm = makeMovie({ id: 'm-1', title: 'Die Hard', isSeries: false });
+
+  const libs: TvPoolLibrary[] = [
+    {
+      id: 'lib-movies',
+      name: 'Movies',
+      movies: [realFilm],
+    },
+    {
+      id: 'lib-tv',
+      name: 'TV Shows',
+      movies: [realSeries, gapSeries],
+    },
+  ];
+
+  const result = buildTvStreamablePool(libs, new Set(['lib-tv']));
+  assert.equal(result.fromChosen, true);
+  assert.deepEqual(result.pool, [realSeries]);
+});
+
+test('buildTvStreamablePool: empty / fully synthetic libraries yield an empty pool', () => {
+  const streamingFilm = makeMovie({ id: 's-1', title: 'Stream', streaming: true });
+  const libs: TvPoolLibrary[] = [
+    {
+      id: 'lib-stream',
+      name: 'Netflix',
+      streaming: true,
+      movies: [streamingFilm],
+    },
+  ];
+
+  const result = buildTvStreamablePool(libs, new Set());
+  assert.equal(result.fromChosen, false);
+  assert.deepEqual(result.pool, []);
+});


### PR DESCRIPTION
### Problem

With streaming services enabled (GH #86), synthetic streaming libraries and unstocked titles (`movie.streaming === true`, Jellyseerr discovery `movie.discovery === true`, collection gaps `movie.collectionGap === true`, coming soon `movie.comingSoon === true`, and games `movie.game === true`) were included in the ambient CRT TV streamable pool in `src/ambient-tvs.ts`.

Because these synthetic items do not correspond to media hosted on the store's media server (Jellyfin or Plex):
1. When `AmbientTvs` randomly selected one of these titles via `pickPoolTitle`, `openStream` called `activeProvider().resolvePlaybackSource(...)` with a non-existent item ID.
2. The request failed / 404'd on the media server.
3. `openStream` caught the error and called `giveUpOnStream()`, causing the overhead TVs to permanently step down to the bundled 30-second Big Buck Bunny promo loop or dead glass even though the media server had valid movies and TV series to stream.

### Solution

- Extracted `isTvStreamableTitle` and `buildTvStreamablePool` in [ambient-tv-pool.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/ambient-tv-pool.ts) to filter out unstocked, streaming, discovery, gap, coming soon, and game titles from the ambient TV playback pool.
- Updated `AmbientTvs.build()` in [ambient-tvs.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/ambient-tvs.ts) to use `buildTvStreamablePool`.
- Added comprehensive unit tests in [ambient-tv-pool.test.ts](file:///home/nobara-user/Documents/antigravity/halcyon-ed/tests/ambient-tv-pool.test.ts) covering unchosen default pool resolution, family genre filtering, TV series container inclusion when chosen, and exclusion of synthetic/unstocked stock.

### Verification

- `npm test`: 308 tests pass cleanly.
- `npm run build`: File budgets, provider boundary checks, slot validation, TypeScript compilation (`tsc`), and Vite production build all pass with zero errors.