### PR TITLE
[ed patrol] Clean up clerk sprite, textures, and in-flight atlas swaps on scene teardown

### DIFF
--- a/src/clerk-template.ts
+++ b/src/clerk-template.ts
@@ -10,7 +10,9 @@ let served = false;
 
 export function maybeServeClerkTemplate(atlas: HTMLCanvasElement): void {
   if (served) return;
+  if (typeof location === 'undefined' || typeof document === 'undefined') return;
   if (new URLSearchParams(location.search).get('clerk_template') !== '1') return;
+  if (typeof atlas?.toBlob !== 'function') return;
   served = true;
   atlas.toBlob((blob) => {
     if (!blob) return;
@@ -21,4 +23,8 @@ export function maybeServeClerkTemplate(atlas: HTMLCanvasElement): void {
     a.download = 'clerk-sprite-template.png';
     a.click();
   }, 'image/png');
+}
+
+export function resetClerkTemplateServedForTesting(): void {
+  served = false;
 }

--- a/src/clerk.ts
+++ b/src/clerk.ts
@@ -95,8 +95,10 @@ export class StoreClerk {
 
   private sprite!: THREE.Sprite;
   private spriteTex!: THREE.Texture;
+  private shadowMesh!: THREE.Mesh;
   private shadowMat!: THREE.MeshBasicMaterial; // blob shadow — fades with the sprite
   private fade = 1; // sleep fade level last applied via setFade()
+  private disposed = false;
 
   // Animation + facing state
   private heading = Math.PI;          // world yaw she faces (atan2(x,z) convention)
@@ -288,8 +290,22 @@ export class StoreClerk {
   }
 
   public dispose() {
+    this.disposed = true;
     this.interaction?.dispose();
     this.interaction = null;
+    this.spriteTex?.dispose();
+    if (this.sprite) {
+      (this.sprite.material as THREE.Material)?.dispose();
+      this.sprite.geometry?.dispose();
+    }
+    if (this.shadowMat) {
+      this.shadowMat.map?.dispose();
+      this.shadowMat.dispose();
+    }
+    if (this.shadowMesh) {
+      this.shadowMesh.geometry?.dispose();
+    }
+    this.group.clear();
   }
 
   /**
@@ -401,11 +417,11 @@ export class StoreClerk {
     // Grounding shadow blob (a billboard can't cast a real shadow).
     const shadowTex = this.buildShadowTexture();
     this.shadowMat = new THREE.MeshBasicMaterial({ map: shadowTex, transparent: true, opacity: 0.34, depthWrite: false });
-    const shadow = new THREE.Mesh(new THREE.PlaneGeometry(2.3, 1.3), this.shadowMat);
-    shadow.rotation.x = -Math.PI / 2;
-    shadow.position.y = 0.02;
-    shadow.renderOrder = 1;
-    this.group.add(shadow);
+    this.shadowMesh = new THREE.Mesh(new THREE.PlaneGeometry(2.3, 1.3), this.shadowMat);
+    this.shadowMesh.rotation.x = -Math.PI / 2;
+    this.shadowMesh.position.y = 0.02;
+    this.shadowMesh.renderOrder = 1;
+    this.group.add(this.shadowMesh);
 
     this.spriteTex = this.buildAtlas();
     this.spriteTex.repeat.set(1 / ATLAS_COLS, 1 / ATLAS_ROWS);
@@ -488,6 +504,10 @@ export class StoreClerk {
    */
   private trySwapUserAtlas() {
     const swap = (tex: THREE.Texture) => {
+      if (this.disposed) {
+        tex.dispose();
+        return;
+      }
       // Same sampling as the procedural atlas: mipmaps bleed between cells.
       tex.magFilter = THREE.LinearFilter;
       tex.minFilter = THREE.LinearFilter;
@@ -505,7 +525,10 @@ export class StoreClerk {
       old.dispose();
     };
     tryLoadUserAssetTexture(`clerk/${getActiveTheme().id}.png`, swap, {
-      onMiss: () => tryLoadUserAssetTexture('clerk/default.png', swap),
+      onMiss: () => {
+        if (this.disposed) return;
+        tryLoadUserAssetTexture('clerk/default.png', swap);
+      },
     });
   }
 

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -5933,7 +5933,8 @@ export class StoreScene {
     // stale poster/bulb pointers.
     this.marqueeBulbsMesh = null;
     this.posterMarqueeFrames = [];
-    this.clerk?.dispose(); // tear down her DOM prompt/dialog so rebuilds don't stack them
+    this.clerk?.dispose(); // tear down her DOM prompt/dialog and GPU textures/materials
+    this.clerk = null;
     this.entrance?.dispose();
     this.entrance = null;
     this.slottedFixtures.forEach(f => f.dispose());

--- a/tests/clerk-template.test.ts
+++ b/tests/clerk-template.test.ts
@@ -1,0 +1,82 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  maybeServeClerkTemplate,
+  resetClerkTemplateServedForTesting,
+} from '../src/clerk-template.ts';
+
+test('maybeServeClerkTemplate is a no-op when location/document are undefined or param absent', () => {
+  resetClerkTemplateServedForTesting();
+  const fakeCanvas = {
+    toBlob: () => {
+      assert.fail('toBlob should not be called when location is undefined');
+    },
+  } as unknown as HTMLCanvasElement;
+
+  // In standard node environment where global location is undefined:
+  maybeServeClerkTemplate(fakeCanvas);
+});
+
+test('maybeServeClerkTemplate triggers download once when ?clerk_template=1 is present', () => {
+  resetClerkTemplateServedForTesting();
+
+  let clicked = false;
+  let downloadedName = '';
+  let downloadUrl = '';
+
+  const origLocation = (globalThis as any).location;
+  const origDocument = (globalThis as any).document;
+  const origUrl = (globalThis as any).URL;
+
+  try {
+    (globalThis as any).location = { search: '?clerk_template=1' };
+    (globalThis as any).URL = {
+      createObjectURL: (_blob: any) => 'blob:test-template-url',
+    };
+    (globalThis as any).document = {
+      createElement: (tag: string) => {
+        if (tag === 'a') {
+          return {
+            set href(val: string) { downloadUrl = val; },
+            get href() { return downloadUrl; },
+            set download(val: string) { downloadedName = val; },
+            get download() { return downloadedName; },
+            click: () => { clicked = true; },
+          };
+        }
+        return {};
+      },
+    };
+
+    let blobCallbackCalled = false;
+    const fakeBlob = {};
+    const fakeCanvas = {
+      toBlob: (cb: (blob: any) => void, mime: string) => {
+        assert.equal(mime, 'image/png');
+        blobCallbackCalled = true;
+        cb(fakeBlob);
+      },
+    } as unknown as HTMLCanvasElement;
+
+    maybeServeClerkTemplate(fakeCanvas);
+
+    assert.ok(blobCallbackCalled, 'toBlob callback should have been invoked');
+    assert.ok(clicked, 'download link should have been clicked');
+    assert.equal(downloadedName, 'clerk-sprite-template.png');
+    assert.equal(downloadUrl, 'blob:test-template-url');
+
+    // Second call should be ignored (served once)
+    let secondCall = false;
+    const fakeCanvas2 = {
+      toBlob: () => { secondCall = true; },
+    } as unknown as HTMLCanvasElement;
+
+    maybeServeClerkTemplate(fakeCanvas2);
+    assert.equal(secondCall, false, 'second call must be suppressed');
+  } finally {
+    (globalThis as any).location = origLocation;
+    (globalThis as any).document = origDocument;
+    (globalThis as any).URL = origUrl;
+    resetClerkTemplateServedForTesting();
+  }
+});


### PR DESCRIPTION
### Problem

1. `StoreClerk` allocates several WebGL resources (`shadowMesh` plane geometry, `shadowMat` canvas texture, `spriteTex` procedural/user atlas texture, `sprite` geometry, and `SpriteMaterial`) upon construction in `src/clerk.ts`.
2. When the 3D scene is rebuilt or torn down in `StoreScene.destroy()` (in `src/three-scene.ts`), `this.clerk?.dispose()` was called, but `StoreClerk.dispose()` only disposed `this.interaction?.dispose()`, leaving all clerk GPU textures and materials allocated in memory. The fallback `this.scene.traverse` loop in `destroy()` also failed to clean them up because `this.sprite` is a `THREE.Sprite` (which is skipped by `object instanceof THREE.Mesh`) and `MeshBasicMaterial.dispose()` does not dispose its map texture.
3. Furthermore, `trySwapUserAtlas()` asynchronously loads custom user/brand clerk atlas textures via `tryLoadUserAssetTexture()`. If the scene or clerk was destroyed while an atlas load was in-flight, the `swap` callback would run on the dead clerk instance and attach the newly loaded texture to a discarded sprite, leaking the texture permanently.
4. `maybeServeClerkTemplate()` in `src/clerk-template.ts` accessed `location.search` and `document` without checking for undefined environments and did not guard `atlas.toBlob`.

### Solution

- **Resource Disposal**: Updated `StoreClerk.dispose()` in `src/clerk.ts` to dispose `this.spriteTex`, `this.sprite` material/geometry, `this.shadowMat` texture/material, `this.shadowMesh` geometry, and clear `this.group`.
- **In-flight Atlas Guard**: Added `this.disposed` state to `StoreClerk`. If `swap` or `onMiss` executes after the clerk has been disposed, the incoming texture is immediately disposed and discarded rather than attached to dead scene objects.
- **Scene Teardown**: Updated `StoreScene.destroy()` in `src/three-scene.ts` to null out `this.clerk = null`.
- **Template Export Guard & Tests**: Guarded `maybeServeClerkTemplate()` in `src/clerk-template.ts` against non-browser/headless environments, exported `resetClerkTemplateServedForTesting()`, and added unit test coverage in `tests/clerk-template.test.ts`.

### Verification

- `npm test`: 304 tests passing cleanly (including new clerk template tests).
- `npm run build`: File budgets, provider boundary checks, slot validation, TypeScript compilation (`tsc`), and Vite production build all pass with zero errors.