### PR TITLE
[ed patrol] Guard non-rentable and streaming items from carry stack and backfill

### DIFF
--- a/src/carried-tapes.ts
+++ b/src/carried-tapes.ts
@@ -123,15 +123,22 @@ export class CarriedTapes {
   private readonly _m = new THREE.Matrix4();
   private readonly _m2 = new THREE.Matrix4();
 
+  private scene: THREE.Scene;
+  private camera: THREE.PerspectiveCamera;
+  private onChange?: () => void;
+
   // T23: rental mode retunes this per the weekday/weekend rule (setCapacity).
   private _capacity: number;
 
   constructor(
-    private scene: THREE.Scene,
-    private camera: THREE.PerspectiveCamera,
+    scene: THREE.Scene,
+    camera: THREE.PerspectiveCamera,
     capacity: number,
-    private onChange?: () => void,
+    onChange?: () => void,
   ) {
+    this.scene = scene;
+    this.camera = camera;
+    this.onChange = onChange;
     this._capacity = Math.max(1, Math.min(MAX_CARRY_CAPACITY, capacity));
     // Viewmodel: the holder rides the camera. The owner guarantees the camera
     // is in the scene graph (StoreScene adds it on first use).

--- a/src/store-checkout.ts
+++ b/src/store-checkout.ts
@@ -14,6 +14,7 @@ import { CandyRow } from './fixtures/period-fixtures';
 import { retailAudio } from './audio';
 import { CarriedTapes, CarryPose, showClerkToast, CARRY_STORAGE_KEY, DEFAULT_CARRY_CAPACITY } from './carried-tapes';
 import { saveRentalRecord, makeRentalRecord, rentalCapacityAt } from './rental-clock';
+import { isDiscoveryRequested } from './jellyseerr';
 import { tipJarEnabled } from './tip-jar';
 import {
   _bagBaseFallback, _checkoutBagFallback, _checkoutCarry, _checkoutStand,
@@ -145,6 +146,42 @@ export function slotBackBoxPose(_scene: StoreScene, slot: MovieSlot): CarryPose 
 // shelf case raycast hit directly out of walk mode. Does not touch scene.mode
 // or the camera — callers decide what happens to the view afterward.
 export function takeTapeIntoCarry(scene: StoreScene, movie: Movie, slot: MovieSlot | null): boolean {
+  if (movie.comingSoon) {
+    retailAudio.playDenyBuzz();
+    showClerkToast(`"${movie.title}" is already on order, hon — it should be in soon.`);
+    scene.onConsoleLog(`[System] "${movie.title}" is coming soon and isn't available to rent yet.`, 'system');
+    return false;
+  }
+  if (movie.discovery || movie.collectionGap) {
+    retailAudio.playDenyBuzz();
+    if (movie.discoveryRequested || isDiscoveryRequested(movie.tmdbId)) {
+      showClerkToast(`"${movie.title}" is already on order, hon — it should be in soon.`);
+      scene.onConsoleLog(`[System] "${movie.title}" has already been requested.`, 'system');
+    } else {
+      showClerkToast(`"${movie.title}" isn't in stock, hon — examine it to request an order.`);
+      scene.onConsoleLog(`[System] "${movie.title}" is not in stock.`, 'system');
+    }
+    return false;
+  }
+  if (movie.streaming) {
+    retailAudio.playDenyBuzz();
+    showClerkToast(`"${movie.title}" is on ${movie.streamingServiceName || 'streaming'} — examine it to open the service.`);
+    scene.onConsoleLog(`[System] "${movie.title}" is on ${movie.streamingServiceName || 'streaming'} and has no in-store rental copy.`, 'system');
+    return false;
+  }
+  if (movie.game) {
+    retailAudio.playDenyBuzz();
+    showClerkToast(`"${movie.title}" is a game — examine it to rent and play.`);
+    scene.onConsoleLog(`[System] "${movie.title}" is a video game and cannot be carried to checkout.`, 'system');
+    return false;
+  }
+  if (movie.isSeries) {
+    retailAudio.playDenyBuzz();
+    showClerkToast(`"${movie.title}" is a series boxset — examine it to pick an episode.`);
+    scene.onConsoleLog(`[System] "${movie.title}" is a series boxset and cannot be carried.`, 'system');
+    return false;
+  }
+
   const carried = scene.ensureCarried();
   const verdict = carried.canTake(movie.id);
   if (verdict === 'full') {

--- a/src/store-rental.ts
+++ b/src/store-rental.ts
@@ -227,7 +227,7 @@ export function debugEnterBackRoom(scene: StoreScene, n: number): boolean {
   const ids: string[] = [];
   outer: for (const lib of scene.libraries) {
     for (const m of lib.movies) {
-      if (m.isSeries || m.comingSoon || m.discovery || m.game) continue;
+      if (m.isSeries || m.comingSoon || m.discovery || m.game || m.streaming || m.collectionGap) continue;
       if (!ids.includes(m.id)) ids.push(m.id);
       if (ids.length >= n) break outer;
     }

--- a/src/three-scene.ts
+++ b/src/three-scene.ts
@@ -1124,7 +1124,8 @@ export class StoreScene {
       let shelfLib: JellyfinLibrary | null = null;
       let best = -1;
       for (const lib of this.libraries) {
-        const n = lib.movies.filter((m) => !m.isSeries && !m.game && !m.collectionGap).length;
+        if (lib.streaming) continue;
+        const n = lib.movies.filter((m) => !m.isSeries && !m.game && !m.collectionGap && !m.discovery && !m.comingSoon && !m.streaming).length;
         if (n > best) { best = n; shelfLib = lib; }
       }
       if (shelfLib) {
@@ -1269,7 +1270,7 @@ export class StoreScene {
     const allMoviesMap = new Map<string, Movie>();
     this.libraries.forEach((lib) => {
       lib.movies.forEach((m) => {
-        if (m.discovery || m.collectionGap || m.comingSoon) return;
+        if (m.discovery || m.collectionGap || m.comingSoon || m.streaming || m.game) return;
         allMoviesMap.set(m.id, m);
       });
     });


### PR DESCRIPTION
## Summary of Changes

### Problem
1. In VR walk mode (`src/store-vr.ts` and `src/store-walk.ts`), trigger raycasting on shelf cases calls `walkTakeSlot` which directly invokes `takeTapeIntoCarry(scene, movie, slot)`. Unlike 2D inspect mode (`src/store-inspect.ts`), `takeTapeIntoCarry` lacked guards for special non-rentable items (`comingSoon`, `discovery`, `collectionGap`, `streaming`, `game`, and `isSeries`).
2. When players in VR picked up these special items, they were placed into `scene.carried`. Upon walking to the checkout register and checking out, `onCheckoutComplete` attempted to launch local video playback on synthetic or non-existent media IDs (e.g. streaming URLs, game ROMs, coming soon items), causing playback errors and breaking expected flows.
3. In `three-scene.ts`, discovery candidate shelving and New Releases wall backfill calculations did not filter streaming services and non-film formats, potentially selecting streaming libraries for Jellyseerr discovery placement and placing streaming titles on the New Releases wall.
4. In `store-rental.ts`, `debugEnterBackRoom` did not filter `streaming` or `collectionGap` titles.

### Fix
- Added explicit type guards with corresponding audio deny buzz and clerk toast notifications in `takeTapeIntoCarry` (`src/store-checkout.ts`) for `comingSoon`, `discovery`, `collectionGap`, `streaming`, `game`, and `isSeries`.
- Excluded streaming libraries and non-rentable items when resolving `shelfLib` for discovery stock and when populating the New Releases wall in `src/three-scene.ts`.
- Filtered `streaming` and `collectionGap` items in `debugEnterBackRoom` (`src/store-rental.ts`).
- Cleaned constructor parameter property types in `CarriedTapes` (`src/carried-tapes.ts`).

### Verification
- `npm test` passes cleanly (302 tests pass).
- `npm run build` compiles with zero errors.