### PR TITLE
[ed patrol] Restore camera into scene hierarchy on VR exit when carried tapes exist

### DIFF
--- a/src/store-vr.ts
+++ b/src/store-vr.ts
@@ -399,6 +399,7 @@ function cleanupAfterSession(scene: StoreScene, state: VRState): void {
   const x = state.rig.position.x;
   const z = state.rig.position.z;
   state.rig.remove(scene.camera);
+  if (scene.carried) scene.scene.add(scene.camera);
   scene.camera.position.set(x, VR_EYE_HEIGHT_FT, z);
   // WebXRManager overwrote fov/zoom from the eye projection for the
   // session's duration (see updateUserCamera in three's WebXRManager.js) —


### PR DESCRIPTION
### Summary of Bug
When entering VR, `enterVR` parents the camera under the VR rig (`state.rig.add(scene.camera)`). When exiting VR, `cleanupAfterSession` calls `state.rig.remove(scene.camera)`, unparenting the camera and leaving `scene.camera.parent === null`.

Because the held-stack viewmodel of carried rental cases (`scene.carried.holder`) is parented to `scene.camera`, Three.js's scene traversal during `renderer.render(scene.scene, scene.camera)` skips the camera and its children if `scene.camera` is not in `scene.scene`. Consequently, after exiting VR while carrying tapes (or picking up tapes in VR and returning to flat walk mode), the carried tapes viewmodel becomes completely invisible.

### Fix
In `cleanupAfterSession` in `src/store-vr.ts`, re-parent `scene.camera` back into `scene.scene` if `scene.carried` is active.

### Verification
- Ran `npm test` (all 302 unit tests pass).
- Ran `npm run build` (passed with zero errors).