### PR TITLE
[ed patrol] Attach resolved release screenshot to GitHub Release and fix fanout help flag

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -200,7 +200,9 @@ jobs:
           # The screenshot is optional (see the header) — attach it only if a
           # shot actually landed.
           ASSETS=()
-          if [ -f release-shot.png ]; then ASSETS+=(release-shot.png); fi
+          if [ -n "${{ steps.shot.outputs.path }}" ] && [ -f "${{ steps.shot.outputs.path }}" ]; then
+            ASSETS+=("${{ steps.shot.outputs.path }}")
+          fi
           gh release create "${{ github.ref_name }}" \
             --repo "${{ github.repository }}" \
             --title "${{ github.ref_name }}" \

--- a/tests/announce.test.ts
+++ b/tests/announce.test.ts
@@ -1,0 +1,56 @@
+// Unit tests for release tools: release-notes.mjs and announce-fanout.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const fanoutScript = path.join(root, 'tools/announce-fanout.mjs');
+const releaseNotesScript = path.join(root, 'tools/release-notes.mjs');
+
+test('announce-fanout: --help and -h print help and exit 0', () => {
+  const res1 = spawnSync('node', [fanoutScript, '--help'], { encoding: 'utf8' });
+  assert.equal(res1.status, 0);
+  assert.match(res1.stderr + res1.stdout, /Usage: node tools\/announce-fanout\.mjs/);
+
+  const res2 = spawnSync('node', [fanoutScript, '-h'], { encoding: 'utf8' });
+  assert.equal(res2.status, 0);
+  assert.match(res2.stderr + res2.stdout, /Usage: node tools\/announce-fanout\.mjs/);
+
+  const res3 = spawnSync('node', [fanoutScript, 'discord', '--help'], { encoding: 'utf8' });
+  assert.equal(res3.status, 0);
+  assert.match(res3.stderr + res3.stdout, /Usage: node tools\/announce-fanout\.mjs/);
+});
+
+test('announce-fanout: missing arguments exit with code 2', () => {
+  const res1 = spawnSync('node', [fanoutScript], { encoding: 'utf8' });
+  assert.equal(res1.status, 2);
+
+  const res2 = spawnSync('node', [fanoutScript, 'discord'], { encoding: 'utf8' });
+  assert.equal(res2.status, 2);
+  assert.match(res2.stderr, /--tag <vX\.Y\.Z> is required/);
+});
+
+test('announce-fanout: reddit-draft produces a valid draft for a known tag', () => {
+  const tmpOut = path.join(os.tmpdir(), `test-reddit-draft-${Date.now()}.md`);
+  try {
+    const res = spawnSync('node', [fanoutScript, 'reddit-draft', '--tag', 'v0.8.1', '--out', tmpOut], { encoding: 'utf8' });
+    assert.equal(res.status, 0);
+    assert.equal(fs.existsSync(tmpOut), true);
+    const content = fs.readFileSync(tmpOut, 'utf8');
+    assert.match(content, /\*\*Halcyon Video v0\.8\.1/);
+    assert.match(content, /Try it in a browser, no server needed:/);
+    assert.match(content, /Posting notes/);
+  } finally {
+    if (fs.existsSync(tmpOut)) fs.unlinkSync(tmpOut);
+  }
+});
+
+test('release-notes: generates grouped release notes', () => {
+  const res = spawnSync('node', [releaseNotesScript, '--to', 'v0.8.1', '--from', 'v0.8.0'], { encoding: 'utf8' });
+  assert.equal(res.status, 0);
+  assert.match(res.stdout, /VR headsets can enter VR without a keyboard/);
+});

--- a/tools/announce-fanout.mjs
+++ b/tools/announce-fanout.mjs
@@ -40,6 +40,10 @@ function git(args) {
 }
 
 function parseArgs(argv) {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    printHelp();
+    process.exit(0);
+  }
   const [channel, ...rest] = argv;
   const opts = { channel, tag: null, screenshot: null, repo: DEFAULT_REPO, out: null };
   for (let i = 0; i < rest.length; i++) {
@@ -48,7 +52,6 @@ function parseArgs(argv) {
     else if (a === '--screenshot') opts.screenshot = rest[++i];
     else if (a === '--repo') opts.repo = rest[++i];
     else if (a === '--out') opts.out = rest[++i];
-    else if (a === '--help' || a === '-h') { printHelp(); process.exit(0); }
     else { console.error(`announce-fanout: unknown option ${a}`); process.exit(2); }
   }
   if (!opts.channel) { printHelp(); process.exit(2); }
@@ -197,7 +200,8 @@ async function channelDiscord(opts, ann) {
 async function channelMastodon(opts, ann) {
   const creds = requireEnv('MASTODON_INSTANCE', 'MASTODON_TOKEN');
   if (!creds) return;
-  const base = creds.MASTODON_INSTANCE.replace(/\/+$/, '');
+  const rawBase = creds.MASTODON_INSTANCE.replace(/\/+$/, '');
+  const base = /^https?:\/\//i.test(rawBase) ? rawBase : `https://${rawBase}`;
   const auth = { Authorization: `Bearer ${creds.MASTODON_TOKEN}` };
   let mediaIds = [];
   const shot = readScreenshot(opts);


### PR DESCRIPTION
## Summary of Changes

### Problem
1. **GitHub Release screenshot asset missing**: In `.github/workflows/announce.yml`, the screenshot resolution step (`Resolve the announcement image`, output `steps.shot.outputs.path`) was updated in recent commits (such as commit `54a46de`) to prioritize committed per-release screenshots (`docs/releases/<tag>.jpg`) and fall back to stills (`release-shot.jpg`). However, the subsequent step `Cut the GitHub Release` still hardcoded `if [ -f release-shot.png ]; then ASSETS+=(release-shot.png); fi`. Because `docs/releases/<tag>.jpg` and `release-shot.jpg` do not match that exact filename, releases cut in CI had no screenshot asset attached.
2. **Help flag parsing in `announce-fanout.mjs`**: In `tools/announce-fanout.mjs`, `parseArgs` assigned `argv[0]` to `channel` without checking for `--help` or `-h`. Invoking `node tools/announce-fanout.mjs --help` resulted in `channel` taking `'--help'`, which bypassed the options loop and failed with `announce-fanout: --tag <vX.Y.Z> is required` (exit status 2).
3. **Mastodon instance URL**: `channelMastodon` assumed `MASTODON_INSTANCE` contained a URL scheme; if configured as a domain name (e.g. `mastodon.social`), `fetch` failed with an invalid URL error.

### Fix
- Updated `announce.yml`'s `Cut the GitHub Release` step to attach `steps.shot.outputs.path` if present and existing on disk.
- Updated `tools/announce-fanout.mjs` to check for `--help` / `-h` before consuming channel positional args, exiting cleanly with 0.
- Normalized `MASTODON_INSTANCE` in `tools/announce-fanout.mjs` to ensure a `https://` prefix is prepended if missing.
- Added comprehensive unit tests in `tests/announce.test.ts` for release note generation, fanout argument parsing, `--help` behavior, and Reddit draft generation.

### Verification
- `npm test` passed cleanly with 306/306 tests passing.
- `npm run build` completed cleanly with zero errors.