### PR TITLE
Boot escape docks the counter CRT instead of the old login form

### DIFF
--- a/src/boot-flow.ts
+++ b/src/boot-flow.ts
@@ -94,7 +94,7 @@ let deps: BootFlowDeps | null = null;
 // Opening-day (#41) plumbing: what the setup terminal should show once the
 // empty scene has revealed, and hooks into the auto-retry loop below so the
 // notice screen's RETRY NOW / CHANGE SERVER rows can drive it.
-let pendingSetup: { notice?: { address: string; detail: string } } | null = null;
+let pendingSetup: { notice?: { title?: string; address: string; detail: string } } | null = null;
 let retryNowHook: (() => void) | null = null;
 let cancelRetryHook: (() => void) | null = null;
 
@@ -141,7 +141,7 @@ export function initBootFlow(d: BootFlowDeps): void {
  * queue the setup terminal to dock once the scene reveals (#41). Serves both
  * the true first run and the unreachable-server failure state.
  */
-export function enterOpeningDay(opts?: { notice?: { address: string; detail: string } }): void {
+export function enterOpeningDay(opts?: { notice?: { title?: string; address: string; detail: string } }): void {
   if (!deps) return;
   pendingSetup = { notice: opts?.notice };
   deps.setLibraries([]);
@@ -162,7 +162,7 @@ export function maybeOpenSetupTerminal(): void {
   if (!pendingSetup) return;
   const p = pendingSetup;
   pendingSetup = null;
-  if (p.notice) openSetupNotice(p.notice.address, p.notice.detail);
+  if (p.notice) openSetupNotice(p.notice.address, p.notice.detail, p.notice.title);
   else openSetupTerminal();
 }
 
@@ -896,17 +896,37 @@ export async function checkCredentialsAndLoad() {
 
   let escaped = false;
   let retryTimeoutId: any = null;
+  let noticeShown = false; // the setup-terminal notice (#41), docked once
 
-  // Any keypress or click on the boot screen skips auto-connect and goes to login.
+  // Any keypress or click on the boot screen skips the wait. In the 3D store
+  // that means the same place every other setup moment lives: the counter
+  // CRT, docked over the empty store with a "paused by you" notice whose
+  // RETRY NOW / CHANGE SERVER / DEMO rows are the ways forward — the
+  // in-flight attempt keeps running underneath, exactly like the failure
+  // notice, and still opens the store if it lands. Jumping to the old DOM
+  // login form / fanned card picker predates the terminal and read as a
+  // different app bolted onto the boot. Flat mode has no counter to dock to
+  // and keeps the classic form.
   const bootEscape = (e: Event) => {
     if (e.type === 'keydown' && (e as KeyboardEvent).key === 'Tab') return; // ignore tab
+    document.removeEventListener('keydown', bootEscape);
+    document.removeEventListener('click', bootEscape);
+    if (getSetting<string>('bb_render_mode') !== 'flat' && jellyfinUrl) {
+      noticeShown = true;
+      enterOpeningDay({
+        notice: {
+          title: 'CONNECTION PAUSED BY YOU',
+          address: jellyfinUrl,
+          detail: 'You skipped the wait. Where to next?',
+        },
+      });
+      return;
+    }
     escaped = true;
     if (retryTimeoutId) {
       clearTimeout(retryTimeoutId);
       retryTimeoutId = null;
     }
-    document.removeEventListener('keydown', bootEscape);
-    document.removeEventListener('click', bootEscape);
     hideBootOverlay();
     showLoginOrCards();
   };
@@ -938,7 +958,6 @@ export async function checkCredentialsAndLoad() {
     const STALL_MS = 45_000;
     let currentDelay = 10_000; // starts at 10s
     const MAX_DELAY = 5 * 60 * 1000; // 5min cap
-    let noticeShown = false; // the empty-store failure notice (#41), once
 
     const attemptSync = async () => {
       if (escaped) return;

--- a/src/store-setup-flow.ts
+++ b/src/store-setup-flow.ts
@@ -193,13 +193,13 @@ export function openSetupTerminal(): void {
  * Safe to call again while open — a failed background retry just updates the
  * detail line.
  */
-export function openSetupNotice(address: string, detail: string): void {
+export function openSetupNotice(address: string, detail: string, title?: string): void {
   if (!deps) return;
   initSetupReport();
   registerSensitiveString(address);
   recordSetupFailure(detail, 'Connect');
   const row = screen.kind === 'notice' ? screen.row : 0;
-  openWith({ kind: 'notice', address, detail: detail.toUpperCase(), row });
+  openWith({ kind: 'notice', title, address, detail: detail.toUpperCase(), row });
 }
 
 function openWith(s: SetupScreen): void {

--- a/src/store-setup-screens.ts
+++ b/src/store-setup-screens.ts
@@ -61,7 +61,7 @@ export type SetupScreen =
   | { kind: 'streaming'; rows: SetupLibraryRow[]; row: number; confirm?: string }
   | { kind: 'sync'; stage: string; pages: number }
   | { kind: 'arriving' }
-  | { kind: 'notice'; address: string; detail: string; row: number; copied?: boolean };
+  | { kind: 'notice'; title?: string; address: string; detail: string; row: number; copied?: boolean };
 
 export function initialHomeScreen(savedAddress?: string | null): SetupHomeScreen {
   return { kind: 'home', row: 1, provider: 0, address: savedAddress || 'http://' };
@@ -412,7 +412,7 @@ export function setupScreenLines(s: SetupScreen): { lines: string[]; cursorLine:
       };
     case 'notice': {
       const lines = [
-        'DISTRIBUTOR NOT ANSWERING',
+        s.title ?? 'DISTRIBUTOR NOT ANSWERING',
         clipTail(s.address, 40),
         s.detail.slice(0, 40),
         '',


### PR DESCRIPTION
Clicking or pressing a key while a saved server was still connecting dropped the player onto the pre-terminal flat login overlay / membership-card picker. Every other setup moment lives on the counter CRT since #41; this escape hatch was the one leftover path.

- 3D store: the escape boots the empty shell and docks the setup notice under a **CONNECTION PAUSED BY YOU** heading, with RETRY NOW / CHANGE SERVER / TRY A DEMO STORE as the ways forward. The connection attempt keeps running underneath (like the failure notice): a later failure refreshes the same screen as DISTRIBUTOR NOT ANSWERING, a late success still opens the store.
- Flat mode keeps the classic form (no counter to dock to).
- Notice screen gains an optional title.

Verified: `npm run build` passes; screenshot below shot from the camp via `tools/shot.mjs --state setup --title paused` (new harness variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)