### PR TITLE
[ed patrol] Hand off streaming-service titles to external URL in 2.5D flat detail view

### DIFF
--- a/src/flat/flat-detail.ts
+++ b/src/flat/flat-detail.ts
@@ -8,7 +8,7 @@ import { getActiveTheme } from '../themes';
 import { getActiveLogoSpec } from '../logo-spec';
 import { drawLogo } from '../logo-renderer';
 import { flatSignal } from './flat-lifecycle';
-import { resolveEpisodePlaybackArgs } from './flat-playback';
+import { resolveEpisodePlaybackArgs, resolveFlatDetailAction } from './flat-playback';
 
 let launchVideoPlaybackFn: ((movie: Movie, overrideItemId?: string, overridePath?: string) => Promise<void>) | null = null;
 
@@ -143,22 +143,11 @@ export function openDetailsOverlay(
   // Determine button text/state
   const isRequested = (movie.discovery || movie.collectionGap) &&
     (movie.discoveryRequested || isDiscoveryRequested(movie.tmdbId));
-  let playBtnText = 'Play';
-  let playBtnDisabled = '';
-  let playBtnIcon = '▶';
+  const action = resolveFlatDetailAction(movie, { isRequested });
+  const playBtnText = action.text;
+  const playBtnDisabled = action.disabled ? 'disabled' : '';
+  const playBtnIcon = action.icon;
 
-  if (movie.game) {
-    playBtnText = 'Rent';
-    playBtnIcon = '🎮';
-  } else if (movie.discovery || movie.collectionGap) {
-    playBtnText = isRequested ? (movie.collectionGap ? 'Coming Soon' : 'Requested') : 'Request';
-    playBtnIcon = isRequested ? '✓' : '✦';
-    playBtnDisabled = isRequested ? 'disabled' : '';
-  } else if (movie.comingSoon) {
-    playBtnText = 'Coming Soon';
-    playBtnIcon = '⏱';
-    playBtnDisabled = 'disabled';
-  }
 
   // The clamshell lip's small embossed brand mark: the ACTIVE emblem, painted
   // from the LogoSpec onto an offscreen canvas (one-shot — flat mode is DOM,
@@ -426,6 +415,19 @@ export function openDetailsOverlay(
       } else {
         logSystemMessage(`[System] Failed to request "${movie.title}" (Jellyseerr unreachable or rejected the request).`);
       }
+    } else if (movie.streaming) {
+      if (!movie.streamingUrl) {
+        logSystemMessage(`[System] "${movie.title}" has no streaming link.`);
+        return;
+      }
+      logSystemMessage(`[System] Opening ${movie.streamingServiceName || 'the streaming service'} for "${movie.title}"...`);
+      try {
+        window.open(movie.streamingUrl, '_blank', 'noopener');
+      } catch {
+        logSystemMessage(`[System] Couldn't open the link for "${movie.title}" (popup blocked?).`);
+      }
+      closeOverlay();
+
     } else {
       if (movie.isSeries) {
         if (episodesList.length > 0) {
@@ -436,6 +438,7 @@ export function openDetailsOverlay(
       }
     }
   });
+
 
   closeBtn.addEventListener('click', () => {
     closeOverlay();

--- a/src/flat/flat-playback.ts
+++ b/src/flat/flat-playback.ts
@@ -32,8 +32,50 @@
 // is the guard: it takes no server, no session, no provider, so a network
 // call — right target or wrong — cannot be smuggled back into it without a
 // reviewer noticing the new parameter.
-import type { Episode } from '../jellyfin.ts';
+import type { Episode, Movie } from '../jellyfin.ts';
 
 export function resolveEpisodePlaybackArgs(ep: Episode): { itemId: string; path: string } {
   return { itemId: ep.id, path: ep.path };
 }
+
+export interface FlatDetailAction {
+  kind: 'play' | 'game' | 'request' | 'coming-soon' | 'streaming';
+  text: string;
+  icon: string;
+  disabled: boolean;
+}
+
+/**
+ * Resolves the primary action button's kind, label, icon, and disabled state for
+ * the 2.5D flat detail overlay. Pure data logic, safe for bare `node --test`.
+ */
+export function resolveFlatDetailAction(
+  movie: Movie,
+  opts: { isRequested?: boolean } = {}
+): FlatDetailAction {
+  if (movie.game) {
+    return { kind: 'game', text: 'Rent', icon: '🎮', disabled: false };
+  }
+  if (movie.discovery || movie.collectionGap) {
+    const req = opts.isRequested ?? false;
+    return {
+      kind: 'request',
+      text: req ? (movie.collectionGap ? 'Coming Soon' : 'Requested') : 'Request',
+      icon: req ? '✓' : '✦',
+      disabled: req,
+    };
+  }
+  if (movie.comingSoon) {
+    return { kind: 'coming-soon', text: 'Coming Soon', icon: '⏱', disabled: true };
+  }
+  if (movie.streaming) {
+    return {
+      kind: 'streaming',
+      text: `Watch on ${movie.streamingServiceName || 'Service'}`,
+      icon: '↗',
+      disabled: false,
+    };
+  }
+  return { kind: 'play', text: 'Play', icon: '▶', disabled: false };
+}
+

--- a/tests/flat-detail.test.ts
+++ b/tests/flat-detail.test.ts
@@ -24,10 +24,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer, type Server } from 'node:http';
-import type { Episode } from '../src/jellyfin.ts';
+import type { Episode, Movie } from '../src/jellyfin.ts';
 import { fetchFirstEpisodeOfSeries } from '../src/jellyfin.ts';
 import { fetchPlexFirstEpisodeOfSeries } from '../src/plex.ts';
-import { resolveEpisodePlaybackArgs } from '../src/flat/flat-playback.ts';
+import { resolveEpisodePlaybackArgs, resolveFlatDetailAction } from '../src/flat/flat-playback.ts';
 
 function mkEpisode(extra: Partial<Episode> = {}): Episode {
   return {
@@ -42,6 +42,23 @@ function mkEpisode(extra: Partial<Episode> = {}): Episode {
     ...extra,
   };
 }
+
+function mkMovie(extra: Partial<Movie> = {}): Movie {
+  return {
+    id: 'm-1',
+    title: 'The Matrix',
+    year: 1999,
+    duration: '136 min',
+    rating: 'R',
+    overview: 'A computer hacker learns the truth...',
+    director: 'The Wachowskis',
+    actors: ['Keanu Reeves'],
+    genres: ['Action', 'Sci-Fi'],
+    localPath: '/media/movies/The Matrix (1999).mkv',
+    ...extra,
+  };
+}
+
 
 // ── Layer 1: the pure function flat-detail.ts's playEpisode now calls ──────
 
@@ -114,3 +131,87 @@ test('Plex: asking for an episode-as-series (the GH #71 trap) resolves null, exa
     assert.equal(result, null);
   });
 });
+
+// ── Layer 3: resolveFlatDetailAction pure button resolution ─────────────────
+
+test('resolveFlatDetailAction: standard movie resolves to Play button', () => {
+  const m = mkMovie();
+  assert.deepEqual(resolveFlatDetailAction(m), {
+    kind: 'play',
+    text: 'Play',
+    icon: '▶',
+    disabled: false,
+  });
+});
+
+test('resolveFlatDetailAction: game resolves to Rent button', () => {
+  const m = mkMovie({ game: true, platform: 'SNES' });
+  assert.deepEqual(resolveFlatDetailAction(m), {
+    kind: 'game',
+    text: 'Rent',
+    icon: '🎮',
+    disabled: false,
+  });
+});
+
+test('resolveFlatDetailAction: unrequested discovery/collectionGap resolves to Request button', () => {
+  const gap = mkMovie({ collectionGap: true, tmdbId: 101 });
+  assert.deepEqual(resolveFlatDetailAction(gap, { isRequested: false }), {
+    kind: 'request',
+    text: 'Request',
+    icon: '✦',
+    disabled: false,
+  });
+
+  const disc = mkMovie({ discovery: true, tmdbId: 102 });
+  assert.deepEqual(resolveFlatDetailAction(disc, { isRequested: false }), {
+    kind: 'request',
+    text: 'Request',
+    icon: '✦',
+    disabled: false,
+  });
+});
+
+test('resolveFlatDetailAction: requested discovery/collectionGap resolves to disabled Requested/Coming Soon button', () => {
+  const gap = mkMovie({ collectionGap: true, tmdbId: 101 });
+  assert.deepEqual(resolveFlatDetailAction(gap, { isRequested: true }), {
+    kind: 'request',
+    text: 'Coming Soon',
+    icon: '✓',
+    disabled: true,
+  });
+
+  const disc = mkMovie({ discovery: true, tmdbId: 102 });
+  assert.deepEqual(resolveFlatDetailAction(disc, { isRequested: true }), {
+    kind: 'request',
+    text: 'Requested',
+    icon: '✓',
+    disabled: true,
+  });
+});
+
+test('resolveFlatDetailAction: comingSoon resolves to disabled Coming Soon button', () => {
+  const m = mkMovie({ comingSoon: true });
+  assert.deepEqual(resolveFlatDetailAction(m), {
+    kind: 'coming-soon',
+    text: 'Coming Soon',
+    icon: '⏱',
+    disabled: true,
+  });
+});
+
+test('resolveFlatDetailAction: streaming-service title resolves to Watch on <Service> button with link icon', () => {
+  const m = mkMovie({
+    streaming: true,
+    streamingServiceId: 'netflix',
+    streamingServiceName: 'NETFLIX',
+    streamingUrl: 'https://www.netflix.com/search?q=The%20Matrix',
+  });
+  assert.deepEqual(resolveFlatDetailAction(m), {
+    kind: 'streaming',
+    text: 'Watch on NETFLIX',
+    icon: '↗',
+    disabled: false,
+  });
+});
+


### PR DESCRIPTION
### Problem
In the 2.5D flat store detail overlay ([`flat-detail.ts`](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/flat/flat-detail.ts)), streaming-service titles (`movie.streaming === true`) were not explicitly handled by the action button state resolver. This caused streaming titles to render a default "Play ▶" button. Clicking this button passed the streaming title into `launchVideoPlaybackFn(movie)`, attempting to stream the title from the local media server or open external players on an empty path (`localPath: \"\"`), which fails.

### Fix
1. Added [`resolveFlatDetailAction`](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/flat/flat-playback.ts) in [`flat-playback.ts`](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/flat/flat-playback.ts) to purely resolve the primary button's action kind, text, icon, and disabled status (`streaming` -> `Watch on <SERVICE>` with `↗` icon).
2. Updated [`openDetailsOverlay`](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/flat/flat-detail.ts) in [`flat-detail.ts`](file:///home/nobara-user/Documents/antigravity/halcyon-ed/src/flat/flat-detail.ts) to use `resolveFlatDetailAction` and open the service's external link (`movie.streamingUrl`) in a new tab via `window.open(movie.streamingUrl, \"_blank\", \"noopener\")`, matching the 3D inspect behavior.
3. Added unit test coverage in [`tests/flat-detail.test.ts`](file:///home/nobara-user/Documents/antigravity/halcyon-ed/tests/flat-detail.test.ts).

### Verification
- `npm test` passes all 308 tests cleanly.
- `npm run build` builds cleanly with zero errors.