### PR TITLE
[ed patrol] Include skipCrop in low-res transitional front material cache key

### DIFF
--- a/src/hero-lowres-front.ts
+++ b/src/hero-lowres-front.ts
@@ -127,7 +127,7 @@ export function getLowResFrontMaterial(
   const src = resolveFallbackPixels(movieId);
   if (!src) return null;
 
-  const key = `${movieId}_anim_${isAnimated}_probe_${probeIdx !== undefined ? probeIdx : 'none'}_fin_${finish ?? 'default'}`;
+  const key = `${movieId}_anim_${isAnimated}_crop_${skipCrop}_probe_${probeIdx !== undefined ? probeIdx : 'none'}_fin_${finish ?? 'default'}`;
   const cached = lowResFrontLRU.get(key);
   if (cached) {
     lowResFrontLRU.delete(key); // refresh recency


### PR DESCRIPTION
### Problem
`getLowResFrontMaterial` creates and caches transitional low-res front materials in `lowResFrontLRU`. Although `skipCrop` is passed as a parameter and used to determine whether to crop the front texture for the medium (`cropFrontTextureForMedium(tex)`) and compute the white border shader width (`skipCrop ? 0 : POSTER_CROP_X`), `skipCrop` was omitted from the LRU cache key.

As a result, if `getLowResFrontMaterial` was called with different `skipCrop` values for the same movie ID (e.g. game box cartons / uncropped covers vs standard cropped media fronts), the cached material for the first requested crop mode would be reused, leading to improper crop or border shader application.

### Fix
Include `skipCrop` in the LRU cache key in `src/hero-lowres-front.ts`, mirroring `hero-front-detail.ts`.

### Verification
- `npm run build` completed cleanly with zero errors.
- `npm test` passed (302 tests passing).